### PR TITLE
Add bash restrictions for safer tests

### DIFF
--- a/tests/core-debug/cmd-actions.sh
+++ b/tests/core-debug/cmd-actions.sh
@@ -2,8 +2,13 @@
 #EXT_TEST TEST_FILE_MINVER 15.1
 #EXT_TEST TEST_FILE_DESC "Check for interactive, printTrace, printStatus, and set actions"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -21,7 +26,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-$LAUNCH 2>&1 << EOF | tee $LOGFILE || exit 1
+$LAUNCH 2>&1 << EOF | tee $LOGFILE
 cd cp0
 ls
 trace maxData > 10 : 8 0 : maxData : interactive

--- a/tests/core-debug/cmd-basic.sh
+++ b/tests/core-debug/cmd-basic.sh
@@ -2,8 +2,13 @@
 #EXT_TEST TEST_FILE_MINVER 15.1
 #EXT_TEST TEST_FILE_DESC "Basic interactive command check: cd, ls, pwd, run, continue"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -21,7 +26,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+$LAUNCH << EOF  | tee $LOGFILE
 pwd
 ls
 cd cp0

--- a/tests/core-debug/cmd-ckptaction-err.sh
+++ b/tests/core-debug/cmd-ckptaction-err.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER 15.1
-#EXT_TEST TEST_FILE_DESC "Check that checkpoint action triggers error when checkpoint not enabled"
+#EXT_TEST TEST_FILE_DESC "Check checkpoint action triggers error when checkpoint not enabled"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -22,7 +27,7 @@ CKPTPREFIX=ckpt_$TNAME
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-start=0s --checkpoint-prefix=$CKPTPREFIX $CONFIG"
 echo $LAUNCH
-( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+$LAUNCH << EOF  | tee $LOGFILE
 cd c0
 cd xorshift
 trace w changed : 32 4 : w x y z : checkpoint

--- a/tests/core-debug/cmd-ckptaction.sh
+++ b/tests/core-debug/cmd-ckptaction.sh
@@ -2,8 +2,13 @@
 #EXT_TEST TEST_FILE_MINVER 15.1
 #EXT_TEST TEST_FILE_DESC "Check that trace checkpoint action triggers checkpoints"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -22,7 +27,7 @@ CKPTPREFIX=ckpt_$TNAME
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-start=0s --checkpoint-enable --checkpoint-prefix=$CKPTPREFIX $CONFIG"
 echo $LAUNCH
-( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+$LAUNCH << EOF  | tee $LOGFILE
 cd c0
 cd xorshift
 trace w changed : 32 4 : w x y z : checkpoint

--- a/tests/core-debug/cmd-cmp-types-false.sh
+++ b/tests/core-debug/cmd-cmp-types-false.sh
@@ -2,8 +2,13 @@
 #EXT_TEST TEST_FILE_MINVER 15.1
 #EXT_TEST TEST_FILE_DESC "Test comparisons for different types: all false"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# ensure non-zero exit code in pipe propagates and no unbound variables
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -21,7 +26,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+$LAUNCH << EOF  | tee $LOGFILE
 cd cp0
 # bool
 watch v_bool != 1
@@ -250,16 +255,18 @@ if [ $retVal -ne 0 ]; then
 fi
 
 # Check that none of the tests evaluated to true and triggered
-for (( i=0; i<69; i++ )); do
-	PSTR="WP$i:"
-	grep "$PSTR" $LOGFILE > /dev/null
-	retVal=$?
-	if [ $retVal -eq 0 ]; then
-	  echo "ERROR found fail string in $LOGFILE \"$PSTR\""
-	  exit $retVal
-	else
-		echo "$PSTR ok"
-	fi
+for i in {0..68}; do
+    PSTR="WP$i:"
+    echo $PSTR
+    grep -q "$PSTR" $LOGFILE
+    retVal=$?
+    echo $retVal
+    if [ $retVal -eq 0 ]; then
+	echo "ERROR found fail string in $LOGFILE: \"$PSTR\""
+	exit 99
+    else
+	echo "$PSTR ok"
+    fi
 done
 
 # Cleanup output file on pass
@@ -269,4 +276,5 @@ fi
 
 wait
 echo "PASS"
-exit $retVal
+exit 0
+

--- a/tests/core-debug/cmd-cmp-types-true.sh
+++ b/tests/core-debug/cmd-cmp-types-true.sh
@@ -2,8 +2,13 @@
 #EXT_TEST TEST_FILE_MINVER 15.1
 #EXT_TEST TEST_FILE_DESC "Test comparisons for different types: all true"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -21,7 +26,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+$LAUNCH << EOF  | tee $LOGFILE
 cd cp0
 # bool
 watch v_bool == 1

--- a/tests/core-debug/cmd-comments-ws.sh
+++ b/tests/core-debug/cmd-comments-ws.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER 15.1
-#EXT_TEST TEST_FILE_DESC "Enter interactive mode and replay session from an external file provided by SST command line option. Check comments have now effect"
+#EXT_TEST TEST_FILE_DESC "Check that comments have no effect in replay file"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# This test will enter interactive mode and replay session from an
+# external file provided by SST command line option and checks
+# that comments have no effect
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -39,7 +48,7 @@ EOF
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --replay-file=$CMDFILE --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+$LAUNCH << EOF  | tee $LOGFILE
 quit
 EOF
 

--- a/tests/core-debug/cmd-cond.sh
+++ b/tests/core-debug/cmd-cond.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER 15.1
-#EXT_TEST TEST_FILE_DESC "Basic check that a simple conditional watch trigger occurs"
+#EXT_TEST TEST_FILE_DESC "Basic check for simple conditional watch trigger"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -21,7 +26,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+$LAUNCH << EOF  | tee $LOGFILE
 ls
 cd c7
 watch duty_cycle_count == 1

--- a/tests/core-debug/cmd-custom-ic.sh
+++ b/tests/core-debug/cmd-custom-ic.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER 15.1
-#EXT_TEST TEST_FILE_DESC "Tests the use of --interactive-console with custom IC"
+#EXT_TEST TEST_FILE_DESC "Tests --interactive-console with custom IC"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -21,7 +26,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=dbgsst15.ICDebugSST15 --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+$LAUNCH << EOF  | tee $LOGFILE
 help
 quit
 EOF

--- a/tests/core-debug/cmd-default-ic.sh
+++ b/tests/core-debug/cmd-default-ic.sh
@@ -2,8 +2,13 @@
 #EXT_TEST TEST_FILE_MINVER 15.1
 #EXT_TEST TEST_FILE_DESC "Tests use of default IC with interactive-start"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -21,7 +26,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+$LAUNCH << EOF  | tee $LOGFILE
 help
 quit
 EOF

--- a/tests/core-debug/cmd-handler.sh
+++ b/tests/core-debug/cmd-handler.sh
@@ -2,8 +2,13 @@
 #EXT_TEST TEST_FILE_MINVER 15.1
 #EXT_TEST TEST_FILE_DESC "Check setHandler commands with trace"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -21,7 +26,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE 
+$LAUNCH << EOF  | tee $LOGFILE 
 cd cp0
 run 2us
 trace size changed : 16 14 : size : interactive

--- a/tests/core-debug/cmd-help.sh
+++ b/tests/core-debug/cmd-help.sh
@@ -3,6 +3,13 @@
 #EXT_TEST TEST_FILE_DESC "Walk through help commands"
 #EXT_TEST TIMEOUT 30
 
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
 # Settings
 CLEANUP=1
 SCRIPT_NAME=$(basename "$0")
@@ -18,7 +25,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+$LAUNCH << EOF  | tee $LOGFILE
 help
 ?
 help fubar

--- a/tests/core-debug/cmd-history.sh
+++ b/tests/core-debug/cmd-history.sh
@@ -2,8 +2,13 @@
 #EXT_TEST TEST_FILE_MINVER 15.1
 #EXT_TEST TEST_FILE_DESC "Log history to file and check it"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -21,7 +26,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-( $LAUNCH << EOF || exit 11 ) |  tee $LOGFILE
+$LAUNCH << EOF  |  tee $LOGFILE
 logging $OUTFILE
 ls
 cd c7

--- a/tests/core-debug/cmd-logging.sh
+++ b/tests/core-debug/cmd-logging.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER 15.1
-#EXT_TEST TEST_FILE_DESC "Enter interactive mode and log commands to an external file"
+#EXT_TEST TEST_FILE_DESC "Log debug commands to an external file"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -31,7 +36,7 @@ EOF
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-$LAUNCH < $CMDFILE > $LOGFILE || exit 1
+$LAUNCH < $CMDFILE | tee $LOGFILE
 
 retVal=$?
 
@@ -39,7 +44,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 

--- a/tests/core-debug/cmd-replay-sync.sh
+++ b/tests/core-debug/cmd-replay-sync.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER 15.1
-#EXT_TEST TEST_FILE_DESC "Basic check that a simple conditional watch trigger occurs when replayed from file"
+#EXT_TEST TEST_FILE_DESC "Conditional watch trigger replayed from file"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -32,7 +37,7 @@ EOF
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --replay-file=$CMDFILE --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-( $LAUNCH || exit 11 ) | tee $LOGFILE
+$LAUNCH | tee $LOGFILE
 retVal=$?
 
 echo $TNAME Complete

--- a/tests/core-debug/cmd-replay.sh
+++ b/tests/core-debug/cmd-replay.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER 15.1
-#EXT_TEST TEST_FILE_DESC "Enter interactive mode and replay session from an external file"
+#EXT_TEST TEST_FILE_DESC "Replay file from inside debug console"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -30,7 +35,7 @@ EOF
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+$LAUNCH << EOF  | tee $LOGFILE
 replay $CMDFILE
 EOF
 

--- a/tests/core-debug/cmd-replay2.sh
+++ b/tests/core-debug/cmd-replay2.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER 15.1
-#EXT_TEST TEST_FILE_DESC "Enter interactive mode and replay session from an external file provided by SST command line option"
+#EXT_TEST TEST_FILE_DESC "Replay session using SST command line option"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# This test will enter interactive mode and replay session
+# from an external file provided by SST command line option
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -30,7 +38,7 @@ EOF
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --replay-file=$CMDFILE --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+$LAUNCH << EOF  | tee $LOGFILE
 quit
 EOF
 

--- a/tests/core-debug/cmd-replay3.sh
+++ b/tests/core-debug/cmd-replay3.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER 15.1
-#EXT_TEST TEST_FILE_DESC "Enter interactive mode and replay session from an external file that does not exit the console. This ensures we get back to command prompt after file is read"
+#EXT_TEST TEST_FILE_DESC "Debug replay from file and check we get a prompt"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# This test will enter interactive mode and replay session from
+# an external file that does not exit the console. This ensures
+# we get back to command prompt after file is read
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -27,7 +36,7 @@ EOF
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+$LAUNCH << EOF  | tee $LOGFILE
 replay $CMDFILE
 set test_string HelloMyNameIsC7AndICannotQuoteAString
 print test_string

--- a/tests/core-debug/cmd-sanity.sh
+++ b/tests/core-debug/cmd-sanity.sh
@@ -2,8 +2,13 @@
 #EXT_TEST TEST_FILE_MINVER 15.1
 #EXT_TEST TEST_FILE_DESC "Enter interactive mode, change an internal variable and confirm it has been change"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -15,7 +20,7 @@ LOGFILE=$TNAME.out
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s  $CONFIG"
 echo $LAUNCH
-( $LAUNCH <<EOF || exit 11 ) | tee $LOGFILE
+$LAUNCH <<EOF | tee $LOGFILE
 ls
 cd c7
 ls

--- a/tests/core-debug/cmd-set.sh
+++ b/tests/core-debug/cmd-set.sh
@@ -2,8 +2,13 @@
 #EXT_TEST TEST_FILE_MINVER 15.1
 #EXT_TEST TEST_FILE_DESC "Check for set and print commands"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -21,7 +26,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+$LAUNCH << EOF  | tee $LOGFILE
 cd cp0
 ls
 set v_bool false

--- a/tests/core-debug/cmd-setstr.sh
+++ b/tests/core-debug/cmd-setstr.sh
@@ -2,8 +2,13 @@
 #EXT_TEST TEST_FILE_MINVER 15.1
 #EXT_TEST TEST_FILE_DESC "Check set string with spaces"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -21,7 +26,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+$LAUNCH << EOF  | tee $LOGFILE
 cd c0
 ls
 set test_string my big beautiful string

--- a/tests/core-debug/cmd-trace.sh
+++ b/tests/core-debug/cmd-trace.sh
@@ -2,8 +2,13 @@
 #EXT_TEST TEST_FILE_MINVER 15.1
 #EXT_TEST TEST_FILE_DESC "Check for trace commands: trace, printWatchpoint, addTraceVar, printTrace, resetTrace, unwatch, quit"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -21,7 +26,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+$LAUNCH << EOF  | tee $LOGFILE
 cd cp0
 trace size > 50 : 32 4 : size : interactive
 printWatchpoint 0

--- a/tests/core-debug/cmd-unwatch.sh
+++ b/tests/core-debug/cmd-unwatch.sh
@@ -2,8 +2,13 @@
 #EXT_TEST TEST_FILE_MINVER 15.1
 #EXT_TEST TEST_FILE_DESC "Check interactive console unwatch command"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -21,7 +26,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+$LAUNCH << EOF  | tee $LOGFILE
 cd cp0
 watch maxData > 10
 watch maxData > 100

--- a/tests/core-debug/cmd-watch.sh
+++ b/tests/core-debug/cmd-watch.sh
@@ -2,8 +2,13 @@
 #EXT_TEST TEST_FILE_MINVER 15.1
 #EXT_TEST TEST_FILE_DESC "Check watch commands with different trigger types"
 #EXT_TEST TIMEOUT 30
-#
-# SST DEV: 
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
 # Settings
 CLEANUP=1
@@ -21,7 +26,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+$LAUNCH << EOF  | tee $LOGFILE
 cd cp0
 watch size > 0
 printWatchpoint 0

--- a/tests/core-debug/testinfo.sh
+++ b/tests/core-debug/testinfo.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_DESC "Provide information on local tests"
-../../bin/sst-ext-tests -d . || exit 11 | tee TEST.INFO
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+../../bin/sst-ext-tests -d . | tee TEST.INFO
 echo PASS

--- a/tests/core-debug/type-bitset.sh
+++ b/tests/core-debug/type-bitset.sh
@@ -3,6 +3,13 @@
 #EXT_TEST TEST_FILE_DESC "Exercise std::bitset and std::vector<bool>"
 #EXT_TEST TIMEOUT 30
 
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
 # Settings
 CLEANUP=1
 SCRIPT_NAME=$(basename "$0")
@@ -84,7 +91,7 @@ EOF
 LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
 echo $LAUNCH
 revVal=0
-( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+$LAUNCH << EOF  | tee $LOGFILE
 replay $CMDFILE
 confirm false
 exit


### PR DESCRIPTION
This is currently only changing tests in the `tests/core-debug` area but we should be consistent everywhere. 

I've added to the top of the script the following:

```
set -uo pipefail
```

This should solve a problem resulting in false passes where sst returns an error code but, because it is in a bash pipe sequence, is not detected.

```
$LAUNCH 2>&1 << EOF | tee $LOGFILE
```

Using `set -o pipefile`, will propagate the sst error code from the LAUNCH command to the `$?` shell variable. Without this set we just get the result of the `tee` function which isn't helpful.

The `u`, in the `set -uo pipefail` command will cause the script to exit with an error if a variable is used that has not been set. Because of this, I need to add some code to make sure any environment variables have a safe value.

Specifically:

```
# --add-lib-path required for Jenkins runs (does not run 'make install')
# Set default ensure failure if not set and component not installed
SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
```
