### PR TITLE
Fix for return error code from pass string check

### DIFF
--- a/tests/rt_action/restart-ckpt-with-heartbeat-DEV.sh
+++ b/tests/rt_action/restart-ckpt-with-heartbeat-DEV.sh
@@ -41,7 +41,7 @@ grep "$PSTR2" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR ckpt.heartbeat grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 # Cleanup output file
@@ -70,7 +70,7 @@ grep "$PSTR2" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR restart.ckpt.heartbeat grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 echo

--- a/tests/rt_action/restart-ckpt-with-heartbeat-KNOWNFAIL-14.1.sh
+++ b/tests/rt_action/restart-ckpt-with-heartbeat-KNOWNFAIL-14.1.sh
@@ -38,7 +38,7 @@ grep "$PSTR2" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR ckpt.heartbeat grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 # Cleanup output file
@@ -67,7 +67,7 @@ grep "$PSTR2" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR restart.ckpt.heartbeat grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 echo

--- a/tests/rt_action/restart-ckpt-with-heartbeat-KNOWNFAIL-15.0.sh
+++ b/tests/rt_action/restart-ckpt-with-heartbeat-KNOWNFAIL-15.0.sh
@@ -38,7 +38,7 @@ grep "$PSTR2" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR ckpt.heartbeat grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 # Cleanup output file
@@ -67,7 +67,7 @@ grep "$PSTR2" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR restart.ckpt.heartbeat grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 echo

--- a/tests/rt_action/restart-ckpt-with-interactive-DEV.sh
+++ b/tests/rt_action/restart-ckpt-with-interactive-DEV.sh
@@ -54,7 +54,7 @@ retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR ckpt.interactive grep"
   rm $pipe
-  exit $grepVal
+  exit $retVal
 fi
 
 # Cleanup output file
@@ -93,7 +93,7 @@ retVal=$?
 if [ $retVal -eq 0 ]; then
   echo "ERROR restart.ckpt.interactive grep"
   rm $pipe
-  exit $grepVal
+  exit $retVal
 fi
 
 echo

--- a/tests/rt_action/restart-ckpt-with-interactive-KNOWNFAIL-14.1.sh
+++ b/tests/rt_action/restart-ckpt-with-interactive-KNOWNFAIL-14.1.sh
@@ -37,7 +37,7 @@ grep "$PSTR2" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR ckpt.interactive grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 # Cleanup output file
@@ -64,7 +64,7 @@ grep "$PSTR2" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR restart.ckpt.interactive grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 echo

--- a/tests/rt_action/restart-ckpt-with-interactive-KNOWNFAIL-15.0.sh
+++ b/tests/rt_action/restart-ckpt-with-interactive-KNOWNFAIL-15.0.sh
@@ -37,7 +37,7 @@ grep "$PSTR2" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR ckpt.interactive grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 # Cleanup output file
@@ -64,7 +64,7 @@ grep "$PSTR2" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR restart.ckpt.interactive grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 echo

--- a/tests/rt_action/restart-ckpt-with-sigalrm-14.1.sh
+++ b/tests/rt_action/restart-ckpt-with-sigalrm-14.1.sh
@@ -58,7 +58,7 @@ grep "$PSTR2" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR ckpt.$sig.$action2 grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 if [ $CLEANUP -eq 1 ]; then
@@ -84,7 +84,7 @@ grep "$PSTR2" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -eq 0 ]; then
   echo "ERROR restart.ckpt.$sig.$action grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 echo

--- a/tests/rt_action/restart-ckpt-with-sigalrm-15.0.sh
+++ b/tests/rt_action/restart-ckpt-with-sigalrm-15.0.sh
@@ -58,7 +58,7 @@ grep "$PSTR2" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR ckpt.$sig.$action2 grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 if [ $CLEANUP -eq 1 ]; then
@@ -84,7 +84,7 @@ grep "$PSTR2" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -eq 0 ]; then
   echo "ERROR restart.ckpt.$sig.$action grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 echo

--- a/tests/rt_action/restart-ckpt-with-sigalrm-DEV.sh
+++ b/tests/rt_action/restart-ckpt-with-sigalrm-DEV.sh
@@ -59,7 +59,7 @@ grep "$PSTR2" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR ckpt.$sig.$action2 grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 if [ $CLEANUP -eq 1 ]; then
@@ -85,7 +85,7 @@ grep "$PSTR2" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -eq 0 ]; then
   echo "ERROR restart.ckpt.$sig.$action grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 echo

--- a/tests/rt_action/restart-heartbeat-14.1.sh
+++ b/tests/rt_action/restart-heartbeat-14.1.sh
@@ -36,7 +36,7 @@ grep "$PSTR" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR $PREFIX grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 # Cleanup output file
@@ -70,7 +70,7 @@ grep "$PSTR" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR restart.heartbeat grep"
-  exit $grepVal
+  exit $retVal
 fi
 echo
 

--- a/tests/rt_action/restart-heartbeat-MIN15.0.sh
+++ b/tests/rt_action/restart-heartbeat-MIN15.0.sh
@@ -36,7 +36,7 @@ grep "$PSTR" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR $PREFIX grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 # Cleanup output file
@@ -70,7 +70,7 @@ grep "$PSTR" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR restart.heartbeat grep"
-  exit $grepVal
+  exit $retVal
 fi
 echo
 

--- a/tests/rt_action/restart-interactive-14.1.sh
+++ b/tests/rt_action/restart-interactive-14.1.sh
@@ -35,7 +35,7 @@ grep "$PSTR" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR $PREFIX grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 # Cleanup output file
@@ -84,7 +84,7 @@ retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR restart.interactive grep"
   rm $pipe
-  exit $grepVal
+  exit $retVal
 fi
 echo
 

--- a/tests/rt_action/restart-interactive-MIN15.0.sh
+++ b/tests/rt_action/restart-interactive-MIN15.0.sh
@@ -35,7 +35,7 @@ grep "$PSTR" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR $PREFIX grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 # Cleanup output file
@@ -84,7 +84,7 @@ retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR restart.interactive grep"
   rm $pipe
-  exit $grepVal
+  exit $retVal
 fi
 echo
 

--- a/tests/rt_action/restart-sigalrm-14.1.sh
+++ b/tests/rt_action/restart-sigalrm-14.1.sh
@@ -37,7 +37,7 @@ grep "$PSTR" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR $PREFIX grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 # Cleanup output file
@@ -93,7 +93,7 @@ grep "$PSTR" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR restart.$sig.$action grep"
-  exit $grepVal
+  exit $retVal
 fi
 echo
 

--- a/tests/rt_action/restart-sigalrm-MIN15.0.sh
+++ b/tests/rt_action/restart-sigalrm-MIN15.0.sh
@@ -37,7 +37,7 @@ grep "$PSTR" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR $PREFIX grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 # Cleanup output file
@@ -93,7 +93,7 @@ grep "$PSTR" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR restart.$sig.$action grep"
-  exit $grepVal
+  exit $retVal
 fi
 echo
 

--- a/tests/rt_action/sigalrm-MIN14.1.sh
+++ b/tests/rt_action/sigalrm-MIN14.1.sh
@@ -66,7 +66,7 @@ grep "$PSTR" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR $sig=$action grep"
-  exit $grepVal
+  exit $retVal
 fi
 echo
 

--- a/tests/rt_action/sigalrm_ckpt_comb-MIN14.1.sh
+++ b/tests/rt_action/sigalrm_ckpt_comb-MIN14.1.sh
@@ -70,14 +70,14 @@ grep "$PSTR" ./test.$sig.$action.$action2.out > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR $sig=$action grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 grep "$PSTR2" ./test.$sig.$action.$action2.out > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR $sig=$action2 grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 echo

--- a/tests/rt_action/sigalrm_combined-MIN14.1.sh
+++ b/tests/rt_action/sigalrm_combined-MIN14.1.sh
@@ -90,14 +90,14 @@ grep "$PSTR" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR $sig=$action grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 grep "$PSTR2" ./$OUTFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR $sig=$action2 grep"
-  exit $grepVal
+  exit $retVal
 fi
 
 # Cleanup output directories

--- a/tests/rt_action/sigusr-MIN14.1.sh
+++ b/tests/rt_action/sigusr-MIN14.1.sh
@@ -75,7 +75,7 @@ grep "$PSTR" ./test.$sig.$action.out > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR $sig=$action grep"
-  exit $grepVal
+  exit $retVal
 fi
 echo
 

--- a/tests/rt_action/sigusr_interactive-MIN15.0.sh
+++ b/tests/rt_action/sigusr_interactive-MIN15.0.sh
@@ -74,7 +74,7 @@ retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR $sig=$action grep"
   rm $pipe
-  exit $grepVal
+  exit $retVal
 fi
 echo
 


### PR DESCRIPTION
The pass string check was always returning 0 even if it failed. Just a simple global search/replace 
