### PR TITLE
provisions for specifying NEW tests excluded from production qualification

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,19 @@ make test
 
 Flags for test selection include:
 ```
-# Enables golden test suite
-ENABLE_ALL_TESTS [OFF] 
+# Enables golden (production) test suite
+ENABLE_ALL_TESTS [OFF]
+
+# Enables NEW tests (non-production) and ALL production tests
+# For these the test header is: #EXT_TEST TEST_FILE_MINVER NEW
+ENABLE_NEW_TESTS [OFF]
+
+#  Note: The NEW tests will be added only when SST_VERSION is DEV.
+#  This can be achieved two ways:
+#  1. sst executable points to a `devel` branch
+#     `cmake .. -DENABLE_NEW_TESTS=ON`
+#  2. Use the SST_VERSION override option
+#     `cmake .. -DENABLE_NEW_TESTS=ON` -DSST_OVERRIDE=DEV
 
 # Individual suites by ENABLE_ALL_TESTS=ON
 ENABLE_CLI_TESTS [OFF]
@@ -36,12 +47,6 @@ ENABLE_MPI_TESTS [OFF]
 ENABLE_CORE_CHKPT_TESTS [OFF]
 
 ```
-
-To run fast test suite use:
-```
-ctest -LE LONG
-```
-
 
 ## Test Format
 
@@ -69,6 +74,10 @@ These are outlined as follows:
 If either the minimum or maximum version number is omitted then that constraint is not used in test selection.
 For example, to select all versions of SST starting at 13.1, set the minimum version to 13.1 and 
 omit the maximum version. To select only version 13.1, select both min and max to 13.1.
+
+Special cases
+- `#EXT_TEST TEST_FILE_MINVER NEW: These tests will be included only when using -DENABLE_NEW_TESTS=ON`
+- Unrecognized strings for TEST_FILE_MINVER results in automatic inclusions for all SST versions.
 
 Optional metadata elements include:
 - `#EXT_TEST DEP "COMP1 COMP2"`     : where within the quotes is a list of components

--- a/components/core-debug/dbgsst15.cc
+++ b/components/core-debug/dbgsst15.cc
@@ -131,6 +131,9 @@ void DbgSST15::init( unsigned int phase ){
   for (size_t i=0;i<v_bitset42.size(); i++) {
     v_bitset42[i] = (i & 3) == 3; // 1000 1000 1000 ... 1000 lsb
   }
+  // v_vecbool.resize(8);
+  // v_vecbool = { true, false, false, false, true, true, false, false };
+  std::cout << "# v_vecbool[0]=" << v_vecbool[0] << std::endl;
 }
 
 void DbgSST15::printStatus( SST::Output& out ){
@@ -170,6 +173,7 @@ void DbgSST15::serialize_order(SST::Core::Serialization::serializer& ser){
   SST_SER(v_double);
   SST_SER(v_ldouble);
   SST_SER(v_bitset42);
+  SST_SER(v_vecbool);
 
 #if TESTSER
   SST_SER(*test_uptr);

--- a/components/core-debug/dbgsst15.cc
+++ b/components/core-debug/dbgsst15.cc
@@ -128,6 +128,9 @@ void DbgSST15::finish(){
 }
 
 void DbgSST15::init( unsigned int phase ){
+  for (size_t i=0;i<v_bitset42.size(); i++) {
+    v_bitset42[i] = (i & 3) == 3; // 1000 1000 1000 ... 1000 lsb
+  }
 }
 
 void DbgSST15::printStatus( SST::Output& out ){
@@ -166,6 +169,7 @@ void DbgSST15::serialize_order(SST::Core::Serialization::serializer& ser){
   SST_SER(v_float);
   SST_SER(v_double);
   SST_SER(v_ldouble);
+  SST_SER(v_bitset42);
 
 #if TESTSER
   SST_SER(*test_uptr);

--- a/components/core-debug/dbgsst15.h
+++ b/components/core-debug/dbgsst15.h
@@ -258,8 +258,9 @@ private:
   float v_float = 1.0;
   double v_double = 2.0;
   long double v_ldouble = 3.0L;
+  // bitset and vector<bool>, sst-simulator/sst-core PR#1483
   std::bitset<42> v_bitset42; // default 0
-
+  std::vector<bool> v_vecbool = { true, true, true, true, true, true, true, true};
 
 #if PROBE
 // -- Component probe state object

--- a/components/core-debug/dbgsst15.h
+++ b/components/core-debug/dbgsst15.h
@@ -258,6 +258,7 @@ private:
   float v_float = 1.0;
   double v_double = 2.0;
   long double v_ldouble = 3.0L;
+  std::bitset<42> v_bitset42; // default 0
 
 
 #if PROBE

--- a/scripts/gen-testlist.sh
+++ b/scripts/gen-testlist.sh
@@ -11,22 +11,23 @@
 #
 
 # Check for arguments
-if [ $# -eq 0 ]; then
+if [ $# -ne 2 ]; then
     echo "Error: No arguments provided"
-    echo "Usage: $0 <sst-version-number>"
+    echo "Usage: $0 <sst-version-number> <enable-new-tests[OFF|ON]>"
     exit 1
 fi
 
 testlist=""
 for f in *.sh; do
-  awk -v sstver=$1 -v dbg=0 '
+  awk -v sstver=$1 -v ennew=$2 -v dbg=0 '
     BEGIN { min=0.0; max=9999.0}
     /EXT_TEST TEST_FILE_MINVER/ {min=$3}
     /EXT_TEST TEST_FILE_MAXVER/ {max=$3}
     END { \
       rangeOK = sstver>=min && sstver<=max; \
       devOK = sstver=="DEV" && max>=999.0; \
-      rc = rangeOK || devOK ? 0 : 1; \
+      excluded = ennew=="OFF" && min=="NEW";  \
+      rc = ((rangeOK || devOK) && (!excluded)) ? 0 : 1; \
       if (dbg==1) {printf("sstver=%2.1f\tmin=%2.1f\tmax=%2.1f\trc=%d\n", sstver, min, max, rc)}; \
       exit(rc)}' $f
   if [ $? -eq 0 ]; then

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,8 @@
 #
 
 # -- make test options visible to ccmake
-option(ENABLE_ALL_TESTS "Enable ALL testing" OFF)
+option(ENABLE_NEW_TESTS "Enable NEW tests for sst-core feature branches" OFF)
+option(ENABLE_ALL_TESTS "Enable ALL production tests" OFF)
 option(ENABLE_CLI_TESTS "Enable CLI testing" OFF)
 
 option(ENABLE_DEBUG_TESTS "Interactive debug mode tests")
@@ -17,6 +18,10 @@ option(ENABLE_CAPTCRUNCH_TESTS "Enable Captain Crunch testing" OFF)
 # -- purely optional tests
 option(ENABLE_CORE_CHKPT_TESTS "Purely optional: Enable sst-core checkpointing tests" OFF)
 option(ENABLE_MPI_TESTS "Purely optional: Enable multi-rank MPI testing" OFF)
+
+if (ENABLE_NEW_TESTS)
+  set(ENABLE_ALL_TESTS ON CACHE BOOL "Enable ALL production tests" FORCE)
+endif()
 
 if (ENABLE_ALL_TESTS)
   set(ENABLE_CLI_TESTS ON CACHE BOOL "Enable CLI testing" FORCE)

--- a/tests/CaptCrunch/CMakeLists.txt
+++ b/tests/CaptCrunch/CMakeLists.txt
@@ -13,7 +13,7 @@ set(passRegex "PASS")
 set(timeout "60")
 
 #-- Test files supporting current sst version
-execute_process(COMMAND ${EXT_TEST_LIST_COMMAND} ${SST_VERSION}
+execute_process(COMMAND ${EXT_TEST_LIST_COMMAND} ${SST_VERSION} ${ENABLE_NEW_TESTS}
                 OUTPUT_VARIABLE TEST_SRCS_TARGET_VER
                 RESULT_VARIABLE EXT_TEST_LIST_RTN
                 OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/tests/cli/CMakeLists.txt
+++ b/tests/cli/CMakeLists.txt
@@ -14,7 +14,7 @@ set(timeout "60")
 
 #-- Test files supporting current sst version
 message(STATUS "Checking ${CMAKE_CURRENT_SOURCE_DIR} for tests supporting ${SST_VERSION}")
-execute_process(COMMAND ${EXT_TEST_LIST_COMMAND} ${SST_VERSION}
+execute_process(COMMAND ${EXT_TEST_LIST_COMMAND} ${SST_VERSION} ${ENABLE_NEW_TESTS}
                 OUTPUT_VARIABLE TEST_SRCS_TARGET_VER
                 RESULT_VARIABLE EXT_TEST_LIST_RTN
                 OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/tests/core-debug/CMakeLists.txt
+++ b/tests/core-debug/CMakeLists.txt
@@ -13,7 +13,7 @@ set(passRegex "PASS")
 set(timeout "60")
 
 #-- Test files supporting current sst version
-execute_process(COMMAND ${EXT_TEST_LIST_COMMAND} ${SST_VERSION}
+execute_process(COMMAND ${EXT_TEST_LIST_COMMAND} ${SST_VERSION} ${ENABLE_NEW_TESTS}
                 OUTPUT_VARIABLE TEST_SRCS_TARGET_VER
                 RESULT_VARIABLE EXT_TEST_LIST_RTN
                 OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/tests/core-debug/cmd-help.sh
+++ b/tests/core-debug/cmd-help.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "Walk through help commands"
+#EXT_TEST TIMEOUT 30
+
+# Settings
+CLEANUP=1
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="dbgsst15.py"
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-start=0s $CONFIG"
+echo $LAUNCH
+$LAUNCH << EOF | tee $LOGFILE || exit
+help
+?
+help fubar
+help addtracevar
+help editing
+help history
+help print
+help printtrace
+help printwatchpoint
+help resettrace 
+help run
+help set
+help sethandler
+help trace
+help unwatch
+help verbose
+help watch
+help watchlist
+help watchpoints
+shutdown
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $NAME returned $retVal"
+  exit $retVal
+fi
+
+# Spot check
+PSTR='history \[N\]: list previous N instructions'
+grep -q "$PSTR" $LOGFILE
+if [ $? -ne 0 ]; then
+    echo "Error: String not found: $PSTR"
+    exit 1
+fi
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/core-debug/type-bitset.sh
+++ b/tests/core-debug/type-bitset.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER NEW
-#EXT_TEST TEST_FILE_DESC "Exercise std::bitset"
+#EXT_TEST TEST_FILE_DESC "Exercise std::bitset and std::vector<bool>"
 #EXT_TEST TIMEOUT 30
 
 # Settings
@@ -25,12 +25,33 @@ p 3
 p 38
 p 39
 set 39 0
+run 1ns
 p 39
+cd ..
+# std::vector<bool> v_vecbool = { true, true, true, true, true, true, true, true};
+p v_vecbool
+cd v_vecbool
+ls
+# set bit 7 to 0
+set 7 0
+run 1ns
+ls
+# set bit 5 to 1
+set 5 1
+run 1ns
+ls
+# change bit 5 back to 0
+set 5 0
+run 1ns
+ls
+# invalid value - segfault #TODO test passes if interactive debugger segfaults!!!!
+set 2 7
 EOF
 
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-start=0s $CONFIG -- --verbose=0"
 echo $LAUNCH
+# TODO are we checking the tee return code instead of sst?
 $LAUNCH << EOF | tee $LOGFILE || exit 1
 replay $CMDFILE
 confirm false

--- a/tests/core-debug/type-bitset.sh
+++ b/tests/core-debug/type-bitset.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "Exercise std::bitset"
+#EXT_TEST TIMEOUT 30
+
+# Settings
+CLEANUP=1
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="dbgsst15.py"
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+
+cat << EOF > $CMDFILE
+cd cp0
+ls
+cd v_bitset42/
+ls
+p 0
+p 3
+p 38
+p 39
+set 39 0
+p 39
+EOF
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-start=0s $CONFIG -- --verbose=0"
+echo $LAUNCH
+$LAUNCH << EOF | tee $LOGFILE || exit 1
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $NAME returned $retVal"
+  exit $retVal
+fi
+
+# spot check
+# egrep -Pzq "> p 39\s*39 = 1 \(bool\)\N*> set 39 0\N*> p 39\N*39 = 0 \(bool\)" $LOGFILE
+grep -q '39 = 1' $LOGFILE
+rc0=$?
+grep -q '39 = 0' $LOGFILE
+rc1=$?
+
+if [ $rc0 -ne 0 ]; then
+  echo "Could not find pass string: 39 = 1"
+  exit 1
+fi
+
+if [ $rc1 -ne 0 ]; then
+  echo "Could not find pass string: 39 = 0"
+  exit 1
+fi
+
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+fi
+
+wait
+echo "PASS"
+exit $retVal

--- a/tests/rt_action/CMakeLists.txt
+++ b/tests/rt_action/CMakeLists.txt
@@ -13,7 +13,7 @@ set(passRegex "PASS")
 set(timeout "60")
 
 #-- Test files supporting current sst version
-execute_process(COMMAND ${EXT_TEST_LIST_COMMAND} ${SST_VERSION}
+execute_process(COMMAND ${EXT_TEST_LIST_COMMAND} ${SST_VERSION} ${ENABLE_NEW_TESTS}
                 OUTPUT_VARIABLE TEST_SRCS_TARGET_VER
                 RESULT_VARIABLE EXT_TEST_LIST_RTN
                 OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
This allows us to commit tests that support local/feature branches of sst-core that do not impact the Jenkins production runs qualification the sst-core branch.  We have the option to stage tests in the `devel` branch using the following in the test header:

`#EXT_TEST TEST_FILE_MINVER NEW`

These tests will be included only when using `cmake -DENABLE_NEW_TESTS=ON ..`

When the sst-core feature branch has been merged we can change the header for these tests to 'DEV' or the set-version and they will be included in the production testing.

@jleidel There should be no change to Jenkins runs... just `cmake -DENABLE_ALL_TESTS=ON` as before. For the `iconsole` feature branch runs, I will use `-DENABLE_NEW_TESTS=ON`

@ct-clmsn For your upcoming PR you can use `#EXT_TEST TEST_FILE_MINVER NEW` in your test header.  I'll merge these PR after yours and verify the system is working on Jenkins.

Hopefully everyone can work with this. We're still keeping the version information only in the test metadata.  You can use this method or maintain your own local branch if you prefer.



