### PR TITLE
Test periodic actions with Checkpoint/Restart

### DIFF
--- a/tests/rt_action/README
+++ b/tests/rt_action/README
@@ -1,0 +1,38 @@
+Tests in this directory test various types of periodic actions alone or combined
+with checkpoint and checkpoint restart including:
+* siguser1/2=sst.rt.<action>
+* sigalrm=sst.rt.<action> (one or more actions)
+* interactive-console & interactive-start
+* heartbeat-period
+
+
+restart-ckpt-with-* 
+These tests combine checkpoint with various periodic actions above to see if they get carried
+over to the run when the checkpoint is restarted (i.e. --load-checkpoint). Note that the
+heart, interactive, and sigalrm periodic actions should NOT be carried over. Currently,
+* restart-ckpt-with-sigalrm works correctly (does not carry over)
+* restart-ckpt-with-heartbeat Fails: heartbeat does get carried over to restart and triggers error
+* restart-ckpt-with-interactive Fails: triggers an error during checkpoint sst-core issue #1223
+
+
+restart-*
+These tests generate a checkpoint and then restart the simulation with the checkpoint file and the 
+specified periodic action. These currently all Pass.
+* restart-heartbeat: --heartbeat-period
+* restart-interactive: --interactive-console, interactive-start
+* restart-sigalrm: --sigalrm
+
+sigalrm*
+These tests use the --sigalrm flag with different combinations of actions.
+* sigalrm: tests sigalrm with sst.rt.{exit.clean, exit.emergency, status.core, status.all, 
+          status.heartbeat}
+* sigalrm_combined: tests sigalrm with a combination of two actions  
+          e.g. sst.rt.exit.clean and sst.rt.status.core (checkpoint is tested separately)
+* sigalrm_ckpt_comb: tests sigalrm with a combination of sst.rt.checkpoint with other actions
+
+
+sigusr*
+These tests use the --sigusr1 or --sigusr2 flag with different actions.
+* sigusr: Pass: tests sigalrm with sst.rt.{exit.clean, exit.emergency, status.core, status.all,
+          status.heartbeat}
+* sigusr_interactive: Passes with the PR branch: tests sigusr1/2 with interactive console

--- a/tests/rt_action/restart-ckpt-with-heartbeat-MIN14.1.sh
+++ b/tests/rt_action/restart-ckpt-with-heartbeat-MIN14.1.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_PARAM MIN14.1
+#EXT_TEST TEST_FILE_DESC "Tests restart for a checkpoint that had heartbeat to see if the heartbeat is carried over. Currently fails with error in restart"
+# 
+# 0) set pass string and checkpoint directory
+# 1) launch the program to generate the checkpoint
+# 2) Check the result
+# 3) Launch the checkpoint restart
+# 4) check result
+
+
+# Settings
+CONFIG="test_Checkpoint.py"
+PREFIX="ckpt_restart_heartbeat"
+CKPT_DIR="ckpt_restart_heartbeat/ckpt_restart_heartbeat_0_1000000000000/ckpt_restart_heartbeat_0_1000000000000.sstcpt"
+CLEANUP=1
+
+
+#0 Get pass criterion 
+PSTR2="Heartbeat"
+
+# 1) Launch the program to generate the checkpoint
+OUTFILE="test.ckpt.heartbeat.out"
+LAUNCH="sst --checkpoint-prefix=$PREFIX --checkpoint-sim-period=1s --heartbeat-period=2s  $CONFIG"
+echo $LAUNCH
+eval $LAUNCH > $OUTFILE 2>&1
+retVal=$?
+
+echo ckpt.heartbeat Complete
+
+# 2) Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR ckpt.heartbeat return code"
+  exit $retVal
+fi
+
+grep "$PSTR2" ./$OUTFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR ckpt.heartbeat grep"
+  exit $grepVal
+fi
+
+# Cleanup output file
+if [ $CLEANUP -eq 1 ]; then
+  rm $OUTFILE
+fi
+
+
+
+# 3) Launch the checkpoint restart
+OUTFILE="test.restart.ckpt.heartbeat.out"
+LAUNCH="sst --load-checkpoint $CKPT_DIR"
+echo $LAUNCH
+eval $LAUNCH > $OUTFILE 2>&1 
+retVal=$?
+
+echo restart.ckpt.heartbeat Complete
+
+# 4) Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR restart.ckpt.heartbeat return code"
+  exit $retVal
+fi
+
+grep "$PSTR2" ./$OUTFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR restart.ckpt.heartbeat grep"
+  exit $grepVal
+fi
+
+echo
+
+# Cleanup output directories
+if [ $CLEANUP -eq 1 ]; then
+  rm $OUTFILE
+fi
+
+if [ $CLEANUP -eq 1 ]; then
+  rm -rf $PREFIX*
+fi
+
+echo "PASS"
+exit $retVal
+
+
+
+
+
+

--- a/tests/rt_action/restart-ckpt-with-interactive-MIN14.1.sh
+++ b/tests/rt_action/restart-ckpt-with-interactive-MIN14.1.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_PARAM MIN14.1
+#EXT_TEST TEST_FILE_DESC "Tests restart for a checkpoint that had interactive console to see if the interactive console is carried over. Currently Fails"
+
+# 0) set pass string 
+# 1) launch the program to generate the checkpoint
+# 2) Check the result
+# 3) Launch the checkpoint restart with interactive consolse
+# 4) check result
+
+
+# Settings
+CONFIG="test_Checkpoint.py"
+PREFIX="ckpt_restart_interactive"
+CKPT_DIR="ckpt_restart_interactive/ckpt_restart_interactive_0_1000000000000/ckpt_restart_interactive_0_1000000000000.sstcpt"
+CLEANUP=1
+
+#0 Get pass criterion 
+PSTR2="Interactive"
+
+# 1) Launch the program to generate the checkpoint
+OUTFILE="test.ckpt.interactive.out"
+LAUNCH="sst --checkpoint-prefix=$PREFIX --checkpoint-sim-period=1s --interactive-console=sst.interactive.simpledebug --interactive-start=2s  $CONFIG"
+echo $LAUNCH
+eval $LAUNCH > $OUTFILE 2>&1
+retVal=$?
+
+echo ckpt.interactive Complete
+
+# 2) Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR ckpt.interactive return code"
+  exit $retVal
+fi
+
+grep "$PSTR2" ./$OUTFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR ckpt.interactive grep"
+  exit $grepVal
+fi
+
+# Cleanup output file
+if [ $CLEANUP -eq 1 ]; then
+  rm $OUTFILE
+fi
+
+
+# 3) Launch the checkpoint restart
+OUTFILE="test.restart.ckpt.interactive.out"
+LAUNCH="sst --load-checkpoint $CKPT_DIR"
+echo $LAUNCH
+exec $LAUNCH > $OUTFILE 2>&1 
+retVal=$?
+echo restart.ckpt.interactive Complete
+
+# 4) Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR restart.ckpt.interactive return code"
+  exit $retVal
+fi
+
+grep "$PSTR2" ./$OUTFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR restart.ckpt.interactive grep"
+  exit $grepVal
+fi
+
+echo
+
+# Cleanup output directories
+if [ $CLEANUP -eq 1 ]; then
+  rm $OUTFILE
+fi
+
+if [ $CLEANUP -eq 1 ]; then
+  rm -rf $PREFIX*
+fi
+
+echo "PASS"
+exit $retVal
+
+
+
+
+
+

--- a/tests/rt_action/restart-ckpt-with-sigalrm-MIN14.1.sh
+++ b/tests/rt_action/restart-ckpt-with-sigalrm-MIN14.1.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_PARAM MIN14.1
+#EXT_TEST TEST_FILE_DESC "Tests checkpoint with sigalrm to see if the sigalrm is carried over to restart (i.e. load-checkpoint)"
+# 
+# 0) set pass string
+# 1) launch sst to generate the checkpoint
+# 2) check result
+# 3) restart sst with the checkpoint file
+# 3) check result
+
+
+# Settings
+SIG="sigalrm"
+ACTION2="sst.rt.status.core sst.rt.status.all sst.rt.heartbeat"
+CONFIG="test_Checkpoint.py"
+CLEANUP=1
+
+
+for sig in $SIG; do
+  for action2 in $ACTION2; do
+
+#0 Get pass criterion
+if [[ $action2 == "sst.rt.status.core" ]]; then
+  #echo status.core
+  PSTR2="CurrentSimCycle"
+elif [[ $action2 == "sst.rt.status.all" ]]; then
+  #echo status.all
+  PSTR2="TimeVortex state"
+elif [[ $action2 == "sst.rt.heartbeat" ]]; then
+  #echo heartbeat
+  PSTR2="Heartbeat"
+fi
+
+PREFIX="ckpt_sigalrm_$action2"
+CKPTDIR="ckpt_sigalrm_$action2/ckpt_sigalrm_${action2}_0_1000000000000/ckpt_sigalrm_${action2}_0_1000000000000.sstcpt"
+
+
+# 1) Launch sst with sigalrm actions to generate the checkpoint file
+#if [[ -f $OUTFILE ]]; then
+#  rm $OUTFILE
+#fi
+OUTFILE="test.ckpt.$sig.$action2.out"
+LAUNCH="sst --checkpoint-prefix=$PREFIX --checkpoint-sim-period=1s --sigalrm='$action2(interval=1s)' $CONFIG"
+echo $LAUNCH
+eval $LAUNCH > $OUTFILE 2>&1
+retVal=$?
+
+echo ckpt.$sig.$action2 Complete
+
+
+# 2) Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR ckpt.$sig.$action2 return code"
+  exit $retVal
+fi
+
+grep "$PSTR2" ./$OUTFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR ckpt.$sig.$action2 grep"
+  exit $grepVal
+fi
+
+if [ $CLEANUP -eq 1 ]; then
+  rm $OUTFILE
+fi
+
+# 3) Launch sst with ckpt file (restart)
+OUTFILE="test.restart.ckpt.$sig.$action2.out"
+LAUNCH="sst --load-checkpoint $CKPTDIR"
+echo $LAUNCH
+eval $LAUNCH > $OUTFILE 2>&1 
+retVal=$?
+
+echo restart.ckpt.$sig.$action2 Complete
+
+# 4) Check result (sigalrm actions should NOT appear at restart so it checks that PSTR does NOT appear)
+if [ $retVal -ne 0 ]; then
+  echo "ERROR restart.ckpt.$sig.$action2 return code"
+  exit $retVal
+fi
+
+grep "$PSTR2" ./$OUTFILE > /dev/null
+retVal=$?
+if [ $retVal -eq 0 ]; then
+  echo "ERROR restart.ckpt.$sig.$action grep"
+  exit $grepVal
+fi
+
+echo
+
+# Cleanup output directories
+if [ $CLEANUP -eq 1 ]; then
+  rm $OUTFILE
+fi
+
+if [ $CLEANUP -eq 1 ]; then
+  rm -rf $PREFIX*
+fi
+
+done  # for $action2
+done  # for $sig
+
+echo "PASS"
+exit $retVal
+
+
+
+
+
+

--- a/tests/rt_action/restart-heartbeat-MIN14.1.sh
+++ b/tests/rt_action/restart-heartbeat-MIN14.1.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_PARAM MIN14.1
+#EXT_TEST TEST_FILE_DESC "Tests using sigalrm with restart (i.e. load checkpoint)"
+# 
+# 0) launch sst to generate the checkpoint
+# 1) check resulti
+# 2) set pass string and output file
+# 3) restart sst with the checkpoint file and sigalrm
+# 4) check result
+
+
+# Settings
+ACTION="heartbeat"
+CONFIG=" test_Checkpoint.py" #test_MessageMesh.py"
+PREFIX="ckpt4restart_heartbeat"
+CKPTDIR="ckpt4restart_heartbeat/ckpt4restart_heartbeat_0_1000000000000/ckpt4restart_heartbeat_0_1000000000000.sstcpt"
+CLEANUP=1
+
+
+# 0) Launch the program to generate the checkpoints
+OUTFILE="test.ckpt4restart.heartbeat.out"
+LAUNCH="sst --checkpoint-prefix=$PREFIX --checkpoint-sim-period=1s $CONFIG"
+echo $LAUNCH
+eval $LAUNCH > $OUTFILE 2>&1
+retVal=$?
+echo $PREFIX Done
+
+# 1) Check result
+PSTR="Checkpoint"
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $PREFIX return code"
+  exit $retVal
+fi
+
+grep "$PSTR" ./$OUTFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $PREFIX grep"
+  exit $grepVal
+fi
+
+# Cleanup output file
+if [ $CLEANUP -eq 1 ]; then
+  rm $OUTFILE
+fi
+
+# 2) Get pass criterion and outputfile
+#echo heartbeat
+PSTR="Heartbeat"
+OUTFILE="test.restart.heartbeat.out"
+
+# 3) Then restart sst with the checkpoint and heartbeat
+if [[ -f $OUTFILE ]]; then
+  rm $OUTFILE
+fi
+
+LAUNCH="sst --heartbeat-period=2s --load-checkpoint $CKPTDIR"
+echo $LAUNCH
+eval $LAUNCH > $OUTFILE 2>&1 
+retVal=$?
+echo restart.heartbeat Complete
+
+# 4) Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR restart.heartbeat return code"
+  exit $retVal
+fi
+
+grep "$PSTR" ./$OUTFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR restart.heartbeat grep"
+  exit $grepVal
+fi
+echo
+
+# Cleanup output directories
+if [ $CLEANUP -eq 1 ]; then
+  rm $OUTFILE
+  rm -r $PREFIX
+fi
+
+echo "PASS"
+exit $retVal
+
+
+
+
+
+

--- a/tests/rt_action/restart-interactive-MIN14.1.sh
+++ b/tests/rt_action/restart-interactive-MIN14.1.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_PARAM MIN14.1
+#EXT_TEST TEST_FILE_DESC "Tests using interactive console with restart (i.e. load checkpoint)"
+# 
+# 0) launch sst to generate the checkpoint
+# 1) check results
+# 2) set pass string and output file
+# 3) restart sst with the checkpoint file and interactive console
+# 4) check result
+
+
+# Settings
+CONFIG=" test_Checkpoint.py" #test_MessageMesh.py"
+PREFIX="ckpt4restart_interactive"
+CKPTDIR="ckpt4restart_interactive/ckpt4restart_interactive_0_1000000000000/ckpt4restart_interactive_0_1000000000000.sstcpt"
+CLEANUP=1
+
+
+# 0) Launch the program to generate the checkpoints
+OUTFILE="test.ckpt4restart.interactive.out"
+LAUNCH="sst --checkpoint-prefix=$PREFIX --checkpoint-sim-period=1s $CONFIG"
+echo $LAUNCH
+eval $LAUNCH > $OUTFILE 2>&1
+retVal=$?
+echo $PREFIX Done
+
+# 1) Check result
+PSTR="Checkpoint"
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $PREFIX return code"
+  exit $retVal
+fi
+
+grep "$PSTR" ./$OUTFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $PREFIX grep"
+  exit $grepVal
+fi
+
+# Cleanup output file
+if [ $CLEANUP -eq 1 ]; then
+  rm $OUTFILE
+fi
+
+# 1) Get pass criterion and outputfile
+#echo heartbeat
+PSTR="Interactive"
+OUTFILE="test.restart.interactive.out"
+
+# 2) Set up pipe for interactive
+pipe="/tmp/test_restart_pipe"
+if [[ ! -p $pipe ]]; then
+  echo "Creating pipe: $pipe"
+  mkfifo $pipe
+fi
+
+# 3) Then restart sst with the checkpoint and heartbeat
+if [[ -f $OUTFILE ]]; then
+  rm $OUTFILE
+fi
+
+LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=1us --load-checkpoint $CKPTDIR"
+echo $LAUNCH
+$LAUNCH < $pipe > $OUTFILE 2>&1 &
+exec 3>$pipe
+
+sleep 2
+echo run > $pipe
+
+wait
+retVal=$?
+echo restart.interactive Complete
+
+# 4) Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR restart.interactive return code"
+  exit $retVal
+fi
+
+grep "$PSTR" ./$OUTFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR restart.interactive grep"
+  exit $grepVal
+fi
+echo
+
+# Cleanup output directories
+if [ $CLEANUP -eq 1 ]; then
+  rm $OUTFILE
+  rm -r $PREFIX
+fi
+
+echo "PASS"
+exit $retVal
+
+
+
+
+
+

--- a/tests/rt_action/restart-sigalrm-MIN14.1.sh
+++ b/tests/rt_action/restart-sigalrm-MIN14.1.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_PARAM MIN14.1
+#EXT_TEST TEST_FILE_DESC "Tests using sigalrm with restart (i.e. load checkpoint)"
+# 
+# 0) launch sst to generate the checkpoint
+# 1) check result
+# 2) set pass string and output file
+# 3) restart sst with the checkpoint file and signalrm
+# 4) check result
+
+
+# Settings
+SIG="sigalrm"
+ACTION="sst.rt.exit.clean sst.rt.exit.emergency sst.rt.status.core sst.rt.status.all sst.rt.heartbeat sst.rt.checkpoint"
+CONFIG=" test_Checkpoint.py" #test_MessageMesh.py"
+PREFIX="ckpt4restart_sigalrm"
+CKPTDIR="ckpt4restart_sigalrm/ckpt4restart_sigalrm_0_1000000000000/ckpt4restart_sigalrm_0_1000000000000.sstcpt"
+CLEANUP=1
+
+
+# 0) Launch the program to generate the checkpoints
+OUTFILE="test.ckpt4restart.sigalrm.out"
+LAUNCH="sst --checkpoint-prefix=$PREFIX --checkpoint-sim-period=1s $CONFIG"
+echo $LAUNCH
+eval $LAUNCH > $OUTFILE 2>&1
+retVal=$?
+echo $PREFIX Done
+
+# 1) Check result
+PSTR="Checkpoint"
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $PREFIX return code"
+  exit $retVal
+fi
+
+grep "$PSTR" ./$OUTFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $PREFIX grep"
+  exit $grepVal
+fi
+
+# Cleanup output file
+if [ $CLEANUP -eq 1 ]; then
+  rm $OUTFILE
+fi
+
+
+for sig in $SIG; do
+  for action in $ACTION; do
+
+# 2) Get pass criterion and outputfile
+if [[ $action == "sst.rt.exit.clean" ]]; then
+#echo clean
+PSTR="EXIT-AFTER TIME"
+elif [[ $action == "sst.rt.exit.emergency" ]]; then
+#echo emergency
+PSTR="EMERGENCY"
+elif [[ $action == "sst.rt.status.core" ]]; then
+#echo status.core
+PSTR="CurrentSimCycle"
+elif [[ $action == "sst.rt.status.all" ]]; then
+#echo status.all
+PSTR="TimeVortex state"
+elif [[ $action == "sst.rt.heartbeat" ]]; then
+#echo heartbeat
+PSTR="Heartbeat"
+elif [[ $action == "sst.rt.checkpoint" ]]; then
+#echo checkpoint
+PSTR="Simulation Checkpoint"
+fi
+
+OUTFILE="test.restart.$sig.$action.out"
+
+# 3) Then restart sst with the checkpoint and sigalrm
+if [[ -f $OUTFILE ]]; then
+  rm $OUTFILE
+fi
+
+LAUNCH="sst --$sig='$action(interval=1s)' --load-checkpoint $CKPTDIR"
+echo $LAUNCH
+eval $LAUNCH > $OUTFILE 2>&1 
+retVal=$?
+echo restart.$sig.$action Complete
+
+# 4) Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR restart.$sig.$action return code"
+  exit $retVal
+fi
+
+grep "$PSTR" ./$OUTFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR restart.$sig.$action grep"
+  exit $grepVal
+fi
+echo
+
+# Cleanup output directories
+if [ $CLEANUP -eq 1 ]; then
+  rm $OUTFILE
+fi
+
+
+done  # for $action
+done  # for $sig
+
+if [ $CLEANUP -eq 1 ]; then
+  rm -r $PREFIX
+  rm -r ${PREFIX}_1
+fi
+
+echo "PASS"
+exit $retVal
+
+
+
+
+
+

--- a/tests/rt_action/sigalrm-MIN14.1.sh
+++ b/tests/rt_action/sigalrm-MIN14.1.sh
@@ -12,40 +12,44 @@
 SIG="sigalrm"
 ACTION="sst.rt.exit.clean sst.rt.exit.emergency sst.rt.status.core sst.rt.status.all sst.rt.heartbeat sst.rt.checkpoint"
 CONFIG=" test_Checkpoint.py" #test_MessageMesh.py"
+CLEANUP=1
 
 for sig in $SIG; do
   for action in $ACTION; do
 
-#0 Get pass criterion
+#0 Get pass criterion, PREFIX, and OUTFILE
 if [[ $action == "sst.rt.exit.clean" ]]; then
-#echo clean
-PSTR="EXIT-AFTER TIME"
+  #echo clean
+  PSTR="EXIT-AFTER TIME"
 elif [[ $action == "sst.rt.exit.emergency" ]]; then
-#echo emergency
-PSTR="EMERGENCY"
+  #echo emergency
+  PSTR="EMERGENCY"
 elif [[ $action == "sst.rt.status.core" ]]; then
-#echo status.core
-PSTR="CurrentSimCycle"
+  #echo status.core
+  PSTR="CurrentSimCycle"
 elif [[ $action == "sst.rt.status.all" ]]; then
-#echo status.all
-PSTR="TimeVortex state"
+  #echo status.all
+  PSTR="TimeVortex state"
 elif [[ $action == "sst.rt.heartbeat" ]]; then
-#echo heartbeat
-PSTR="Heartbeat"
+  #echo heartbeat
+  PSTR="Heartbeat"
 elif [[ $action == "sst.rt.checkpoint" ]]; then
-#echo checkpoint
-PSTR="Simulation Checkpoint"
+  #echo checkpoint
+  PSTR="Simulation Checkpoint"
 fi
+
+PREFIX="ckpt_${sig}_$action"
+OUTFILE="test.$sig.$action.out"
 
 # 1) Launch the program
-if [[ -f test.$sig.$action.out ]]; then
-  rm test.$sig.$action.out
+if [[ -f $OUTFILE ]]; then
+  rm $OUTFILE
 fi
 
-LAUNCH="sst --$sig='$action(interval=1s)' $CONFIG"
+LAUNCH="sst --$sig='$action(interval=1s)' --checkpoint-prefix=$PREFIX $CONFIG"
 echo $LAUNCH
 
-eval $LAUNCH > test.$sig.$action.out 2>&1 
+eval $LAUNCH > $OUTFILE 2>&1 
 
 # 2) wait for completion 
 wait
@@ -58,7 +62,7 @@ if [ $retVal -ne 0 ]; then
   exit $retVal
 fi
 
-grep "$PSTR" ./test.$sig.$action.out > /dev/null
+grep "$PSTR" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR $sig=$action grep"
@@ -67,7 +71,12 @@ fi
 echo
 
 # Cleanup output directories
-rm test.$sig.$action.out
+if [ $CLEANUP -eq 1 ]; then
+  rm $OUTFILE
+  if [[ $action == "sst.rt.checkpoint" ]]; then
+    rm -r $PREFIX
+  fi
+fi
 
 done  # for $action
 done  # for $sig

--- a/tests/rt_action/sigalrm-MIN14.1.sh
+++ b/tests/rt_action/sigalrm-MIN14.1.sh
@@ -49,11 +49,10 @@ eval $LAUNCH > test.$sig.$action.out 2>&1
 
 # 2) wait for completion 
 wait
-
+retVal=$?
 echo $sig=$action Complete
 
 # 3) Check result
-retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR $sig=$action return code"
   exit $retVal

--- a/tests/rt_action/sigalrm_ckpt_comb-MIN14.1.sh
+++ b/tests/rt_action/sigalrm_ckpt_comb-MIN14.1.sh
@@ -13,12 +13,15 @@ SIG="sigalrm"
 ACTION="sst.rt.checkpoint"
 ACTION2="sst.rt.exit.clean sst.rt.exit.emergency sst.rt.status.core sst.rt.status.all sst.rt.heartbeat"
 CONFIG="test_Checkpoint.py"
-PREFIX="ckpt_sigalrm"
+PREFIX="ckpt"
+CLEANUP=1
 
 for sig in $SIG; do
   for action in $ACTION; do
     for action2 in $ACTION2; do
 
+PREFIX="ckpt_$action2"
+echo $PREFIX
 
 #0 Get pass criterion
 PSTR="Simulation Checkpoint"
@@ -54,11 +57,11 @@ eval $LAUNCH > test.$sig.$action.$action2.out 2>&1
 
 # 2) wait for completion 
 wait
+retVal=$?
 
 echo $sig=$action $action2 Complete
 
 # 3) Check result
-retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR $sig=$action $action2 return code"
   exit $retVal
@@ -81,13 +84,17 @@ fi
 echo
 
 # Cleanup output directories
-rm test.$sig.$action.$action2.out
+if [ $CLEANUP -eq 1 ]; then
+  rm test.$sig.$action.$action2.out
+fi
 
 done  # for $action2
 done  # for $action
 done  # for $sig
 
-rm -rf $PREFIX*
+if [ $CLEANUP -eq 1 ]; then
+  rm -rf $PREFIX*
+fi
 
 echo "PASS"
 exit $retVal

--- a/tests/rt_action/sigalrm_ckpt_comb-MIN14.1.sh
+++ b/tests/rt_action/sigalrm_ckpt_comb-MIN14.1.sh
@@ -13,7 +13,6 @@ SIG="sigalrm"
 ACTION="sst.rt.checkpoint"
 ACTION2="sst.rt.exit.clean sst.rt.exit.emergency sst.rt.status.core sst.rt.status.all sst.rt.heartbeat"
 CONFIG="test_Checkpoint.py"
-PREFIX="ckpt"
 CLEANUP=1
 
 for sig in $SIG; do
@@ -83,18 +82,15 @@ fi
 
 echo
 
-# Cleanup output directories
+# Cleanup output files and directories
 if [ $CLEANUP -eq 1 ]; then
   rm test.$sig.$action.$action2.out
+  rm -r $PREFIX
 fi
 
 done  # for $action2
 done  # for $action
 done  # for $sig
-
-if [ $CLEANUP -eq 1 ]; then
-  rm -rf $PREFIX*
-fi
 
 echo "PASS"
 exit $retVal

--- a/tests/rt_action/sigalrm_combined-MIN14.1.sh
+++ b/tests/rt_action/sigalrm_combined-MIN14.1.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_PARAM MIN14.1
 #EXT_TEST TEST_FILE_DESC "Tests sigalrm for combinations of two real time actions (checkpoint not included)"
+#EXT_TEST TIMEOUT 75
 # 
 # 0) set pass string 
 # 1) launch the program
@@ -63,14 +64,16 @@ elif [[ $action2 == "sst.rt.checkpoint" ]]; then
 PSTR2="Simulation Checkpoint"
 fi
 
+OUTFILE="test.$sig.$action.$action2.out"
+
 # 1) Launch the program
-if [[ -f test.$sig.$action.$action2.out ]]; then
-  rm test.$sig.$action.$action2.out
+if [[ -f $OUTFILE ]]; then
+  rm $OUTFILE
 fi
 
 LAUNCH="sst --$sig='$action(interval=1s);$action2(interval=2s)' $CONFIG"
 echo $LAUNCH
-eval $LAUNCH > test.$sig.$action.$action2.out 2>&1 
+eval $LAUNCH > $OUTFILE 2>&1 
 
 # 2) wait for completion 
 wait
@@ -83,25 +86,25 @@ if [ $retVal -ne 0 ]; then
   exit $retVal
 fi
 
-grep "$PSTR" ./test.$sig.$action.$action2.out > /dev/null
+grep "$PSTR" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR $sig=$action grep"
   exit $grepVal
 fi
 
-grep "$PSTR2" ./test.$sig.$action.$action2.out > /dev/null
+grep "$PSTR2" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR $sig=$action2 grep"
   exit $grepVal
 fi
 
+# Cleanup output directories
+rm $OUTFILE
+
 echo
 fi    # if $action != $action2
-
-# Cleanup output directories
-rm test.$sig.$action.$action2.out
 
 done  # for $action2
 done  # for $action

--- a/tests/rt_action/sigalrm_combined-MIN14.1.sh
+++ b/tests/rt_action/sigalrm_combined-MIN14.1.sh
@@ -74,11 +74,10 @@ eval $LAUNCH > test.$sig.$action.$action2.out 2>&1
 
 # 2) wait for completion 
 wait
-
+retVal=$?
 echo $sig=$action $action2 Complete
 
 # 3) Check result
-retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR $sig=$action $action2 return code"
   exit $retVal

--- a/tests/rt_action/sigusr-MIN14.1.sh
+++ b/tests/rt_action/sigusr-MIN14.1.sh
@@ -61,11 +61,10 @@ kill -$sig $PID
 
 # 4) wait for completion 
 wait
-
+retVal=$?
 echo $sig=$action Complete
 
 # 5) Check result
-retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR $sig=$action return code"
   exit $retVal

--- a/tests/rt_action/sigusr_interactive-DEV.sh
+++ b/tests/rt_action/sigusr_interactive-DEV.sh
@@ -58,11 +58,11 @@ echo run > $pipe
 
 # 5) Wait for completion
 wait
+retVal=$?
 exec 3>&- # close pipe
 echo $sig=$action Complete
 
 # 6) Check results
-retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR $sig=$action return code"
   exit $retVal


### PR DESCRIPTION
This PR adds a set of tests to verify whether the various periodic actions act correctly with checkpoint and restart. This includes testing:

- sigalrm
- interactive-console
- heartbeat

If sigalrm, interactive-console or heartbeat are used when checkpointing, they should NOT be checkpointed and carried over to restart. However, all of these flags should work when combined with a restart (e.g. `sst --heartbeat-period=1s --load-checkpoint <checkpoint_file>`).

The `restart-ckpt-with-<action>` tests combine the flags with the checkpoint. The restart-ckpt-with-heartbeat test currently  fails because the heartbeat action gets carried over to restart, triggering an error. The restart-ckpt-with-interactive currently fails because the interactive-console run command triggers an error during checkpointing (sst-core issue #1223).

The `restart-<action>` tests test the flags during restart (e.g.  `sst --heartbeat-period=1s --load-checkpoint <checkpoint_file>`). These currently all pass.

This PR also includes some cleanup of the existing tests to fix an issue with capturing the return value and other minor improvements. 