### PR TITLE
Tests for new command line option fuctionality

### DIFF
--- a/tests/core-debug-components/CMakeLists.txt
+++ b/tests/core-debug-components/CMakeLists.txt
@@ -10,6 +10,8 @@
 set(DbgSST15Srcs
   dbgsst15.cc
   dbgsst15.h
+  ICDbgSST15.cc
+  ICDbgSST15.h
   probe.cc
   probe.h
 )
@@ -19,5 +21,6 @@ target_include_directories(dbgsst15 PUBLIC ${SST_INSTALL_DIR}/include)
 install(TARGETS dbgsst15 DESTINATION ${CMAKE_CURRENT_SOURCE_DIR})
 install(CODE "execute_process(COMMAND sst-register dbgsst15 dbgsst15_LIBDIR=${CMAKE_CURRENT_SOURCE_DIR})")
 
+install(CODE "execute_process(COMMAND sst-register ICDebugSST15 dgbsst15_LIBDIR=${CMAKE_CURRENT_SOURCE_DIR})")
 
 # EOF

--- a/tests/core-debug-components/ICDbgSST15.cc
+++ b/tests/core-debug-components/ICDbgSST15.cc
@@ -1,0 +1,1180 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#include "ICDbgSST15.h"
+
+namespace SST::ICDbgSST15 {
+
+ICDebugSST15::ICDebugSST15(Params& UNUSED(params)) :
+    InteractiveConsole()
+{
+    // registerAsPrimaryComponent();
+}
+
+void
+ICDebugSST15::execute(const std::string& msg)
+{
+    printf("Test Interactive Console. Does nothing but provide help and quit\n");
+    printf("Entering interactive mode at time %" PRI_SIMTIME " \n", getCurrentSimCycle());
+    printf("%s\n", msg.c_str());
+    if ( nullptr == obj_ ) {
+        obj_ = getComponentObjectMap();
+    }
+    done = false;
+
+    std::string line;
+    while ( !done ) {
+        printf("> ");
+        std::getline(std::cin, line);
+        dispatch_cmd(line);
+    }
+}
+
+// Functions for the Explorer
+
+std::vector<std::string>
+ICDebugSST15::tokenize(std::vector<std::string>& tokens, const std::string& input)
+{
+    std::istringstream iss(input);
+    std::string        token;
+
+    while ( iss >> token ) {
+        tokens.push_back(token);
+    }
+
+    return tokens;
+}
+
+void
+ICDebugSST15::cmd_help(std::vector<std::string>& UNUSED(tokens))
+{
+    std::string help = "Interactive Console Debugger Commands\n";
+    help.append("  Navigation: Navigate the current object map\n");
+    help.append("   - pwd: print the current working directory in the object map\n");
+    help.append("   - cd: change directory level in the object map\n");
+    help.append("   - ls: list the objects in the current level of the object map\n");
+
+    help.append("  Current State: Print information about the current simulation "
+                "state\n");
+    help.append("   - time: print current simulation time in cycles\n");
+    help.append("   - print [-rN][<obj>]: print objects in the current level of "
+                "the object map;\n");
+    help.append("                         if -rN is provided print recursive N "
+                "levels (default N=4)\n");
+
+    help.append("  Modify State: Modify simulation variables\n");
+    help.append("   - set <obj> <value>: sets an object in the current scope to "
+                "the provided value;\n");
+    help.append("                        object must be a \"fundamental type\" "
+                "e.g. int \n");
+    help.append("\n");
+    help.append("  Watchpoints: Manage watchpoints (with or without tracing)\n");
+    help.append("                A <trigger> can be a <comparison> or a sequence "
+                "of comparisons combined with a <logicOp>\n");
+    help.append("                E.g. <trigger> = <comparison> or <comparison1> "
+                "<logicOp> <comparison2> ...\n");
+    help.append("                A <comparision> can be \"<var> changed\" which "
+                "checks whether the value has changed\n");
+    help.append("                or \"<var> <comp> <val>\" which compares the "
+                "variable to a given value\n");
+    help.append("                A <comp> can be <, <=, >, >=, ==, or !=\n");
+    help.append("                A <logicOp> can be && or ||\n");
+    help.append("                \"watch\" creates a default watchpoint that "
+                "breaks into an interactive console when triggered\n");
+    help.append("                \"trace\" creates a watchpoint with a trace "
+                "buffer to trace a set of variables and trigger an <action>\n");
+    help.append("                Available actions include: interactive, "
+                "printTrace, checkpoint, set, or printStatus\n");
+    help.append("   - watch <trigger>: adds watchpoint to the watchlist; breaks "
+                "into interactive console when triggered\n");
+    help.append("                Example: watch size > 90 && count < 100 || "
+                "status changed\n");
+    help.append("   - trace <trigger> : <bufferSize> <postDelay> : <var1> ... "
+                "<varN> : <action> \n");
+    help.append("                Adds watchpoint to the watchlist with a trace buffer of "
+                "<bufferSize> and a post trigger delay of <postDelay>\n");
+    help.append("                Traces all of the variables specified in the var list "
+                "and invokes the <action> after postDelay when triggered\n");
+    help.append("                Example: trace size > 90 || count == 100 : 32 4 "
+                ": size count state : printTrace\n");
+    help.append("   - watchlist: prints the current list of watchpoints and "
+                "their associated indices\n");
+    help.append("                Note: a watchpoint's index may change as "
+                "watchpoints are deleted\n");
+    help.append("   - addTraceVar <watchpointIndex> <var1> ... <varN> : adds the "
+                "specified variables to the specified watchpoint's trace buffer\n");
+    help.append("   - printWatchpoint <watchpointIndex>: prints the watchpoint "
+                "based on the index specified by watchlist\n");
+    help.append("   - printTrace <watchpointIndex>: prints the trace buffer for "
+                "the specified watchpoint\n");
+    help.append("   - resetTrace <watchpointIndex>: resets the trace buffer for "
+                "the specified watchpoint\n");
+    help.append("   - unwatch <watchpointIndex>: removes the specified "
+                "watchpoint from the watch list. If no index is provided, all watchpoints are removed.\n");
+    help.append("\n");
+    help.append("  Execute: Execute the simulation for a specified duration\n");
+    help.append("   - run [TIME]: runs the simulation from the current point for "
+                "TIME and then returns to\n");
+    help.append("                 interactive mode; if no time is given, the "
+                "simulation runs to completion;\n");
+    help.append("                 TIME is of the format <Number><unit> e.g. 4us\n");
+    help.append("\n");
+    help.append("  Exit: Exit the interactive console\n");
+    help.append("   - exit or quit: exits the interactive console and resumes "
+                "simulation execution\n");
+    help.append("   - shutdown: exits the interactive console and does a clean "
+                "shutdown of the simulation\n");
+    help.append("\n");
+    printf("%s", help.c_str());
+}
+
+#if 0
+void
+ICDebugSST15::cmd_pwd(std::vector<std::string>& UNUSED(tokens))
+{
+    // std::string path = obj_->getName();
+    // std::string slash("/");
+    // // path = slash + path;
+    // SST::Core::Serialization::ObjectMap* curr = obj_->getParent();
+    // while ( curr != nullptr ) {
+    //     path = curr->getName() + slash + path;
+    //     curr = curr->getParent();
+    // }
+
+    printf("%s (%s)\n", obj_->getFullName().c_str(), obj_->getType().c_str());
+}
+
+void
+ICDebugSST15::cmd_ls(std::vector<std::string>& UNUSED(tokens))
+{
+    auto& vars = obj_->getVariables();
+    for ( auto& x : vars ) {
+        if ( x.second->isFundamental() ) {
+            printf("%s = %s (%s)\n", x.first.c_str(), x.second->get().c_str(), x.second->getType().c_str());
+        }
+        else {
+            printf("%s/ (%s)\n", x.first.c_str(), x.second->getType().c_str());
+        }
+    }
+}
+
+void
+ICDebugSST15::cmd_cd(std::vector<std::string>& tokens)
+{
+    if ( tokens.size() != 2 ) {
+        printf("Invalid format for cd command (cd <obj>)\n");
+        return;
+    }
+
+    // Check for ..
+    if ( tokens[1] == ".." ) {
+        auto* parent = obj_->selectParent();
+        if ( parent == nullptr ) {
+            printf("Already at top of object hierarchy\n");
+            return;
+        }
+        // See if this is the top level component, and if so, set it
+        // to nullptr
+        if ( dynamic_cast<Core::Serialization::ObjectMap*>(base_comp_) == obj_ ) {
+            base_comp_ = nullptr;
+        }
+        obj_ = parent;
+        return;
+    }
+
+    bool                                 loop_detected = false;
+    SST::Core::Serialization::ObjectMap* new_obj       = obj_->selectVariable(tokens[1], loop_detected);
+
+    if ( !new_obj ) {
+        printf("Unknown object in cd command: %s\n", tokens[1].c_str());
+        return;
+    }
+
+    if ( new_obj->isFundamental() ) {
+        printf("Object %s is a fundamental type so you cannot cd into it\n", tokens[1].c_str());
+        new_obj->selectParent();
+        return;
+    }
+
+    if ( loop_detected ) {
+        printf("Loop detected in cd.  New working directory will be set to level "
+               "of looped object: %s\n",
+            new_obj->getFullName().c_str());
+    }
+    obj_ = new_obj;
+
+    // If we don't already have the top level component, check to see
+    // if this is it
+    if ( nullptr == base_comp_ ) {
+        Core::Serialization::ObjectMapDeferred<BaseComponent>* base_comp =
+            dynamic_cast<Core::Serialization::ObjectMapDeferred<BaseComponent>*>(obj_);
+        if ( base_comp ) base_comp_ = base_comp;
+    }
+}
+
+void
+ICDebugSST15::cmd_print(std::vector<std::string>& tokens)
+{
+    // Index in tokens array where we may find the variable name
+    size_t var_index = 1;
+
+    if ( tokens.size() < 2 ) {
+        printf("Invalid format for print command (print [-rN] [<obj>])\n");
+        return;
+    }
+
+    // See if have a -r or not
+    int         recurse = 0;
+    std::string tok     = tokens[1];
+    if ( tok.size() >= 2 && tok[0] == '-' && tok[1] == 'r' ) {
+        // Got a -r
+        std::string num = tok.substr(2);
+        if ( num.size() != 0 ) {
+            try {
+                recurse = SST::Core::from_string<int>(num);
+            }
+            catch ( std::invalid_argument& e ) {
+                printf("Invalid number format specified with -r: %s\n", tok.c_str());
+                return;
+            }
+        }
+        else {
+            recurse = 4; // default -r depth
+        }
+
+        var_index = 2;
+    }
+
+    if ( tokens.size() == var_index ) {
+        // Print current object
+        obj_->list(recurse);
+        return;
+    }
+
+    if ( tokens.size() != (var_index + 1) ) {
+        printf("Invalid format for print command (print [-rN] [<obj>])\n");
+        return;
+    }
+
+    bool        found;
+    std::string listing = obj_->listVariable(tokens[var_index], found, recurse);
+
+    if ( !found ) {
+        printf("Unknown object in print command: %s\n", tokens[1].c_str());
+        return;
+    }
+    else {
+        printf("%s", listing.c_str());
+    }
+}
+
+void
+ICDebugSST15::cmd_set(std::vector<std::string>& tokens)
+{
+    if ( tokens.size() != 3 ) {
+        printf("Invalid format for set command (set <obj> <value>)\n");
+        return;
+    }
+
+    if ( obj_->isContainer() ) {
+        bool found     = false;
+        bool read_only = false;
+        obj_->set(tokens[1], tokens[2], found, read_only);
+        if ( !found ) printf("Unknown object in set command: %s\n", tokens[1].c_str());
+        if ( read_only ) printf("Object specified in set command is read-only: %s\n", tokens[1].c_str());
+        return;
+    }
+
+    bool  loop_detected = false;
+    auto* var           = obj_->selectVariable(tokens[1], loop_detected);
+    if ( !var ) {
+        printf("Unknown object in set command: %s\n", tokens[1].c_str());
+        return;
+    }
+
+    if ( var->isReadOnly() ) {
+        printf("Object specified in set command is read-only: %s\n", tokens[1].c_str());
+        var->selectParent();
+        return;
+    }
+
+    if ( !var->isFundamental() ) {
+        printf("Invalid object in set command: %s is not a fundamental type\n", tokens[1].c_str());
+        var->selectParent();
+        return;
+    }
+
+    try {
+        var->set(tokens[2]);
+    }
+    catch ( std::exception& e ) {
+        printf("Invalid format: %s\n", tokens[2].c_str());
+        return;
+    }
+    var->selectParent();
+}
+
+void
+ICDebugSST15::cmd_time(std::vector<std::string>& UNUSED(tokens))
+{
+    printf("current time = %" PRI_SIMTIME "\n", getCurrentSimCycle());
+}
+
+void
+ICDebugSST15::cmd_run(std::vector<std::string>& tokens)
+{
+    if ( tokens.size() == 2 ) {
+        try {
+            TimeConverter* tc  = getTimeConverter(tokens[1]);
+            std::string    msg = format_string("Running clock %" PRI_SIMTIME " sim cycles", tc->getFactor());
+            schedule_interactive(tc->getFactor(), msg);
+        }
+        catch ( std::exception& e ) {
+            printf("Unknown time in call to run: %s\n", tokens[1].c_str());
+            return;
+        }
+    }
+
+    done = true;
+    return;
+}
+
+// setHandler <wpIndex> <handlerType1> ... <handlerTypeN>
+void
+ICDebugSST15::cmd_setHandler(std::vector<std::string>& tokens)
+{
+    if ( tokens.size() < 3 ) {
+        printf("Invalid format: setHandler <watchpointIndex> <handlerType1> ... <handlerTypeN>\n");
+        return;
+    }
+    size_t wpIndex = watch_points_.size();
+    try {
+        wpIndex = std::stoi(tokens[1]);
+    }
+    catch ( const std::invalid_argument& e ) {
+        std::cerr << "Error: Invalid argument for buffer size: " << tokens[5] << std::endl;
+        return;
+    }
+    catch ( const std::out_of_range& e ) {
+        std::cerr << "Error: Out of range for buffer size: " << tokens[5] << std::endl;
+        return;
+    }
+    if ( wpIndex >= watch_points_.size() ) {
+        printf(" Invalid watchpoint index: %ld\n", wpIndex);
+        return;
+    }
+
+    WatchPoint* wp = watch_points_.at(wpIndex).first;
+    printf("WP %ld - %s\n", wpIndex, wp->getName().c_str());
+
+    // Get handlerTypes and add associated objectBuffers
+    size_t   tindex  = 2;
+    unsigned handler = 0;
+    while ( tindex < tokens.size() ) {
+        std::string type = tokens[tindex++];
+        // printf("%s ", type.c_str());
+
+        if ( type == "bc" )
+            handler = handler | (unsigned)WatchPoint::BEFORE_CLOCK;
+        else if ( type == "ac" )
+            handler = handler | (unsigned)WatchPoint::AFTER_CLOCK;
+        else if ( type == "be" )
+            handler = handler | (unsigned)WatchPoint::BEFORE_EVENT;
+        else if ( type == "ae" )
+            handler = handler | (unsigned)WatchPoint::AFTER_EVENT;
+        else if ( type == "all" )
+            handler = handler | (unsigned)WatchPoint::ALL;
+        else
+            printf(" Invalid handler type: %s\n", type.c_str());
+    }
+
+    wp->setHandler(handler);
+    return;
+}
+
+// addTraceVar <wpIndex> <var1> ... <varN>
+void
+ICDebugSST15::cmd_addTraceVar(std::vector<std::string>& tokens)
+{
+    if ( tokens.size() < 3 ) {
+        printf("Invalid format: addTraceVar <watchpointIndex> <var1> ... <varN>\n");
+        return;
+    }
+    size_t wpIndex = watch_points_.size();
+    try {
+        wpIndex = std::stoi(tokens[1]);
+    }
+    catch ( const std::invalid_argument& e ) {
+        std::cerr << "Error: Invalid argument for buffer size: " << tokens[5] << std::endl;
+        return;
+    }
+    catch ( const std::out_of_range& e ) {
+        std::cerr << "Error: Out of range for buffer size: " << tokens[5] << std::endl;
+        return;
+    }
+    if ( wpIndex >= watch_points_.size() ) {
+        printf(" Invalid watchpoint index\n");
+        return;
+    }
+
+    WatchPoint* wp = watch_points_.at(wpIndex).first;
+    printf("WP %ld - %s\n", wpIndex, wp->getName().c_str());
+
+    // Get trace vars and add associated objectBuffers
+    size_t tindex = 2;
+    while ( tindex < tokens.size() ) {
+        std::string tvar = tokens[tindex++];
+        // printf("%s ", tvar.c_str());
+
+        // Find and check trace variable
+        Core::Serialization::ObjectMap* map = obj_->findVariable(tvar);
+        if ( nullptr == map ) {
+            printf("Unknown variable: %s\n", tvar.c_str());
+            return;
+        }
+
+        // Is variable fundamental
+        if ( !map->isFundamental() ) {
+            printf("Traces can only be placed on fundamental types; %s is not "
+                   "fundamental\n",
+                tvar.c_str());
+            return;
+        }
+        size_t bufsize = wp->getBufferSize();
+        if ( bufsize == 0 ) {
+            printf("Watchpoint %ld does not have tracing enabled\n", wpIndex);
+        }
+        auto* ob = map->getObjectBuffer(obj_->getFullName() + "/" + tvar, bufsize);
+        wp->addObjectBuffer(ob);
+    }
+    return;
+}
+
+// resetTraceBuffer <wpIndex>
+void
+ICDebugSST15::cmd_resetTraceBuffer(std::vector<std::string>& tokens)
+{
+    if ( tokens.size() != 2 ) {
+        printf("Invalid format: resetTraceBuffer <watchpointIndex>\n");
+        return;
+    }
+    size_t wpIndex = watch_points_.size();
+    try {
+        wpIndex = std::stoi(tokens[1]);
+    }
+    catch ( const std::invalid_argument& e ) {
+        std::cerr << "Error: Invalid argument for buffer size: " << tokens[5] << std::endl;
+        return;
+    }
+    catch ( const std::out_of_range& e ) {
+        std::cerr << "Error: Out of range for buffer size: " << tokens[5] << std::endl;
+        return;
+    }
+    if ( wpIndex >= watch_points_.size() ) {
+        printf(" Invalid watchpoint index\n");
+        return;
+    }
+
+    WatchPoint* wp = watch_points_.at(wpIndex).first;
+    // printf("WP %ld - %s\n", wpIndex, wp->getName().c_str());
+    wp->resetTraceBuffer();
+
+    return;
+}
+
+// printTrace <wpIndex>
+void
+ICDebugSST15::cmd_printTrace(std::vector<std::string>& tokens)
+{
+    if ( tokens.size() != 2 ) {
+        printf("Invalid format: printTrace <watchpointIndex>\n");
+        return;
+    }
+    size_t wpIndex = watch_points_.size();
+    try {
+        wpIndex = std::stoi(tokens[1]);
+    }
+    catch ( const std::invalid_argument& e ) {
+        std::cerr << "Error: Invalid argument for buffer size: " << tokens[5] << std::endl;
+        return;
+    }
+    catch ( const std::out_of_range& e ) {
+        std::cerr << "Error: Out of range for buffer size: " << tokens[5] << std::endl;
+        return;
+    }
+    if ( wpIndex >= watch_points_.size() ) {
+        printf(" Invalid watchpoint index\n");
+        return;
+    }
+
+    WatchPoint* wp = watch_points_.at(wpIndex).first;
+    // printf("WP %ld - %s\n", wpIndex, wp->getName().c_str());
+    wp->printTrace();
+
+    return;
+}
+
+// printWatchpoint <wpIndex>
+void
+ICDebugSST15::cmd_printWatchpoint(std::vector<std::string>& tokens)
+{
+    if ( tokens.size() != 2 ) {
+        printf("Invalid format: printWatchpoint <watchpointIndex>\n");
+        return;
+    }
+    size_t wpIndex = watch_points_.size();
+    try {
+        wpIndex = std::stoi(tokens[1]);
+    }
+    catch ( const std::invalid_argument& e ) {
+        std::cerr << "Error: Invalid argument for buffer size: " << tokens[5] << std::endl;
+        return;
+    }
+    catch ( const std::out_of_range& e ) {
+        std::cerr << "Error: Out of range for buffer size: " << tokens[5] << std::endl;
+        return;
+    }
+    if ( wpIndex >= watch_points_.size() ) {
+        printf(" Invalid watchpoint index\n");
+        return;
+    }
+
+    WatchPoint* wp = watch_points_.at(wpIndex).first;
+    // printf("WP %ld: - %s\n", wpIndex, wp->getName().c_str());
+    std::cout << "WP" << wpIndex << ": ";
+    wp->printWatchpoint();
+
+    return;
+}
+
+WatchPoint::LogicOp
+getLogicOpFromString(const std::string& opStr)
+{
+    if ( opStr == "&&" ) {
+        return WatchPoint::LogicOp::AND;
+    }
+    else if ( opStr == "||" ) {
+        return WatchPoint::LogicOp::OR;
+    }
+    else {
+        return WatchPoint::LogicOp::UNDEFINED;
+    }
+}
+
+// watchlist
+void
+ICDebugSST15::cmd_watchlist(std::vector<std::string>& tokens)
+{
+    // Print the watch points
+    printf("Current watch points:\n");
+    int count = 0;
+    for ( auto& x : watch_points_ ) {
+        // printf("  %d - %s\n", count++, x.first->getName().c_str());
+        std::cout << count++ << ": ";
+        x.first->printWatchpoint();
+    }
+    return;
+}
+
+Core::Serialization::ObjectMapComparison*
+parseComparison(std::vector<std::string>& tokens, size_t& index, Core::Serialization::ObjectMap* obj, std::string& name)
+{
+
+    std::string                                  var("");
+    Core::Serialization::ObjectMapComparison::Op op = Core::Serialization::ObjectMapComparison::Op::INVALID;
+    std::string                                  v2("");
+    std::string                                  name2("");
+    std::string                                  opstr("");
+
+    // Get first comparison
+    var = tokens[index++];
+    if (index == tokens.size()) {
+        printf("Invalid format for trigger test\n");
+        return nullptr;
+    }
+    opstr = tokens[index++];
+    op = Core::Serialization::ObjectMapComparison::getOperationFromString(opstr);
+    if (op != Core::Serialization::ObjectMapComparison::Op::CHANGED) {
+        if (index == tokens.size()) {
+            printf("Invalid format for trigger test. Valid formats are <var> changed"
+                "and <var> <op> <val>\n");
+            return nullptr;
+        }
+        v2 = tokens[index++];
+    }
+
+    // Check for errors and build ObjectMapComparison
+    // Look for variable
+    Core::Serialization::ObjectMap* map = obj->findVariable(var);
+
+    // Valid variable name
+    if (nullptr == map) {
+        printf("Unknown variable: %s\n", var.c_str());
+        return nullptr;
+    }
+
+    // Is variable fundamental
+    if (!map->isFundamental()) {
+        printf("Triggers can only use fundamental types; %s is not "
+            "fundamental\n",
+            var.c_str());
+        return nullptr;
+    }
+
+    // Is operator valid
+    if (op == Core::Serialization::ObjectMapComparison::Op::INVALID) {
+        printf("Unknown comparison operation specified in trigger test\n");
+        return nullptr;
+    }
+
+    name = obj->getFullName() + "/" + var;
+
+    // Check if v2 is a variable
+    Core::Serialization::ObjectMap* map2 = obj->findVariable(v2);
+
+    // V2 is valid variable
+    if (nullptr != map2) {
+        //printf("v2 is variable\n");
+
+        // Is variable fundamental
+        if (!map2->isFundamental()) {
+            printf("Triggers can only use fundamental types; %s is not "
+                "fundamental\n",
+                v2.c_str());
+            return nullptr;
+        }
+
+        name2 = obj->getFullName() + "/" + v2;
+        try {
+            auto* c = map->getComparisonVar(name, op, name2, map2); // Can throw an exception
+            return c;
+        }
+        catch (std::exception& e) {
+            printf("Invalid argument passed to trigger test: %s %s %s\n", var.c_str(), opstr.c_str(), v2.c_str());
+            return nullptr;
+        }
+    }
+    else {  // V2 is value string
+        //printf("v2 is value string\n");
+        try {
+            auto* c = map->getComparison(name, op, v2); // Can throw an exception
+            return c;
+        }
+        catch (std::exception& e) {
+            printf("Invalid argument passed to trigger test: %s %s %s\n", var.c_str(), opstr.c_str(), v2.c_str());
+            return nullptr;
+        }
+    }
+}
+
+
+WatchPoint::WPAction*
+parseAction(std::vector<std::string>& tokens, size_t& index, Core::Serialization::ObjectMap* obj)
+{
+    std::string action = tokens[index++];
+
+    if (action == "interactive") {
+        return new WatchPoint::InteractiveWPAction();
+    }
+    else if (action == "printTrace") {
+        return new WatchPoint::PrintTraceWPAction();
+    }
+    else if (action == "checkpoint") {
+        return new WatchPoint::CheckpointWPAction();
+    }
+    else if (action == "printStatus") {
+        return new WatchPoint::PrintStatusWPAction();
+    }
+    else if (action == "set") {
+        if (index >= tokens.size()) {
+            printf("Missing variable for set command\n");
+            return nullptr;
+        }
+        std::string tvar = tokens[index++];
+        // printf("%s ", tvar.c_str());
+
+        if (index >= tokens.size()) {
+            printf("Missing value for set command\n");
+            return nullptr;
+        }
+        std::string tval = tokens[index++];
+
+        // Find and check variable
+        Core::Serialization::ObjectMap* map = obj->findVariable(tvar);
+        if (nullptr == map) {
+            printf("Unknown variable: %s\n", tvar.c_str());
+            return nullptr;
+        }
+
+        // Is variable fundamental
+        if (!map->isFundamental()) {
+            printf("Can only set fundamental variable, %s is not fundamental\n",
+                tvar.c_str());
+            return nullptr;
+        }
+
+        // Is variable read-only
+        if (map->isReadOnly()) {
+            printf("Object specified in set command is read-only: %s\n", tvar.c_str());
+            return nullptr;
+        }
+
+        // Check for valid value
+        if (!map->checkValue(tval)) {
+            //printf("Invalid value specified in set command: %s\n", tval.c_str());
+            return nullptr;
+        }
+
+        std::string name = obj->getFullName() + "/" + tvar;
+
+        return new WatchPoint::SetVarWPAction(name, map, tval);
+
+    }
+#if 0
+    else if (action == "heartbeat") {
+        return WatchPoint::HeartbeatAction();
+    }
+#endif
+    else {
+        return nullptr;
+    }
+}
+
+// watch <trigger>   where
+//  <trigger> is <comparison> OR <comparison> <logicOp> <comparison> ...
+//  <comparison> is <var> changed OR <var> <op> <val>
+//  <logicOp> is one of:  &&,  ||
+//  <op> is one of:  <, <=, >, >=, ==, !=
+// Examples
+//  watch size changed
+//  watch size > 90
+//  watch size > 90 && value == 100
+//  watch size changed || value == 100 && index == 55
+void
+ICDebugSST15::cmd_watch(std::vector<std::string>& tokens)
+{
+    size_t      index = 1;
+    std::string name  = "";
+    try {
+        // Get first comparison
+        Core::Serialization::ObjectMapComparison* c = parseComparison(tokens, index, obj_, name);
+        if ( c == nullptr ) {
+            printf("Invalid comparison argument passed to watch command\n");
+            return;
+        }
+        auto* pt = new WatchPoint(name, c);
+
+#if 0 // watch variables currently don't trace, but they could automatically
+      // trace test vars
+        auto* tb = map->getTraceBuffer(obj_, 32, 4);
+        pt->addTraceBuffer(tb);
+
+        auto* ob = map->getObjectBuffer(obj_->getFullName() + "/" + var, 32);
+        pt->addObjectBuffer(ob);
+#endif
+
+        // Get the top level component to set the watch point
+        BaseComponent* comp = static_cast<BaseComponent*>(base_comp_->getAddr());
+        if ( comp ) {
+            comp->addWatchPoint(pt);
+            watch_points_.emplace_back(pt, comp);
+        }
+        else
+            printf("Not a component\n");
+
+        // Add additional comparisons and logical ops
+        while ( index < tokens.size() ) {
+
+            // Get Logical Operator
+            WatchPoint::LogicOp logicOp = getLogicOpFromString(tokens[index++]);
+            if ( logicOp == WatchPoint::LogicOp::UNDEFINED ) {
+                printf("Invalid logic operator: %s", tokens[index - 1].c_str());
+            }
+            else {
+                pt->addLogicOp(logicOp);
+            }
+            if ( index == tokens.size() ) {
+                printf("Invalid format for watch command\n");
+                return;
+            }
+
+            // Get next comparison
+            Core::Serialization::ObjectMapComparison* c = parseComparison(tokens, index, obj_, name);
+            if ( c == nullptr ) {
+                printf("Invalid comparison argument passed to watch command\n");
+                return;
+            }
+            pt->addComparison(c);
+
+        } // while index < tokens.size(), add another logic op and test comparision
+
+        // Parse action
+        std::string action = "interactive";
+        WatchPoint::WPAction* actionObj = new WatchPoint::InteractiveWPAction();
+        if (actionObj == nullptr) {
+            printf("Error in action: %s\n", action.c_str());
+            return;
+        }
+        else {
+            pt->setAction(actionObj);
+        }
+    } // try/catch  TODO: need to revisit what can actually throw an exception
+    catch ( std::exception& e ) {
+        printf("Invalid format for watch command\n");
+        return;
+    }
+
+    // Check for extra arguments
+    if (index != tokens.size()) {
+        printf("Invalid format for watch command: too many arguments\n");
+        return;
+    }
+
+}
+
+void
+ICDebugSST15::cmd_unwatch(std::vector<std::string>& tokens)
+{
+
+    // If no arguments, unwatch all watchpoints in this component
+    if (tokens.size() == 1) {
+        for (std::pair<WatchPoint*, BaseComponent*>& wp : watch_points_) { // 'element' is a reference to each vector element
+            WatchPoint* pt = wp.first;
+            BaseComponent* comp = wp.second;
+            comp->removeWatchPoint(pt);
+        }
+        watch_points_.clear();
+        return;
+    }
+
+    if ( tokens.size() != 2 ) {
+        printf("Invalid format for unwatch command\n");
+        return;
+    }
+
+    long unsigned int index = 0;
+
+    try {
+        index = (long unsigned int)SST::Core::from_string<int>(tokens[1]);
+    }
+    catch ( std::invalid_argument& e ) {
+        printf("Invalid index format specified. The unwatch command requires that "
+               "one of the index shown when "
+               "\"watch\" is run with no arguments be specified\n");
+        return;
+    }
+
+    if ( watch_points_.size() <= index ) {
+        printf("Watch point %s not found. The unwatch command requires that one of "
+               "the index shown when \"watchlist\" is run be specified\n",
+            tokens[1].c_str());
+        return;
+    }
+
+    WatchPoint*    pt   = watch_points_[index].first;
+    BaseComponent* comp = watch_points_[index].second;
+
+    comp->removeWatchPoint(pt);
+
+    watch_points_.erase(watch_points_.begin() + index);
+}
+
+
+Core::Serialization::TraceBuffer*
+parseTraceBuffer(std::vector<std::string>& tokens, size_t& index, Core::Serialization::ObjectMap* obj)
+{
+    size_t bufsize = 32;
+    size_t pdelay  = 0;
+
+    // Get buffer config
+    if ( tokens[index++] != ":" ) {
+        printf("Invalid format: trace <trigger> : <bufsize> <postdelay> : <v1> ... "
+               "<vN> : <action>\n");
+        return nullptr;
+    }
+    // Could check for ":" here and assume that means they just want default
+    // values for buffer size and post delay
+
+    try {
+        bufsize = std::stoi(tokens[index++]);
+    }
+    catch ( const std::invalid_argument& e ) {
+        std::cerr << "Error: Invalid argument for buffer size: " << tokens[5] << std::endl;
+        return nullptr;
+    }
+    catch ( const std::out_of_range& e ) {
+        std::cerr << "Error: Out of range for buffer size: " << tokens[5] << std::endl;
+        return nullptr;
+    }
+
+    // Get post delay
+    try {
+        pdelay = std::stoi(tokens[index++]);
+    }
+    catch ( const std::invalid_argument& e ) {
+        std::cerr << "Error: Invalid argument for post trigger delay: " << tokens[6] << std::endl;
+        return nullptr;
+    }
+    catch ( const std::out_of_range& e ) {
+        std::cerr << "Error: Out of range for post trigger delay: " << tokens[6] << std::endl;
+        return nullptr;
+    }
+
+    if ( tokens[index++] != ":" ) {
+        printf("Invalid format: trace <var> <op> <value> : <bufsize> <postdelay> : "
+               "<v1> ... <vN> : <action>\n");
+        return nullptr;
+    }
+
+    try {
+        // Setup Trace Buffer
+        return new Core::Serialization::TraceBuffer(obj, bufsize, pdelay);
+        
+    }
+    catch ( std::exception& e ) {
+        printf("HERE: Invalid buffer argument passed to trace command\n");
+        return nullptr;
+    }
+}
+
+Core::Serialization::ObjectBuffer*
+parseTraceVar(std::string& tvar, Core::Serialization::ObjectMap* obj, Core::Serialization::TraceBuffer* tb)
+{
+    // Find and check trace variable
+    Core::Serialization::ObjectMap* map = obj->findVariable(tvar);
+    if ( nullptr == map ) {
+        printf("Unknown variable: %s\n", tvar.c_str());
+        return nullptr;
+    }
+
+    // Is variable fundamental
+    if ( !map->isFundamental() ) {
+        printf("Traces can only be placed on fundamental types; %s is not "
+               "fundamental\n",
+            tvar.c_str());
+        return nullptr;
+    }
+    std::string name = obj->getFullName() + "/" + tvar;
+    return map->getObjectBuffer(name, tb->getBufferSize());
+}
+
+// trace <trigger> : <bufsize> <postdelay> : <v1> ... <vN> :  <action>
+// <trigger> is defined in cmd_watch above
+// <action> is optional - default is break to interactive console
+// Could also consider having multiple actions and/or default buffer config
+// TODO check at each step that we haven't exceeded token size
+void
+ICDebugSST15::cmd_trace(std::vector<std::string>& tokens)
+{
+    if ( tokens.size() < 9 ) {
+        printf("Invalid format: trace <var> <op> <value> : <bufsize> <postdelay> : "
+               "<v1> ... <vN> : <action>\n");
+        return;
+    }
+
+    size_t      index = 1;
+    std::string name  = "";
+
+    // Get first comparison
+    Core::Serialization::ObjectMapComparison* c = parseComparison(tokens, index, obj_, name);
+    if ( c == nullptr ) {
+        printf("Invalid argument passed in comparison trigger command\n");
+        return;
+    }
+    auto* pt = new WatchPoint(name, c);
+
+    // Add additional comparisons and logical ops
+    while ( index < tokens.size() ) {
+
+        if ( tokens[index] == ":" ) { // end of trace vars
+            break;
+        }
+
+        // Get Logical Operator
+        WatchPoint::LogicOp logicOp = getLogicOpFromString(tokens[index++]);
+        if ( logicOp == WatchPoint::LogicOp::UNDEFINED ) {
+            printf("Invalid logic operator: %s", tokens[index - 1].c_str());
+        }
+        else {
+            pt->addLogicOp(logicOp);
+        }
+        if ( index == tokens.size() ) {
+            printf("Invalid format for trace command\n");
+            return;
+        }
+
+        // Get next comparison
+        Core::Serialization::ObjectMapComparison* c = parseComparison(tokens, index, obj_, name);
+        if ( c == nullptr ) {
+            printf("Invalid argument in comparison of trace command\n");
+            return;
+        }
+        pt->addComparison(c);
+
+    } // while index < tokens.size(), add another logic op and test comparision
+
+    try {
+        auto* tb = parseTraceBuffer(tokens, index, obj_);
+        if ( tb == nullptr ) {
+            printf("Invalid trace buffer argument in trace command\n");
+            return;
+        }
+        pt->addTraceBuffer(tb);
+
+        // Get trace vars and add associated objectBuffers
+        while ( index < tokens.size() ) {
+
+            std::string tvar = tokens[index++];
+            if ( tvar == ":" ) { // end of trace vars
+                break;
+            }
+
+            auto* objBuf = parseTraceVar(tvar, obj_, tb);
+            if ( objBuf == nullptr ) {
+                printf("Invalid trace variable argument passed to trace command\n");
+                return;
+            }
+            pt->addObjectBuffer(objBuf);
+        } // end while get trace vars
+
+        // Parse action
+        std::string action = tokens[index];
+
+        WatchPoint::WPAction* actionObj = parseAction(tokens, index, obj_);
+        if (actionObj == nullptr) {
+            printf("Error in action: %s\n", action.c_str());
+            return;
+        }
+        else {
+            pt->setAction(actionObj);
+        }
+
+        // Check for extra arguments
+        if ( index != tokens.size() ) {
+            printf("Error, too many arguments\n");
+            return;
+        }
+
+        // Get the top level component to set the watch point
+        BaseComponent* comp = static_cast<BaseComponent*>(base_comp_->getAddr());
+        if ( comp ) {
+            comp->addWatchPoint(pt);
+            watch_points_.emplace_back(pt, comp);
+        }
+        else
+            printf("Not a component\n");
+    }
+    catch ( std::exception& e ) {
+        printf("Invalid format for trace command\n");
+        return;
+    }
+};
+
+void
+ICDebugSST15::cmd_shutdown(std::vector<std::string>& tokens)
+{
+    simulationShutdown();
+    done = true;
+    printf("Exiting ObjectExplorer and shutting down simulation\n");
+    return;
+}
+
+#endif
+void
+ICDebugSST15::dispatch_cmd(std::string cmd)
+{
+    std::vector<std::string> tokens;
+    tokenize(tokens, cmd);
+
+    if (cmd.size() == 0) return;
+
+    if ( tokens[0] == "exit" || tokens[0] == "quit" ) {
+        printf("Exiting ObjectExplorer\n");
+        done = true;
+    }
+    else if ( tokens[0] == "pwd" ) {
+        //cmd_pwd(tokens)i;
+        printf("%s\n", tokens[0].c_str());
+    }
+    else if ( tokens[0] == "ls" ) {
+        //cmd_ls(tokens);
+        printf("%s\n", tokens[0].c_str());
+    }
+    else if ( tokens[0] == "cd" ) {
+        //cmd_cd(tokens);
+        printf("%s\n", tokens[0].c_str());
+    }
+    else if ( tokens[0] == "print" ) {
+        //cmd_print(tokens);
+        printf("%s\n", tokens[0].c_str());
+    }
+    else if ( tokens[0] == "set" ) {
+        //cmd_set(tokens);
+        printf("%s\n", tokens[0].c_str());
+    }
+    else if ( tokens[0] == "time" ) {
+        //cmd_time(tokens);
+        printf("%s\n", tokens[0].c_str());
+    }
+    else if ( tokens[0] == "run" ) {
+        //cmd_run(tokens);
+        printf("%s\n", tokens[0].c_str());
+    }
+    else if ( tokens[0] == "watchlist" ) {
+        //cmd_watchlist(tokens);
+        printf("%s\n", tokens[0].c_str());
+    }
+    else if ( tokens[0] == "watch" ) {
+        //cmd_watch(tokens);
+        printf("%s\n", tokens[0].c_str());
+    }
+    else if ( tokens[0] == "unwatch" ) {
+        //cmd_unwatch(tokens);
+        printf("%s\n", tokens[0].c_str());
+    }
+    else if ( tokens[0] == "shutdown" ) {
+        //cmd_shutdown(tokens);
+        printf("%s\n", tokens[0].c_str());
+    }
+    else if ( tokens[0] == "help" ) {
+        cmd_help(tokens);
+        //printf("%s\n", tokens[0].c_str());
+    }
+    else if ( tokens[0] == "trace" ) {
+        //cmd_trace(tokens);
+        printf("%s\n", tokens[0].c_str());
+    }
+    else if ( tokens[0] == "setHandler" ) {
+        //cmd_setHandler(tokens);
+         printf("%s\n", tokens[0].c_str());
+    }
+    else if ( tokens[0] == "addTraceVar" ) {
+        //cmd_addTraceVar(tokens);
+        printf("%s\n", tokens[0].c_str());
+    }
+    else if ( tokens[0] == "resetTraceBuffer" ) {
+        //cmd_resetTraceBuffer(tokens);
+        printf("%s\n", tokens[0].c_str());
+    }
+    else if ( tokens[0] == "printTrace" ) {
+        //cmd_printTrace(tokens);
+        printf("%s\n", tokens[0].c_str());
+    }
+    else if ( tokens[0] == "printWatchpoint" ) {
+        //cmd_printWatchpoint(tokens);
+        printf("%s\n", tokens[0].c_str());
+    }
+    else {
+        printf("Unknown command: %s\n", tokens[0].c_str());
+    }
+}
+
+} // namespace SST::ICDbgSST15

--- a/tests/core-debug-components/ICDbgSST15.h
+++ b/tests/core-debug-components/ICDbgSST15.h
@@ -1,0 +1,90 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef INTERACTIVE_CONSOLE_DEBUG_SST15_H
+#define INTERACTIVE_CONSOLE_DEBUG_SST15_H
+
+#include "SST.h"
+// #include "sst/core/eli/elementinfo.h"
+// #include <sst/core/watchPoint.h>
+// #include <sst/core/interactiveConsole.h>
+// #include "sst/core/serialization/objectMapDeferred.h"
+#include "probe.h"
+using namespace SSTDEBUG::Probe;
+
+namespace SST::ICDbgSST15 {
+
+class ICDebugSST15 : public SST::InteractiveConsole
+{
+
+public:
+    SST_ELI_REGISTER_INTERACTIVE_CONSOLE(
+      ICDebugSST15,   // class
+      "dbgsst15",     // library
+      "ICDebugSST15", // name
+      SST_ELI_ELEMENT_VERSION(1, 0, 0),
+      "{EXPERIMENTAL} Interactive console debug probe")
+
+    ICDebugSST15(Params& params);
+    ~ICDebugSST15() {}
+
+    void execute(const std::string& msg) override;
+
+private:
+    // This is the stack of where we are in the class hierarchy.  This
+    // is needed because when we advance time, we'll need to delete
+    // any ObjectMap because they could change during execution.
+    // After running, this will allow us to recreate the working
+    // directory as far as we can.
+    std::vector<std::string> name_stack;
+
+    SST::Core::Serialization::ObjectMap* obj_ = nullptr;
+    bool                                 done = false;
+
+    // Keep a pointer to the ObjectMap for the top level Component
+    SST::Core::Serialization::ObjectMapDeferred<BaseComponent>* base_comp_ = nullptr;
+
+    // Keep track of all the WatchPoints
+    std::vector<std::pair<WatchPoint*, BaseComponent*>> watch_points_;
+
+    std::vector<std::string> tokenize(std::vector<std::string>& tokens, const std::string& input);
+
+    void cmd_help(std::vector<std::string>& UNUSED(tokens));
+#if 0
+    void cmd_pwd(std::vector<std::string>& UNUSED(tokens));
+    void cmd_ls(std::vector<std::string>& UNUSED(tokens));
+    void cmd_cd(std::vector<std::string>& tokens);
+    void cmd_print(std::vector<std::string>& tokens);
+    void cmd_set(std::vector<std::string>& tokens);
+    void cmd_time(std::vector<std::string>& tokens);
+    void cmd_run(std::vector<std::string>& tokens);
+    void cmd_watch(std::vector<std::string>& tokens);
+    void cmd_unwatch(std::vector<std::string>& tokens);
+    void cmd_shutdown(std::vector<std::string>& tokens);
+#endif
+
+    void dispatch_cmd(std::string cmd);
+
+    // Trace functionality
+#if 0
+    void cmd_watchlist(std::vector<std::string>& tokens);
+    void cmd_trace(std::vector<std::string>& tokens);
+    void cmd_setHandler(std::vector<std::string>& tokens);
+    void cmd_addTraceVar(std::vector<std::string>& tokens);
+    void cmd_resetTraceBuffer(std::vector<std::string>& tokens);
+    void cmd_printTrace(std::vector<std::string>& tokens);
+    void cmd_printWatchpoint(std::vector<std::string>& tokens);
+#endif
+};
+
+} // namespace SST::ICDbgSST15
+
+#endif

--- a/tests/core-debug-components/SST.h
+++ b/tests/core-debug-components/SST.h
@@ -48,12 +48,12 @@
 #include <sst/core/rng/rng.h>
 #include <sst/core/rng/mersenne.h>
 #include <sst/core/serialization/serialize.h>
-#if 0 // Used for interactive console
+#if 1 // Used for interactive console
 #include <sst/core/baseComponent.h>
 #include <sst/core/stringize.h>
 #include <sst/core/interactiveConsole.h>
 #include <sst/core/serialization/objectMapDeferred.h>
-#include <sst/core/watchPoint.h>
+//#include <sst/core/watchPoint.h>
 #endif
 // clang-format on
 

--- a/tests/core-debug/cmd-ckptaction-DEV.sh
+++ b/tests/core-debug/cmd-ckptaction-DEV.sh
@@ -20,7 +20,7 @@ CHKFILE=$TNAME.chk
 CKPTPREFIX=ckpt_$TNAME
 
 # Launch the program to start interactive mode at time 0
-LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s --checkpoint-sim-period=5ms --checkpoint-prefix=$CKPTPREFIX $CONFIG"
+LAUNCH="sst --interactive-start=0s --checkpoint-enable --checkpoint-prefix=$CKPTPREFIX $CONFIG"
 echo $LAUNCH
 $LAUNCH << EOF | tee $LOGFILE || exit 1
 cd c0

--- a/tests/core-debug/cmd-ckptaction-err-DEV.sh
+++ b/tests/core-debug/cmd-ckptaction-err-DEV.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_PARAM DEV
+#EXT_TEST TEST_FILE_DESC "Check that trace checkpoint action triggers checkpoints"
+#EXT_TEST TIMEOUT 30
+#
+# SST DEV: 
+
+# Settings
+CLEANUP=1
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="test_Checkpoint_4ms.py"
+PSTR=""
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+CKPTPREFIX=ckpt_$TNAME
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-start=0s --checkpoint-prefix=$CKPTPREFIX $CONFIG"
+echo $LAUNCH
+$LAUNCH << EOF | tee $LOGFILE || exit 1
+cd c0
+cd xorshift
+trace w changed : 32 4 : w x y z : checkpoint
+shutdown
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $NAME returned $retVal"
+  exit $retVal
+fi
+
+PSTR="Invalid action: checkpointing not enabled"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# Simulation Complete
+PSTR="Simulation is complete"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+  rm -rf $CKPTPREFIX
+fi
+
+wait
+echo "PASS"
+exit $retVal

--- a/tests/core-debug/cmd-custom-ic-DEV.sh
+++ b/tests/core-debug/cmd-custom-ic-DEV.sh
@@ -36,6 +36,17 @@ if [ $retVal -ne 0 ]; then
   exit $retVal
 fi
 
+# Entering IC
+PSTR="Entering interactive mode"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+
 # Simulation Complete
 PSTR="Simulation is complete"
 grep "$PSTR" $LOGFILE > /dev/null

--- a/tests/core-debug/cmd-custom-ic-DEV.sh
+++ b/tests/core-debug/cmd-custom-ic-DEV.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_PARAM DEV
+#EXT_TEST TEST_FILE_DESC "Tests the use of --interactive-console with custom IC"
+#EXT_TEST TIMEOUT 30
+#
+# SST DEV: 
+
+# Settings
+CLEANUP=1
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="dbgsst15.py"
+PSTR="Simulation complete"
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-console=dbgsst15.ICDebugSST15 --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/tests/core-debug-components $CONFIG"
+echo $LAUNCH
+$LAUNCH << EOF | tee $LOGFILE || exit 1
+help
+quit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $NAME returned $retVal"
+  exit $retVal
+fi
+
+# Simulation Complete
+PSTR="Simulation is complete"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE
+fi
+
+wait
+echo "PASS"
+exit $retVal

--- a/tests/core-debug/cmd-default-ic-DEV.sh
+++ b/tests/core-debug/cmd-default-ic-DEV.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_PARAM DEV
+#EXT_TEST TEST_FILE_DESC "Tests the use of --interactive-console with custom IC"
+#EXT_TEST TIMEOUT 30
+#
+# SST DEV: 
+
+# Settings
+CLEANUP=1
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="dbgsst15.py"
+PSTR="Simulation complete"
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/tests/core-debug-components $CONFIG"
+echo $LAUNCH
+$LAUNCH << EOF | tee $LOGFILE || exit 1
+help
+quit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $NAME returned $retVal"
+  exit $retVal
+fi
+
+# Entering interactive
+PSTR="Entering interactive mode"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+
+# Simulation Complete
+PSTR="Simulation is complete"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE
+fi
+
+wait
+echo "PASS"
+exit $retVal

--- a/tests/rt_action/sigusr-interactive-DEV.sh
+++ b/tests/rt_action/sigusr-interactive-DEV.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_PARAM DEV
+#EXT_TEST TEST_FILE_DESC "Tests sigusr1/2 with interactive console real time action"
+#EXT_TEST TIMEOUT 90
+#
+# 0) Set up pipe
+# 1) launch the program in the background
+# 2) 'jobs -l' to get the PID
+# 3) 'kill -s SIGUSR<N> <PID>' to send the signal
+# 4) run command in interactive consols
+# 5) wait for completion
+# 6) compare to expected results (offline?)
+#set -m # enable job control
+
+# Settings
+SIG="sigusr1 sigusr2"
+ACTION="sst.rt.interactive"
+CLEANUP=0
+
+
+# 0) Set up the pipe
+pipe=/tmp/testpipe
+#mkfifo $pipe
+if [[ ! -p $pipe ]]; then
+  echo "Creating pipe: $pipe"
+  mkfifo $pipe
+fi
+
+for sig in $SIG; do
+  for action in $ACTION; do
+
+# 1) Launch the program in the background, running long enough to send signal
+if [[ -f test.$sig.$action.out ]]; then
+  rm test.$sig.$action.out
+fi
+
+LAUNCH="sst --interactive-console=sst.interactive.simpledebug --$sig=$action test_Checkpoint.py"
+echo $LAUNCH
+$LAUNCH < $pipe > test.$sig.$action.out &
+exec 3>$pipe    # Opens pipe for writing
+
+# 2) Get the PID
+JOBS=($(jobs -l))
+JSTR=${JOBS[0]}
+PID=${JOBS[1]}
+sleep 2
+
+# 3) Send signal 
+kill -s $sig $PID
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo ERROR with kill -s $sig $PID
+  exit $retVal
+fi
+
+# 4) Send run command in interactive console
+#fg $JID
+echo run 1us > $pipe
+echo run > $pipe
+
+# 5) Wait for completion
+wait
+retVal=$?
+exec 3>&- # close pipe
+echo $sig=$action Complete
+
+# 6) Check results
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $sig=$action return code"
+  rm $pipe
+  exit $retVal
+fi
+
+grep "Interactive Console real time action" ./test.$sig.$action.out;
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $sig=$action grep"
+  rm $pipe
+  exit $retVal
+fi
+echo
+
+# Cleanup output directories
+if [ $CLEANUP -eq 1 ]; then
+  rm test.$sig.$action.out
+fi
+
+done  # for $action
+done  # for $sigusr
+
+
+rm $pipe
+
+
+echo "PASS"
+exit $retVal
+
+
+
+
+
+
+

--- a/tests/rt_action/sigusr-interactive-ckpt-DEV.sh
+++ b/tests/rt_action/sigusr-interactive-ckpt-DEV.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_PARAM DEV
+#EXT_TEST TEST_FILE_DESC "Tests sigusr1/2 with default interactive console w/checkpoint"
+#EXT_TEST TIMEOUT 90
+#
+# 0) Set up PIPE
+# 1) launch the program in the background
+# 2) 'jobs -l' to get the PID
+# 3) 'kill -s SIGUSR<N> <PID>' to send the signal
+# 4) run command in interactive consols
+# 5) wait for completion
+# 6) compare to expected results (offline?)
+#set -m # enable job control
+
+# Settings
+CLEANUP=1
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="test_Checkpoint.py"
+PSTR=""
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+CKPTPREFIX=ckpt_$TNAME
+PIPE=/tmp/$TNAME.pipe
+
+SIG="sigusr1 sigusr2"
+ACTION="sst.rt.interactive"
+
+# 0) Set up the PIPE
+#mkfifo $PIPE
+if [[ ! -p $PIPE ]]; then
+  echo "Creating PIPE: $PIPE"
+  mkfifo $PIPE
+fi
+
+for sig in $SIG; do
+  for action in $ACTION; do
+
+  # 1) Launch the program in the background, running long enough to send signal
+  LOGFILE=$TNAME.$sig.$action.log
+  if [[ -f $LOGFILE ]]; then
+    rm $LOGFILE
+  fi
+
+  LAUNCH="sst --$sig=$action --checkpoint-enable --checkpoint-prefix=$CKPTPREFIX test_Checkpoint.py"
+  echo $LAUNCH
+  $LAUNCH < $PIPE > $LOGFILE &
+  exec 3>$PIPE    # Opens PIPE for writing
+
+  # 2) Get the PID
+  JOBS=($(jobs -l))
+  JSTR=${JOBS[0]}
+  PID=${JOBS[1]}
+  sleep 2
+
+  # 3) Send signal 
+  kill -s $sig $PID
+  retVal=$?
+  if [ $retVal -ne 0 ]; then
+    echo ERROR sending signal: kill -s $sig $PID
+    exit $retVal
+  fi
+
+  # 4) Send run command in interactive console
+  #fg $JID
+  echo cd c0 > $PIPE
+  echo cd xorshift > $PIPE
+  echo trace w changed : 32 4 : w x y z : checkpoint > $PIPE
+  echo setHandler 0 ae ac > $PIPE
+  echo printWatchpoint 0 > $PIPE
+  echo run 400us > $PIPE
+  echo shutdown > $PIPE
+
+  # 5) Wait for completion
+  wait
+  retVal=$?
+  exec 3>&- # close PIPE
+  wait
+  echo $TNAME $sig=$action Complete
+
+  # 6) Check results
+  if [ $retVal -ne 0 ]; then
+    echo "ERROR $sig=$action returned $retVal"
+    rm $PIPE
+    exit $retVal
+  fi
+
+  PSTR="Interactive Console real time action"
+  grep "$PSTR" $LOGFILE > /dev/null
+  retVal=$?
+  if [ $retVal -ne 0 ]; then
+    echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+    rm $PIPE
+    exit $retVal
+  fi
+  echo "Found pass string \"$PSTR\""
+
+  PSTR="Simulation Checkpoint"
+  grep "$PSTR" $LOGFILE > /dev/null
+  retVal=$?
+  if [ $retVal -ne 0 ]; then
+    echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+    rm $PIPE
+    exit $retVal
+  fi
+  echo "Found pass string \"$PSTR\""
+
+  PSTR="Simulation is complete"
+  grep "$PSTR" $LOGFILE > /dev/null
+  retVal=$?
+  if [ $retVal -ne 0 ]; then
+    echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+    rm $PIPE
+    exit $retVal
+  fi
+  echo "Found pass string \"$PSTR\""
+
+
+  echo
+
+  # Cleanup output directories
+  if [ $CLEANUP -eq 1 ]; then
+    rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+    rm -rf $CKPTPREFIX
+  fi
+
+  #rm $PIPE
+
+done  # for $action
+done  # for $sigusr
+
+rm $PIPE
+echo "PASS"
+exit $retVal

--- a/tests/rt_action/sigusr-interactive2-DEV.sh
+++ b/tests/rt_action/sigusr-interactive2-DEV.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_PARAM DEV
+#EXT_TEST TEST_FILE_DESC "Tests sigusr1/2 with default interactive console & real time action"
+#EXT_TEST TIMEOUT 90
+#
+# 0) Set up pipe
+# 1) launch the program in the background
+# 2) 'jobs -l' to get the PID
+# 3) 'kill -s SIGUSR<N> <PID>' to send the signal
+# 4) run command in interactive consols
+# 5) wait for completion
+# 6) compare to expected results (offline?)
+#set -m # enable job control
+
+# Settings
+SIG="sigusr1 sigusr2"
+ACTION="sst.rt.interactive"
+
+# 0) Set up the pipe
+pipe=/tmp/testpipe
+#mkfifo $pipe
+if [[ ! -p $pipe ]]; then
+  echo "Creating pipe: $pipe"
+  mkfifo $pipe
+fi
+
+for sig in $SIG; do
+  for action in $ACTION; do
+
+# 1) Launch the program in the background, running long enough to send signal
+if [[ -f test.$sig.$action.out ]]; then
+  rm test.$sig.$action.out
+fi
+
+LAUNCH="sst --$sig=$action test_Checkpoint.py"
+echo $LAUNCH
+$LAUNCH < $pipe > test.$sig.$action.out &
+exec 3>$pipe    # Opens pipe for writing
+
+# 2) Get the PID
+JOBS=($(jobs -l))
+JSTR=${JOBS[0]}
+PID=${JOBS[1]}
+sleep 2
+
+# 3) Send signal 
+kill -s $sig $PID
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo ERROR with kill -s $sig $PID
+  exit $retVal
+fi
+
+# 4) Send run command in interactive console
+#fg $JID
+echo run 1us > $pipe
+echo run > $pipe
+
+# 5) Wait for completion
+wait
+retVal=$?
+exec 3>&- # close pipe
+echo $sig=$action Complete
+
+# 6) Check results
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $sig=$action return code"
+  rm $pipe
+  exit $retVal
+fi
+
+grep "Interactive Console real time action" ./test.$sig.$action.out;
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $sig=$action grep"
+  rm $pipe
+  exit $retVal
+fi
+echo
+
+# Cleanup output directories
+rm test.$sig.$action.out
+#rm $pipe
+
+done  # for $action
+done  # for $sigusr
+
+
+rm $pipe
+
+
+echo "PASS"
+exit $retVal
+
+
+
+
+
+
+


### PR DESCRIPTION
Tests the new command line option functionality in cmd_line_opt branch of sst-core:
1) Interactive console now uses sst.interactive.simpledebug as the default. You only need to use --interactive-console if you want to specify a custom interactive console.
2) Added --checkpoint-enable flag to enable checkpointing for interactive console checkpoint action

Tests interactive console using both --interactive-start and --sigusr1/2=sst.rt.interactive, with and without the checkpoint action.