### PR TITLE
adding the ability to set per-test timeouts; Issue #8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -std=c++17 ${FP_MODE_FLAG} -g -pg 
 
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -Wall")
 set(EXT_TEST_DEP_COMMAND "${CMAKE_SOURCE_DIR}/scripts/test-dep.sh")
+set(EXT_TEST_TIMEOUT_COMMAND "${CMAKE_SOURCE_DIR}/scripts/test-timeout.sh")
 
 #-- Setup supported version arrays
 set(SST_TMP_VER_LIST "13.0" "14.0" "14.1")

--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ All new tests must include, at minimum, two units of metadata in the file header
 These are outlined as follows:
 - `EXT_TEST TEST_FILE_PARAM PARAM` : where `PARAM` is the `VERSION` string from above
 - `EXT_TEST TEST_FILE_DESC "DESC"` : where `DESC` is a description of the test
+
+Optional metadat elements include:
 - `EXT_TEST DEP "COMP1 COMP2"`     : where within the quotes is a list of components
+- `EXT_TEST TIMEOUT XX`            : where XX is the number of seconds for the script to timeout (default is 60)
 
 ## Test Interrogation
 `sst-ext-tests` includes a Python tool that discovers appropriately 

--- a/scripts/test-timeout.sh
+++ b/scripts/test-timeout.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# test-timeout.sh
+# Given a fully qualified path to a test file (.sh or .py), examines
+# the file header for EXT_TEST TIMEOUT VALUE
+#
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+# See LICENSE in the top level directory for licensing details
+#
+
+# Check for arguments
+if [ $# -eq 0 ]; then
+    echo "Error: No arguments provided"
+    echo "Usage: $0 <filename>"
+    exit 1
+fi
+
+# Check if file exists
+if [ ! -f "$1" ]; then
+    echo "Error: File '$1' not found"
+    exit 1
+fi
+
+# Process the file
+SEARCH=`grep "#EXT_TEST TIMEOUT" "$1"`
+if [ -n "$SEARCH" ]; then
+  TIMEOUT=`grep "#EXT_TEST TIMEOUT" "$1" | sed -n 's/.*TIMEOUT \([0-9]*\).*/\1/p'`
+  echo $TIMEOUT
+  exit 0
+fi
+
+echo "0"
+exit 0
+
+# EOF

--- a/tests/cli/CMakeLists.txt
+++ b/tests/cli/CMakeLists.txt
@@ -10,6 +10,7 @@
 
 set(TEST_FILE_EXT "sh")
 set(passRegex "PASS")
+set(timeout "60")
 
 #-- SST Enabled Minimum Test Versions
 file(GLOB TEST_SRCS_TARGET_VER RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *-MIN${SST_VERSION}.${TEST_FILE_EXT})
@@ -23,6 +24,12 @@ foreach(testSrc ${TEST_SRCS_TARGET_VER})
                 OUTPUT_STRIP_TRAILING_WHITESPACE
 		ERROR_QUIET
   )
+  execute_process(COMMAND ${EXT_TEST_TIMEOUT_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${testSrc}
+                OUTPUT_VARIABLE EXT_TEST_TIMEOUT
+                RESULT_VARIABLE EXT_TEST_RTN
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
+  )
 
   message(STATUS "Dep Check ${testSrc} = ${EXT_TEST_CHECK}")
 
@@ -32,6 +39,13 @@ foreach(testSrc ${TEST_SRCS_TARGET_VER})
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND ./${testSrc})
     set_property(TEST ${testName} PROPERTY LABELS "${SST_VERSION}")
+    set_property(TEST ${testName} PROPERTY PASS_REGULAR_EXPRESSION "${passRegex}")
+    if(NOT ${EXT_TEST_TIMEOUT} EQUAL 0)
+      set_property(TEST ${testName} PROPERTY TIMEOUT ${EXT_TEST_TIMEOUT})
+      message(STATUS "Runtime ${testSrc} = ${EXT_TEST_TIMEOUT}")
+    else()
+      set_property(TEST ${testName} PROPERTY TIMEOUT ${timeout})
+    endif()
   endif()
 endforeach(testSrc)
 
@@ -49,6 +63,12 @@ foreach(testVer ${SST_VER_LIST})
                   OUTPUT_STRIP_TRAILING_WHITESPACE
 		  ERROR_QUIET
     )
+    execute_process(COMMAND ${EXT_TEST_TIMEOUT_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${testSrc}
+                  OUTPUT_VARIABLE EXT_TEST_TIMEOUT
+                  RESULT_VARIABLE EXT_TEST_RTN
+                  OUTPUT_STRIP_TRAILING_WHITESPACE
+                  ERROR_QUIET
+    )
 
     message(STATUS "Dep Check ${testSrc} = ${EXT_TEST_CHECK}")
 
@@ -58,6 +78,13 @@ foreach(testVer ${SST_VER_LIST})
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMAND ./${testSrc})
       set_property(TEST ${testName} PROPERTY LABELS "${testVer}")
+      set_property(TEST ${testName} PROPERTY PASS_REGULAR_EXPRESSION "${passRegex}")
+      if(NOT ${EXT_TEST_TIMEOUT} EQUAL 0)
+        set_property(TEST ${testName} PROPERTY TIMEOUT ${EXT_TEST_TIMEOUT})
+        message(STATUS "Runtime ${testSrc} = ${EXT_TEST_TIMEOUT}")
+      else()
+        set_property(TEST ${testName} PROPERTY TIMEOUT ${timeout})
+      endif()
     endif()
   endforeach(testSrc)
 endforeach(testVer)
@@ -74,6 +101,12 @@ foreach(testSrc ${TEST_SRCS_ALL})
                 OUTPUT_STRIP_TRAILING_WHITESPACE
 		ERROR_QUIET
   )
+  execute_process(COMMAND ${EXT_TEST_TIMEOUT_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${testSrc}
+                OUTPUT_VARIABLE EXT_TEST_TIMEOUT
+                RESULT_VARIABLE EXT_TEST_RTN
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
+  )
 
   message(STATUS "Dep Check ${testSrc} = ${EXT_TEST_CHECK}")
 
@@ -83,6 +116,13 @@ foreach(testSrc ${TEST_SRCS_ALL})
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND ./${testSrc})
     set_property(TEST ${testName} PROPERTY LABELS "ALL")
+    set_property(TEST ${testName} PROPERTY PASS_REGULAR_EXPRESSION "${passRegex}")
+    if(NOT ${EXT_TEST_TIMEOUT} EQUAL 0)
+      set_property(TEST ${testName} PROPERTY TIMEOUT ${EXT_TEST_TIMEOUT})
+      message(STATUS "Runtime ${testSrc} = ${EXT_TEST_TIMEOUT}")
+    else()
+      set_property(TEST ${testName} PROPERTY TIMEOUT ${timeout})
+    endif()
   endif()
 endforeach(testSrc)
 

--- a/tests/core-chkpt/CMakeLists.txt
+++ b/tests/core-chkpt/CMakeLists.txt
@@ -24,6 +24,12 @@ foreach(testSrc ${TEST_SRCS_TARGET_VER})
                 OUTPUT_STRIP_TRAILING_WHITESPACE
 		ERROR_QUIET
   )
+  execute_process(COMMAND ${EXT_TEST_TIMEOUT_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${testSrc}
+                OUTPUT_VARIABLE EXT_TEST_TIMEOUT
+                RESULT_VARIABLE EXT_TEST_RTN
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
+  )
 
   message(STATUS "Dep Check ${testSrc} = ${EXT_TEST_CHECK}")
 
@@ -34,7 +40,12 @@ foreach(testSrc ${TEST_SRCS_TARGET_VER})
       COMMAND sst --checkpoint-prefix=${testName} --checkpoint-wall-period=1s ./${testSrc})
     set_property(TEST ${testName} PROPERTY LABELS "${SST_VERSION}")
     set_property(TEST ${testName} PROPERTY PASS_REGULAR_EXPRESSION "${passRegex}")
-    set_property(TEST ${testName} PROPERTY TIMEOUT ${timeout})
+    if(NOT ${EXT_TEST_TIMEOUT} EQUAL 0)
+      set_property(TEST ${testName} PROPERTY TIMEOUT ${EXT_TEST_TIMEOUT})
+      message(STATUS "Runtime ${testSrc} = ${EXT_TEST_TIMEOUT}")
+    else()
+      set_property(TEST ${testName} PROPERTY TIMEOUT ${timeout})
+    endif()
   endif()
 endforeach(testSrc)
 
@@ -52,6 +63,12 @@ foreach(testVer ${SST_VER_LIST})
                   OUTPUT_STRIP_TRAILING_WHITESPACE
 		  ERROR_QUIET
     )
+    execute_process(COMMAND ${EXT_TEST_TIMEOUT_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${testSrc}
+                  OUTPUT_VARIABLE EXT_TEST_TIMEOUT
+                  RESULT_VARIABLE EXT_TEST_RTN
+                  OUTPUT_STRIP_TRAILING_WHITESPACE
+                  ERROR_QUIET
+    )
 
     message(STATUS "Dep Check ${testSrc} = ${EXT_TEST_CHECK}")
 
@@ -62,7 +79,12 @@ foreach(testVer ${SST_VER_LIST})
         COMMAND sst --checkpoint-prefix=${testName} --checkpoint-wall-period=1s ./${testSrc})
       set_property(TEST ${testName} PROPERTY LABELS "${testVer}")
       set_property(TEST ${testName} PROPERTY PASS_REGULAR_EXPRESSION "${passRegex}")
-      set_property(TEST ${testName} PROPERTY TIMEOUT ${timeout})
+      if(NOT ${EXT_TEST_TIMEOUT} EQUAL 0)
+        set_property(TEST ${testName} PROPERTY TIMEOUT ${EXT_TEST_TIMEOUT})
+        message(STATUS "Runtime ${testSrc} = ${EXT_TEST_TIMEOUT}")
+      else()
+        set_property(TEST ${testName} PROPERTY TIMEOUT ${timeout})
+      endif()
     endif()
   endforeach(testSrc)
 endforeach(testVer)
@@ -79,6 +101,12 @@ foreach(testSrc ${TEST_SRCS_ALL})
                 OUTPUT_STRIP_TRAILING_WHITESPACE
 		ERROR_QUIET
   )
+  execute_process(COMMAND ${EXT_TEST_TIMEOUT_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${testSrc}
+                OUTPUT_VARIABLE EXT_TEST_TIMEOUT
+                RESULT_VARIABLE EXT_TEST_RTN
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
+  )
 
   message(STATUS "Dep Check ${testSrc} = ${EXT_TEST_CHECK}")
 
@@ -89,7 +117,12 @@ foreach(testSrc ${TEST_SRCS_ALL})
       COMMAND sst --checkpoint-prefix=${testName} --checkpoint-wall-period=1s ./${testSrc})
     set_property(TEST ${testName} PROPERTY LABELS "ALL")
     set_property(TEST ${testName} PROPERTY PASS_REGULAR_EXPRESSION "${passRegex}")
-    set_property(TEST ${testName} PROPERTY TIMEOUT ${timeout})
+    if(NOT ${EXT_TEST_TIMEOUT} EQUAL 0)
+      set_property(TEST ${testName} PROPERTY TIMEOUT ${EXT_TEST_TIMEOUT})
+      message(STATUS "Runtime ${testSrc} = ${EXT_TEST_TIMEOUT}")
+    else()
+      set_property(TEST ${testName} PROPERTY TIMEOUT ${timeout})
+    endif()
   endif()
 endforeach(testSrc)
 

--- a/tests/rt_action/CMakeLists.txt
+++ b/tests/rt_action/CMakeLists.txt
@@ -10,6 +10,7 @@
 
 set(TEST_FILE_EXT "sh")
 set(passRegex "PASS")
+set(timeout "60")
 
 #-- SST Enabled Minimum Test Versions
 file(GLOB TEST_SRCS_TARGET_VER RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *-MIN${SST_VERSION}.${TEST_FILE_EXT})
@@ -23,6 +24,12 @@ foreach(testSrc ${TEST_SRCS_TARGET_VER})
                 OUTPUT_STRIP_TRAILING_WHITESPACE
 		ERROR_QUIET
   )
+  execute_process(COMMAND ${EXT_TEST_TIMEOUT_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${testSrc}
+                OUTPUT_VARIABLE EXT_TEST_TIMEOUT
+                RESULT_VARIABLE EXT_TEST_RTN
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
+  )
 
   message(STATUS "Dep Check ${testSrc} = ${EXT_TEST_CHECK}")
 
@@ -32,6 +39,13 @@ foreach(testSrc ${TEST_SRCS_TARGET_VER})
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND ./${testSrc})
     set_property(TEST ${testName} PROPERTY LABELS "${SST_VERSION}")
+    set_property(TEST ${testName} PROPERTY PASS_REGULAR_EXPRESSION "${passRegex}")
+    if(NOT ${EXT_TEST_TIMEOUT} EQUAL 0)
+      set_property(TEST ${testName} PROPERTY TIMEOUT ${EXT_TEST_TIMEOUT})
+      message(STATUS "Runtime ${testSrc} = ${EXT_TEST_TIMEOUT}")
+    else()
+      set_property(TEST ${testName} PROPERTY TIMEOUT ${timeout})
+    endif()
   endif()
 endforeach(testSrc)
 
@@ -49,6 +63,12 @@ foreach(testVer ${SST_VER_LIST})
                   OUTPUT_STRIP_TRAILING_WHITESPACE
 		  ERROR_QUIET
     )
+    execute_process(COMMAND ${EXT_TEST_TIMEOUT_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${testSrc}
+                  OUTPUT_VARIABLE EXT_TEST_TIMEOUT
+                  RESULT_VARIABLE EXT_TEST_RTN
+                  OUTPUT_STRIP_TRAILING_WHITESPACE
+                  ERROR_QUIET
+    )
 
     message(STATUS "Dep Check ${testSrc} = ${EXT_TEST_CHECK}")
 
@@ -58,6 +78,13 @@ foreach(testVer ${SST_VER_LIST})
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMAND ./${testSrc})
       set_property(TEST ${testName} PROPERTY LABELS "${testVer}")
+      set_property(TEST ${testName} PROPERTY PASS_REGULAR_EXPRESSION "${passRegex}")
+      if(NOT ${EXT_TEST_TIMEOUT} EQUAL 0)
+        set_property(TEST ${testName} PROPERTY TIMEOUT ${EXT_TEST_TIMEOUT})
+        message(STATUS "Runtime ${testSrc} = ${EXT_TEST_TIMEOUT}")
+      else()
+        set_property(TEST ${testName} PROPERTY TIMEOUT ${timeout})
+      endif()
     endif()
   endforeach(testSrc)
 endforeach(testVer)
@@ -74,6 +101,12 @@ foreach(testSrc ${TEST_SRCS_ALL})
                 OUTPUT_STRIP_TRAILING_WHITESPACE
 		ERROR_QUIET
   )
+  execute_process(COMMAND ${EXT_TEST_TIMEOUT_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${testSrc}
+                OUTPUT_VARIABLE EXT_TEST_TIMEOUT
+                RESULT_VARIABLE EXT_TEST_RTN
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
+  )
 
   message(STATUS "Dep Check ${testSrc} = ${EXT_TEST_CHECK}")
 
@@ -83,6 +116,13 @@ foreach(testSrc ${TEST_SRCS_ALL})
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND ./${testSrc})
     set_property(TEST ${testName} PROPERTY LABELS "ALL")
+    set_property(TEST ${testName} PROPERTY PASS_REGULAR_EXPRESSION "${passRegex}")
+    if(NOT ${EXT_TEST_TIMEOUT} EQUAL 0)
+      set_property(TEST ${testName} PROPERTY TIMEOUT ${EXT_TEST_TIMEOUT})
+      message(STATUS "Runtime ${testSrc} = ${EXT_TEST_TIMEOUT}")
+    else()
+      set_property(TEST ${testName} PROPERTY TIMEOUT ${timeout})
+    endif()
   endif()
 endforeach(testSrc)
 

--- a/tests/rt_action/sigusr_interactive-DEV.sh
+++ b/tests/rt_action/sigusr_interactive-DEV.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_PARAM DEV
 #EXT_TEST TEST_FILE_DESC "Tests sigusr1/2 with interactive console real time action"
+##EXT_TEST TIMEOUT 90
 #
 # 0) Set up pipe
 # 1) launch the program in the background


### PR DESCRIPTION
adds `#EXT_TEST TIMEOUT VALUE` metadata and associated scripts to resolve the value; added to the three existing directory CMakeLists.txt