### PR TITLE
changed tests to use checkpoint starting index of 1 instead of 0

### DIFF
--- a/tests/cli/sst_checkpoint_name_format-DEV.sh
+++ b/tests/cli/sst_checkpoint_name_format-DEV.sh
@@ -28,9 +28,9 @@ if [ ! -d "$pfx" ]; then
     exit 1
 fi
 cptfiles=(\
- "$pfx/0_10000000/cpt.sstcpt" \
- "$pfx/0_10000000/cpt_0_0.bin" \
- "$pfx/0_10000000/cpt_globals.bin"\
+ "$pfx/1_10000000/cpt.sstcpt" \
+ "$pfx/1_10000000/cpt_0_0.bin" \
+ "$pfx/1_10000000/cpt_globals.bin"\
 )
 for cptfile in "${cptfiles[@]}"; do
     if [ ! -e "$cptfile" ]; then
@@ -52,9 +52,9 @@ if [ ! -d "test2/$pfx" ]; then
     exit 1
 fi
 cptfiles=(\
- "test2/$pfx/0_10000000/${pfx}_cpt.sstcpt" \
- "test2/$pfx/0_10000000/${pfx}_cpt_0_0.bin" \
- "test2/$pfx/0_10000000/${pfx}_cpt_globals.bin"\
+ "test2/$pfx/1_10000000/${pfx}_cpt.sstcpt" \
+ "test2/$pfx/1_10000000/${pfx}_cpt_0_0.bin" \
+ "test2/$pfx/1_10000000/${pfx}_cpt_globals.bin"\
 )
 for cptfile in "${cptfiles[@]}"; do
     if [ ! -e "$cptfile" ]; then

--- a/tests/cli/sst_output_dir_cpt-DEV.sh
+++ b/tests/cli/sst_output_dir_cpt-DEV.sh
@@ -17,9 +17,9 @@ check_odir() {
         exit 1
     fi
     cptfiles=(\
-     "$odir/checkpoint/checkpoint_0_10000000/checkpoint_0_10000000.sstcpt" \
-     "$odir/checkpoint/checkpoint_0_10000000/checkpoint_0_10000000_0_0.bin" \
-     "$odir/checkpoint/checkpoint_0_10000000/checkpoint_0_10000000_globals.bin"\
+     "$odir/checkpoint/checkpoint_1_10000000/checkpoint_1_10000000.sstcpt" \
+     "$odir/checkpoint/checkpoint_1_10000000/checkpoint_1_10000000_0_0.bin" \
+     "$odir/checkpoint/checkpoint_1_10000000/checkpoint_1_10000000_globals.bin"\
     )
     for cptfile in "${cptfiles[@]}"; do
         if [ ! -e "$cptfile" ]; then


### PR DESCRIPTION
To be compatible with latest sst-core devel version checkpoints start their number at 1 instead of 0.
Trivial change but may have missed some tests.
