### PR TITLE
Cleaner uninstall

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -3,6 +3,9 @@
 # Unregisters components from the SST infrastructure
 #
 
+#--remove files from cmake install manifest                                           
+xargs rm < install_manifest.txt
+
 #-- unregister it
 sst-register -u captcrunch
 


### PR DESCRIPTION
The adds one line to the uninstall script to remove shared library objects from their install area which is with the source code.  This prevents unknowingly using stale libraries even after deleting everything in the build area.
Minor change but wanted you to be aware of it for benefit of other repos. Conversely, if "it's been done" and there is some reason not to do it... 
