### PR TITLE
git base management of jenkins scripts

### DIFF
--- a/jenkins/sstcore-macos26.1-Aarch64-clang17.0-EXP.sh
+++ b/jenkins/sstcore-macos26.1-Aarch64-clang17.0-EXP.sh
@@ -6,10 +6,13 @@ cd $WORKSPACE || exit 2
 
 echo "---> $0 Started in $PWD"
 
+#-- unique to target
+export SST_INSTALL=/Users/builduser/jenkins/install/sst-$BRANCH-macos26.1-clang17.0-EXP
+
+#-- common
 export TERM=linux
 export CC=clang
 export CXX=clang++
-export SST_INSTALL=/Users/builduser/jenkins/install/sst-$BRANCH-macos26.1-clang17.0
 export PATH=/opt/homebrew/bin:/opt/homebrew/opt/libtool/libexec/gnubin:$PATH
 
 echo "REPO=$REPO"


### PR DESCRIPTION
This is a proof-of-concept PR for improving how we manage Jenkins scripts for the sst-core verification pipeline.

Refer to:  http://jenkins.dev.tactcomplabs.com:8080/job/SST/job/Targets/job/sstcore-macos26.1-Aarch64-clang17.0-EXP/

The idea is that the target specific run script resides in `sst-ext-tests/jenkins/\<jobname\>.sh.
For this example PR I provided one script, `sst-ext-tests/jenkins/sstcore-macos26.1-Aarch64-clang17.0-EXP.sh`

If the jobscript does not exist, it fails right away.

In the Jenkins configuration, the run script in now the same for all the targets. 
```
#-- use the built-in script to run

#-- Experimental 
#--  sst-ext-tests contains script to execute tests for this target
#--  Always clone sst-ext-tests but conditionally run

rm -Rf ./sst-ext-tests
git clone https://github.com/tactcomplabs/sst-ext-tests.git
cd sst-ext-tests || exit 1
git checkout $EXTTESTBRANCH
cd ..

# Make sure we have a script for this target
jobscript="sst-ext-tests/jenkins/${JOB_BASE_NAME}.sh"
if [[ ! -x ${jobscript} ]]; then
	echo "error: Missing ${jobscript}"
    exit 1
fi

${jobscript}
echo "Completed ${JOB_BASE_NAME}"
exit 0
```

If you agree with this approach and we merge this, I can start refactoring the code so we can split the common code from the target specific code. Then start to phase in the change to each target on Jenkins.

