### PR TITLE
Bitset test and embedded regexp concept

### DIFF
--- a/components/core-debug/dbgsst15.cc
+++ b/components/core-debug/dbgsst15.cc
@@ -279,6 +279,12 @@ void DbgSST15::sendData(){
   }
 }
 
+void DbgSST15::tickleBits()
+{
+  v_bitset42.flip();
+  v_vecbool.flip();
+}
+
 bool DbgSST15::clockTick( SST::Cycle_t currentCycle ){
 
   if (currentCycle==1 && sleep>0 ) {
@@ -292,6 +298,7 @@ bool DbgSST15::clockTick( SST::Cycle_t currentCycle ){
   if( curCycle >= clockDelay ){
     sendData();
     curCycle = 0;
+    tickleBits();
   }
 
   // check to see if we've reached the completion state

--- a/components/core-debug/dbgsst15.h
+++ b/components/core-debug/dbgsst15.h
@@ -260,7 +260,7 @@ private:
   long double v_ldouble = 3.0L;
   // bitset and vector<bool>, sst-simulator/sst-core PR#1483
   std::bitset<42> v_bitset42; // default 0
-  std::vector<bool> v_vecbool = { true, true, true, true, true, true, true, true};
+  std::vector<bool> v_vecbool = { true, false, true, true, false, false, true, true};
 
 #if PROBE
 // -- Component probe state object
@@ -302,6 +302,9 @@ void handleEvent(SST::Event *ev);
 
 /// sends data to adjacent links
 void sendData();
+
+/// watchpoint faciliation
+void tickleBits();
 
 };  // class DbgSST15
 #if PROBE

--- a/tests/core-debug/type-bitset.sh
+++ b/tests/core-debug/type-bitset.sh
@@ -16,43 +16,75 @@ CMDFILE=$TNAME.cmd
 CHKFILE=$TNAME.chk
 
 cat << EOF > $CMDFILE
+confirm false
 cd cp0
 ls
 cd v_bitset42/
 ls
+# CHECK 0 p 0\n0 = 0 \(bool\)
 p 0
+# CHECK 1 p 3\n3 = 1 \(bool\)
 p 3
+# CHECK 2 p 38\n38 = 0 \(bool\)
 p 38
+# CHECK 3 p 39\n39 = 1 \(bool\)
 p 39
+# Flip bits 38 and 39
+set 38 1
 set 39 0
 run 1ns
+# CHECK 4 p 38\n38 = 1 \(bool\)
+p 38
+# CHECK 5 p 39\n39 = 0 \(bool\)
 p 39
 cd ..
-# std::vector<bool> v_vecbool = { true, true, true, true, true, true, true, true};
+# std::vector<bool> v_vecbool  =  { true, false, true, true, false, false, true, true};
 p v_vecbool
 cd v_vecbool
 ls
-# set bit 7 to 0
-set 7 0
-run 1ns
-ls
-# set bit 5 to 1
+# CHECK 6 p 5\n5 = 0 \(bool\)
+p 5
+# CHECK 7 p 6\n6 = 1 \(bool\)
+p 6
+# flip 5 and 6
 set 5 1
+set 6 0
 run 1ns
 ls
-# change bit 5 back to 0
-set 5 0
-run 1ns
+# CHECK 8 p 5\n5 = 1 \(bool\)
+p 5
+# CHECK 9 p 6\n6 = 0 \(bool\)
+p 6
+
+# Invalid setting
+set 5 0x10
+# CHECK 10 p 5\n5 = 1 \(bool\)
+p 5
+
+# Watch a vector bool bit
+watch 7 changed
+# CHECK 11 run\nEntering interactive mode
+run
 ls
-# invalid value - segfault #TODO test passes if interactive debugger segfaults!!!!
-set 2 7
+
+# clear all watches
+unwatch
+
+# back up to bitset and do the same
+cd ..
+cd v_bitset42/
+watch 41 changed
+# CHECK 12 run\nEntering interactive mode
+run
+ls
+
 EOF
 
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-start=0s $CONFIG -- --verbose=0"
 echo $LAUNCH
-# TODO are we checking the tee return code instead of sst?
-$LAUNCH << EOF | tee $LOGFILE || exit 1
+revVal=0
+( $LAUNCH << EOF || exit 99 ) | tee $LOGFILE
 replay $CMDFILE
 confirm false
 exit
@@ -68,23 +100,32 @@ if [ $retVal -ne 0 ]; then
   exit $retVal
 fi
 
-# spot check
-# egrep -Pzq "> p 39\s*39 = 1 \(bool\)\N*> set 39 0\N*> p 39\N*39 = 0 \(bool\)" $LOGFILE
-grep -q '39 = 1' $LOGFILE
-rc0=$?
-grep -q '39 = 0' $LOGFILE
-rc1=$?
+# spot checks
+# initialize rc to the number of expected checks
+awk '
+  BEGIN {idx=0; rc=13; lines=""; check=-1 }
+  /# CHECK/ { idx=0; lines=""; check=$4; re=substr($0,index($0,$5))}
+  { if (check==-1) {next}; 
+    lines = sprintf("%s\n%s",lines,$0);
+    if (++idx==3) {
+      print check; 
+      printf("TEST[%d] %s\n",check,lines);
+      # printf("RE[%d] %s\n", check, re);
+      if (!match(lines,re)) {
+        printf("ERROR: Failed TEST[%d]\n",check);
+        exit 1;
+      }
+      rc--; check=-1; idx=0;
+    }
+  }
+  END { exit rc; }
+' $LOGFILE
 
-if [ $rc0 -ne 0 ]; then
-  echo "Could not find pass string: 39 = 1"
-  exit 1
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
 fi
-
-if [ $rc1 -ne 0 ]; then
-  echo "Could not find pass string: 39 = 0"
-  exit 1
-fi
-
 
 # Cleanup output file on pass
 if [ $CLEANUP -eq 1 ]; then
@@ -93,4 +134,4 @@ fi
 
 wait
 echo "PASS"
-exit $retVal
+exit 0


### PR DESCRIPTION
Adding a test for an upcoming PR from Lee to support mapping of `std::bitset` and `std::vector<bool>` .

What's more interesting is I'm experimenting with using comments in the debugger instruction stream to define a checking mechanism in the stream itself.  A 'check number' and a regular expression that defines that next 2 lines output from the debugger in in the comment.  The test is run and then an awk script scans the file for the comments and extracts the regular expression. To keep it simple I just capture and check the next 2 lines of output but this could be generalized.

Just wanted to share this in case others want to expand on it or improve it.

