### PR TITLE
fixing issues with detecting dev version numbering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,21 @@
 # See LICENSE in the top level directory for licensing details
 #
 
+# ---------------------------------------------------
+# string_contains_number
+# ---------------------------------------------------
+function(string_contains_number str result)
+  string(REGEX MATCH "[0-9]" has_number "${str}")
+  if(has_number)
+    set(${result} TRUE PARENT_SCOPE)
+  else()
+    set(${result} FALSE PARENT_SCOPE)
+  endif()
+endfunction()
+
+# ---------------------------------------------------
+# main
+# ---------------------------------------------------
 #-- Prevent in-source builds
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
   message(FATAL_ERROR "DO NOT BUILD in-tree.")
@@ -50,6 +65,17 @@ execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/sst-minor-version.sh
                 OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+string_contains_number("${SST_MAJOR_VERSION}" contains_num)
+if(NOT contains_num)
+  set(SST_MAJOR_VERSION "DEV")
+  set(SST_MINOR_VERSION "DEV")
+  execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/sst-git-hash.sh
+                  OUTPUT_VARIABLE SST_GIT_HASH
+                  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  message(STATUS "SST GIT HASH=${SST_GIT_HASH}")
+endif()
+
 message(STATUS "SST MAJOR VERSION=${SST_MAJOR_VERSION}")
 message(STATUS "SST MINOR VERSION=${SST_MINOR_VERSION}")
 string(CONCAT SST_VERSION  ${SST_MAJOR_VERSION} "." ${SST_MINOR_VERSION})
@@ -72,17 +98,18 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -std=c++17 ${FP_MODE_FLAG} -g -pg 
 
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -Wall")
 set(EXT_TEST_DEP_COMMAND "${CMAKE_SOURCE_DIR}/scripts/test-dep.sh")
-message(STATUS "SST TEST DEP SCRIPT=${EXT_TEST_DEP_COMMAND}")
 
 #-- Setup supported version arrays
 set(SST_TMP_VER_LIST "13.0" "14.0" "14.1")
 set(SST_VER_LIST "DEV")
 
-foreach(VERSION ${SST_TMP_VER_LIST})
-  if(NOT ${VERSION} VERSION_LESS ${SST_VERSION})
-    list(APPEND SST_VER_LIST ${VERSION})
-  endif()
-endforeach()
+if(NOT "${SST_MAJOR_VERSION}" STREQUAL "DEV")
+  foreach(VERSION ${SST_TMP_VER_LIST})
+    if(NOT ${VERSION} VERSION_LESS ${SST_VERSION})
+      list(APPEND SST_VER_LIST ${VERSION})
+    endif()
+  endforeach()
+endif()
 
 #-- Add testing
 enable_testing()

--- a/scripts/sst-git-hash.sh
+++ b/scripts/sst-git-hash.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# Derives the SST git hash
+# SST-Core Version (-dev, git branch : HEAD, SHA: 42b92ad9f44436a03fb3e30899f0aebb378ca987)
+# returns, 42b92ad9f44436a03fb3e30899f0aebb378ca987
+#
+
+sst --version | awk '{print $9}' | tr -d '()' | awk '{split($0,a,"."); print a[1]}'
+
+# EOF

--- a/scripts/test-dep.sh
+++ b/scripts/test-dep.sh
@@ -29,9 +29,8 @@ fi
 COMPS=`grep "#EXT_TEST DEP" "$1" | sed 's/#EXT_TEST DEP "\(.*\)"/\1/' | tr ' ' '\n'`
 
 for C in $COMPS;do
-  sst-info -q $C >> /dev/null 2>&1
-  retVal=$?
-  if [ $retVal -ne 0 ]; then
+  VAL=`sst-info -q $C | grep "ELEMENT LIBRARY"`
+  if [ -z "$VAL" ]; then
     echo "NO_RUN"
     exit -1
   fi

--- a/tests/cli/CMakeLists.txt
+++ b/tests/cli/CMakeLists.txt
@@ -21,12 +21,13 @@ foreach(testSrc ${TEST_SRCS_TARGET_VER})
                 OUTPUT_VARIABLE EXT_TEST_CHECK
                 RESULT_VARIABLE EXT_TEST_RTN
                 OUTPUT_STRIP_TRAILING_WHITESPACE
+		ERROR_QUIET
   )
 
   message(STATUS "Dep Check ${testSrc} = ${EXT_TEST_CHECK}")
 
   # Add the tests for execution
-  if( ${EXT_TEST_RTN} EQUAL 0 )
+  if( "${EXT_TEST_CHECK}" STREQUAL "RUN" )
     add_test(NAME ${testName}
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND ./${testSrc})
@@ -46,12 +47,13 @@ foreach(testVer ${SST_VER_LIST})
                   OUTPUT_VARIABLE EXT_TEST_CHECK
                   RESULT_VARIABLE EXT_TEST_RTN
                   OUTPUT_STRIP_TRAILING_WHITESPACE
+		  ERROR_QUIET
     )
 
     message(STATUS "Dep Check ${testSrc} = ${EXT_TEST_CHECK}")
 
     # Add the tests for execution
-    if( ${EXT_TEST_RTN} EQUAL 0 )
+    if( "${EXT_TEST_CHECK}" STREQUAL "RUN" )
       add_test(NAME ${testName}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMAND ./${testSrc})
@@ -70,12 +72,13 @@ foreach(testSrc ${TEST_SRCS_ALL})
                 OUTPUT_VARIABLE EXT_TEST_CHECK
                 RESULT_VARIABLE EXT_TEST_RTN
                 OUTPUT_STRIP_TRAILING_WHITESPACE
+		ERROR_QUIET
   )
 
   message(STATUS "Dep Check ${testSrc} = ${EXT_TEST_CHECK}")
 
   # Add the tests for execution
-  if( ${EXT_TEST_RTN} EQUAL 0 )
+  if( "${EXT_TEST_CHECK}" STREQUAL "RUN" )
     add_test(NAME ${testName}
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND ./${testSrc})


### PR DESCRIPTION
Fix issues with dev version numbering.  The CMake infrastructure now sets `SST_MAJOR_VERSION` and `SST_MINOR_VERSION` version numbers to "DEV" when upstream dev versions are detected.  The git hash is also set to `SST_GIT_HASH`.  I also fixed a number of bugs in detecting the correct set of tests when specific elements are or are not installed