### PR TITLE
misc test updates

### DIFF
--- a/tests/core-debug/cmd-basic.sh
+++ b/tests/core-debug/cmd-basic.sh
@@ -21,7 +21,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF | tee $LOGFILE || exit 1
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
 pwd
 ls
 cd cp0

--- a/tests/core-debug/cmd-ckptaction-err.sh
+++ b/tests/core-debug/cmd-ckptaction-err.sh
@@ -22,7 +22,7 @@ CKPTPREFIX=ckpt_$TNAME
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-start=0s --checkpoint-prefix=$CKPTPREFIX $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF | tee $LOGFILE || exit 1
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
 cd c0
 cd xorshift
 trace w changed : 32 4 : w x y z : checkpoint

--- a/tests/core-debug/cmd-ckptaction.sh
+++ b/tests/core-debug/cmd-ckptaction.sh
@@ -22,7 +22,7 @@ CKPTPREFIX=ckpt_$TNAME
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-start=0s --checkpoint-enable --checkpoint-prefix=$CKPTPREFIX $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF | tee $LOGFILE || exit 1
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
 cd c0
 cd xorshift
 trace w changed : 32 4 : w x y z : checkpoint

--- a/tests/core-debug/cmd-cmp-types-false.sh
+++ b/tests/core-debug/cmd-cmp-types-false.sh
@@ -21,7 +21,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF | tee $LOGFILE || exit 1
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
 cd cp0
 # bool
 watch v_bool != 1

--- a/tests/core-debug/cmd-cmp-types-true.sh
+++ b/tests/core-debug/cmd-cmp-types-true.sh
@@ -21,7 +21,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF | tee $LOGFILE || exit 1
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
 cd cp0
 # bool
 watch v_bool == 1

--- a/tests/core-debug/cmd-comments-ws.sh
+++ b/tests/core-debug/cmd-comments-ws.sh
@@ -39,7 +39,7 @@ EOF
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --replay-file=$CMDFILE --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF | tee $LOGFILE || exit 1
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
 quit
 EOF
 

--- a/tests/core-debug/cmd-cond.sh
+++ b/tests/core-debug/cmd-cond.sh
@@ -21,7 +21,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF | tee $LOGFILE || exit 1
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
 ls
 cd c7
 watch duty_cycle_count == 1

--- a/tests/core-debug/cmd-custom-ic.sh
+++ b/tests/core-debug/cmd-custom-ic.sh
@@ -21,7 +21,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=dbgsst15.ICDebugSST15 --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF | tee $LOGFILE || exit 1
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
 help
 quit
 EOF

--- a/tests/core-debug/cmd-default-ic.sh
+++ b/tests/core-debug/cmd-default-ic.sh
@@ -21,7 +21,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF | tee $LOGFILE || exit 1
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
 help
 quit
 EOF

--- a/tests/core-debug/cmd-handler.sh
+++ b/tests/core-debug/cmd-handler.sh
@@ -21,7 +21,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-$LAUNCH 2>&1 << EOF | tee $LOGFILE || exit 1
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE 
 cd cp0
 run 2us
 trace size changed : 16 14 : size : interactive

--- a/tests/core-debug/cmd-help.sh
+++ b/tests/core-debug/cmd-help.sh
@@ -16,9 +16,9 @@ CMDFILE=$TNAME.cmd
 CHKFILE=$TNAME.chk
 
 # Launch the program to start interactive mode at time 0
-LAUNCH="sst --interactive-start=0s $CONFIG"
+LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF | tee $LOGFILE || exit
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
 help
 ?
 help fubar

--- a/tests/core-debug/cmd-history.sh
+++ b/tests/core-debug/cmd-history.sh
@@ -21,7 +21,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF | tee $LOGFILE || exit
+( $LAUNCH << EOF || exit 11 ) |  tee $LOGFILE
 logging $OUTFILE
 ls
 cd c7

--- a/tests/core-debug/cmd-replay-sync.sh
+++ b/tests/core-debug/cmd-replay-sync.sh
@@ -32,7 +32,7 @@ EOF
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --replay-file=$CMDFILE --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-$LAUNCH | tee $LOGFILE || exit 1
+( $LAUNCH || exit 11 ) | tee $LOGFILE
 retVal=$?
 
 echo $TNAME Complete

--- a/tests/core-debug/cmd-replay.sh
+++ b/tests/core-debug/cmd-replay.sh
@@ -30,7 +30,7 @@ EOF
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF | tee $LOGFILE || exit 1
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
 replay $CMDFILE
 EOF
 

--- a/tests/core-debug/cmd-replay2.sh
+++ b/tests/core-debug/cmd-replay2.sh
@@ -30,7 +30,7 @@ EOF
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --replay-file=$CMDFILE --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF | tee $LOGFILE || exit 1
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
 quit
 EOF
 

--- a/tests/core-debug/cmd-replay3.sh
+++ b/tests/core-debug/cmd-replay3.sh
@@ -27,7 +27,7 @@ EOF
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF | tee $LOGFILE || exit 1
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
 replay $CMDFILE
 set test_string HelloMyNameIsC7AndICannotQuoteAString
 print test_string

--- a/tests/core-debug/cmd-sanity.sh
+++ b/tests/core-debug/cmd-sanity.sh
@@ -15,7 +15,7 @@ LOGFILE=$TNAME.out
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s  $CONFIG"
 echo $LAUNCH
-$LAUNCH <<EOF | tee $LOGFILE || exit 1
+( $LAUNCH <<EOF || exit 11 ) | tee $LOGFILE
 ls
 cd c7
 ls

--- a/tests/core-debug/cmd-set.sh
+++ b/tests/core-debug/cmd-set.sh
@@ -21,7 +21,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF | tee $LOGFILE || exit 1
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
 cd cp0
 ls
 set v_bool false

--- a/tests/core-debug/cmd-setstr.sh
+++ b/tests/core-debug/cmd-setstr.sh
@@ -21,7 +21,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF | tee $LOGFILE || exit 1
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
 cd c0
 ls
 set test_string my big beautiful string

--- a/tests/core-debug/cmd-trace.sh
+++ b/tests/core-debug/cmd-trace.sh
@@ -21,7 +21,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF | tee $LOGFILE || exit 1
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
 cd cp0
 trace size > 50 : 32 4 : size : interactive
 printWatchpoint 0

--- a/tests/core-debug/cmd-unwatch.sh
+++ b/tests/core-debug/cmd-unwatch.sh
@@ -21,7 +21,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF | tee $LOGFILE || exit 1
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
 cd cp0
 watch maxData > 10
 watch maxData > 100

--- a/tests/core-debug/cmd-watch.sh
+++ b/tests/core-debug/cmd-watch.sh
@@ -21,7 +21,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF | tee $LOGFILE || exit 1
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
 cd cp0
 watch size > 0
 printWatchpoint 0

--- a/tests/core-debug/testinfo.sh
+++ b/tests/core-debug/testinfo.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_DESC "Provide information on local tests"
-../../bin/sst-ext-tests -d . | tee TEST.INFO
-echo PASS | tee TEST.INFO
+../../bin/sst-ext-tests -d . || exit 11 | tee TEST.INFO
+echo PASS

--- a/tests/core-debug/type-bitset.sh
+++ b/tests/core-debug/type-bitset.sh
@@ -84,7 +84,7 @@ EOF
 LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
 echo $LAUNCH
 revVal=0
-( $LAUNCH << EOF || exit 99 ) | tee $LOGFILE
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
 replay $CMDFILE
 confirm false
 exit

--- a/tests/rt_action/restart-ckpt-with-interactive.sh
+++ b/tests/rt_action/restart-ckpt-with-interactive.sh
@@ -20,40 +20,25 @@ CLEANUP=1
 
 #0 Get pass criterion and setup pipe for interactive 
 PSTR="Interactive"
-pipe="/tmp/test_restart_ckpt_pipe"
-if [[ ! -p $pipe ]]; then
-  echo "Creating pipe: $pipe"
-  mkfifo $pipe
-fi
 
 # 1) Launch the program to generate the checkpoint
 OUTFILE="test.ckpt.interactive.out"
-LAUNCH="sst --checkpoint-prefix=$PREFIX --checkpoint-sim-period=1s --interactive-console=sst.interactive.simpledebug --interactive-start=2s  $CONFIG"
+VERBOSE="--verbose=0"
+LAUNCH="sst --checkpoint-prefix=$PREFIX --checkpoint-sim-period=1s --interactive-console=sst.interactive.simpledebug --interactive-start=2s $VERBOSE $CONFIG"
 
 echo $LAUNCH
-$LAUNCH <$pipe > $OUTFILE 2>&1 &
-exec 3>$pipe
-
-sleep 2
-echo run > $pipe
-
+( $LAUNCH << EOF || exit 11 ) | grep -v talking | tee $OUTFILE
+run
+EOF
 wait
-retVal=$?
 
 echo ckpt.interactive Complete
 
 # 2) Check result
-if [ $retVal -ne 0 ]; then
-  echo "ERROR ckpt.interactive return code"
-  rm $pipe
-  exit $retVal
-fi
-
-grep "$PSTR" ./$OUTFILE > /dev/null
+grep -q "$PSTR" ./$OUTFILE
 retVal=$?
 if [ $retVal -ne 0 ]; then
-  echo "ERROR ckpt.interactive grep"
-  rm $pipe
+  echo "ERROR ckpt.interactive grep missing string: $PSTR"
   exit $retVal
 fi
 
@@ -62,37 +47,20 @@ if [ $CLEANUP -eq 1 ]; then
   rm $OUTFILE
 fi
 
-
 # 3) Launch the checkpoint restart
 OUTFILE="test.restart.ckpt.interactive.out"
-LAUNCH="sst --load-checkpoint $CKPT_DIR"
+LAUNCH="sst --load-checkpoint $VERBOSE $CKPT_DIR"
 echo $LAUNCH
-$LAUNCH  > $OUTFILE 2>&1
-
-#$LAUNCH <$pipe  > $OUTFILE 2>&1 &
-#exec 3>$pipe
-#sleep 2
-#echo run > $pipe
-
+( $LAUNCH || exit 12 ) | grep -v talking | tee $OUTFILE
 wait
-retVal=$?
-
 echo restart.ckpt.interactive Complete
-
 # 4) Check result
-if [ $retVal -ne 0 ]; then
-  echo "ERROR restart.ckpt.interactive return code"
-  rm $pipe
-  exit $retVal
-fi
-
 # In this example, interactive will not be triggered on restart
 # because it is set for 2s AFTER start and it only runs from 1-2s
-grep "$PSTR" ./$OUTFILE > /dev/null
+grep -q "$PSTR" ./$OUTFILE
 retVal=$?
 if [ $retVal -eq 0 ]; then
-  echo "ERROR restart.ckpt.interactive grep"
-  rm $pipe
+  echo "ERROR restart.ckpt.interactive grep unexpected string: $PSTR"
   exit $retVal
 fi
 
@@ -102,14 +70,7 @@ echo
 if [ $CLEANUP -eq 1 ]; then
   rm $OUTFILE
   rm -rf $PREFIX*
-  rm $pipe
 fi
 
 echo "PASS"
-exit $retVal
-
-
-
-
-
-
+exit 0

--- a/tests/rt_action/restart-interactive.sh
+++ b/tests/rt_action/restart-interactive.sh
@@ -10,31 +10,27 @@
 
 
 # Settings
-CONFIG=" test_Checkpoint.py" #test_MessageMesh.py"
+CONFIG=" test_Checkpoint.py"
 PREFIX="ckpt4restart_interactive"
 CKPTDIR="ckpt4restart_interactive/ckpt4restart_interactive_1_1000000000000/ckpt4restart_interactive_1_1000000000000.sstcpt"
 CLEANUP=1
 
+# remove stale checkpoint directory
+rm -rf $PREFIX
 
 # 0) Launch the program to generate the checkpoints
 OUTFILE="test.ckpt4restart.interactive.out"
 LAUNCH="sst --checkpoint-prefix=$PREFIX --checkpoint-sim-period=1s $CONFIG"
 echo $LAUNCH
-eval $LAUNCH > $OUTFILE 2>&1
-retVal=$?
+( $LAUNCH || exit 11 ) | grep -v talking | tee $OUTFILE
 echo $PREFIX Done
 
 # 1) Check result
 PSTR="Checkpoint"
-if [ $retVal -ne 0 ]; then
-  echo "ERROR $PREFIX return code"
-  exit $retVal
-fi
-
-grep "$PSTR" ./$OUTFILE > /dev/null
+grep -q "$PSTR" ./$OUTFILE
 retVal=$?
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $PREFIX grep"
+  echo "ERROR $PREFIX grep missing string: $PSTR"
   exit $retVal
 fi
 
@@ -44,62 +40,38 @@ if [ $CLEANUP -eq 1 ]; then
 fi
 
 # 1) Get pass criterion and outputfile
-#echo heartbeat
-PSTR="Interactive"
 OUTFILE="test.restart.interactive.out"
 
-# 2) Set up pipe for interactive
-pipe="/tmp/test_restart_pipe"
-if [[ ! -p $pipe ]]; then
-  echo "Creating pipe: $pipe"
-  mkfifo $pipe
-fi
-
-# 3) Then restart sst with the checkpoint and heartbeat
+# 2) Then restart sst with the checkpoint and heartbeat
 if [[ -f $OUTFILE ]]; then
   rm $OUTFILE
 fi
 
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=1us --load-checkpoint $CKPTDIR"
 echo $LAUNCH
-$LAUNCH < $pipe > $OUTFILE 2>&1 &
-exec 3>$pipe
-
-sleep 2
-echo run > $pipe
+( $LAUNCH << EOF || exit 12 ) | grep -v talking | tee $OUTFILE
+run
+EOF
 
 wait
-retVal=$?
 echo restart.interactive Complete
 
 # 4) Check result
+PSTR="Interactive"
+grep -q "$PSTR" ./$OUTFILE
+retVal=$?
 if [ $retVal -ne 0 ]; then
-  echo "ERROR restart.interactive return code"
-  rm $pipe
+  echo "ERROR restart.interactive grep missing string: $PSTR"
   exit $retVal
 fi
 
-grep "$PSTR" ./$OUTFILE > /dev/null
-retVal=$?
-if [ $retVal -ne 0 ]; then
-  echo "ERROR restart.interactive grep"
-  rm $pipe
-  exit $retVal
-fi
 echo
 
 # Cleanup output directories
 if [ $CLEANUP -eq 1 ]; then
-  rm $OUTFILE
-  rm -r $PREFIX
-  rm $pipe
+  rm -f $OUTFILE
+  rm -rf $PREFIX
 fi
 
 echo "PASS"
-exit $retVal
-
-
-
-
-
-
+exit 0


### PR DESCRIPTION
Updating various test to avoid false passes and resource pitfalls. 
Mostly changed tests in core-debug. In rt_action, I changed 2 tests to remove the unneeded pipe 'restart-interactive.sh` and `restart-ckpt-with-interactive.sh`

@skuntz 
Jenkins pipeline appears to be passing all tests for me (so far) but these tests seem to be flaky on my local (Mac) machine.

	 37 - restart-ckpt-with-heartbeat (Failed)              DEV
	 39 - restart-ckpt-with-sigalrm (Failed)                DEV
	 40 - restart-heartbeat (Failed)                        DEV
         43 = sigusr-interactive-ckpt (Failed)                DEV
