### PR TITLE
common run script for jenkins pipeline

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -1,0 +1,6 @@
+This area contains scripts used by Jenkins sst-core development pipeline.
+
+  
+- `serverside.sh`:  Copy this script into the build steps 'command' text window. Modify SST_INSTALL and PATH for the target system. This will invoke `run.sh` unless an override script exists, `sst-ext-tests/jenkins/${JOB_BASE_NAME}.sh`
+- `run.sh`: This is invoked by `servserside.sh` 
+- examples/sstcore-macos26.1-Aarch64-clang17.0-EXP.sh: Example override script. Copy to parent directory for `sstcore-macos26.1-Aarch64-clang17.0` to use this script instead of `run.sh`

--- a/jenkins/examples/sstcore-macos26.1-Aarch64-clang17.0-EXP.sh
+++ b/jenkins/examples/sstcore-macos26.1-Aarch64-clang17.0-EXP.sh
@@ -8,12 +8,12 @@ echo "---> $0 Started in $PWD"
 
 #-- unique to target
 export SST_INSTALL=/Users/builduser/jenkins/install/sst-$BRANCH-macos26.1-clang17.0-EXP
+export PATH=/opt/homebrew/bin:/opt/homebrew/opt/libtool/libexec/gnubin:$PATH
 
 #-- common
 export TERM=linux
 export CC=clang
 export CXX=clang++
-export PATH=/opt/homebrew/bin:/opt/homebrew/opt/libtool/libexec/gnubin:$PATH
 
 echo "REPO=$REPO"
 echo "BRANCH=$BRANCH"

--- a/jenkins/run.sh
+++ b/jenkins/run.sh
@@ -1,0 +1,96 @@
+#!/bin/bash -x
+
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+# See LICENSE in the top level directory for licensing details
+
+# Usage:
+# 1. Set platform specific environment variables. e.g.
+#    export SST_INSTALL=/Users/builduser/jenkins/install/sst-$BRANCH-macos26.1-clang17.0-EXP
+#    export PATH=/opt/homebrew/bin:/opt/homebrew/opt/libtool/libexec/gnubin:$PATH
+# 2. Run it
+#    run.sh
+
+echo "---> $0 Started in $PWD"
+echo "BUILDNAME=$BUILDNAME"
+echo "WORKSPACE=$WORKSPACE"
+cd $WORKSPACE || exit 2
+
+#-- common
+export TERM=linux
+export CC=clang
+export CXX=clang++
+
+#-- environment feedback
+echo "REPO=$REPO"
+echo "BRANCH=$BRANCH"
+echo "EXTTESTBRANCH=$EXTTESTBRANCH"
+echo "EXTTESTARGS=$EXTTESTARGS"
+echo "HEADERCHECK=$HEADERCHECK"
+echo "EXTTEST=$EXTTEST"
+echo "DEBUG=$DEBUG"
+echo "CLANGFORMAT=$CLANGFORMAT"
+if [ $SANITIZER = true ] && [ $VALGRIND = true ]; then
+	echo "SANITIZER and VALGRIND are mutually exclusive. Using SANITIZER only"
+	VALGRIND=false
+fi
+echo "SANITIZER=$SANITIZER"
+echo "VALGRIND=$VALGRIND"
+echo $SST_INSTALL
+echo $PATH
+
+#-- SST
+rm -Rf $SST_INSTALL/*
+if [ "$CLANGFORMAT" = true ]; then
+	./scripts/clang-format-test.sh --format-exe /opt/homebrew/opt/llvm@20/bin/clang-format
+fi
+./autogen.sh
+if [ "$DEBUG" = true ]; then
+    export DBGFLAGS="--enable-debug"
+    export CXXFLAGS="-O0 -g"
+else
+	export DBGFLAGS=""
+fi
+if [ "$SANITIZER" = true ]; then
+    export CXXFLAGS="${CXX_FLAGS} -g -fsanitize=address -fno-omit-frame-pointer"
+    export EXTTESTASAN="-DSST_ASAN=ON"
+	if [[ "$(uname)" != "Darwin" ]]; then
+		# detect_leaks is not supported on Mac
+		export ASAN_OPTIONS=detect_leaks=0
+	fi
+fi
+./configure --prefix=$SST_INSTALL $DBGFLAGS --disable-mpi
+if [ "$HEADERCHECK" = true ] ; then
+	./scripts/test-includes.pl
+fi
+make -j4
+make install
+export PATH=$PATH:$SST_INSTALL/bin
+
+#-- Run SST tests
+if [ "$SST_TEST_CORE" = true ]; then
+	which sst-test-core
+	sst-test-core
+fi
+
+#-- Run EXT tests
+if [ "$EXTTEST" = true ] ; then
+	cd sst-text-tests
+	mkdir build
+	cd build
+	if [ "$VALGRIND" = false ]; then
+	    cmake -DENABLE_ALL_TESTS=ON $EXTTESTASAN $EXTTESTARGS ../
+	else
+    	cmake -DENABLE_ALL_TESTS=ON -DENABLE_VALGRIND=ON $EXTTESTARGS ../
+	fi
+	export SST_COMPONENT_BASE=`pwd`
+	make
+	if [ "$VALGRIND" = false ]; then
+	    make test || ctest --rerun-failed --output-on-failure
+	else
+    	../scripts/valgrind_ctest
+	fi
+fi
+
+echo "---> $0 Finished"

--- a/jenkins/serverside.sh
+++ b/jenkins/serverside.sh
@@ -1,0 +1,43 @@
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+# See LICENSE in the top level directory for licensing details
+
+# Usage: Use this script in the target->Configure->BuildSteps command
+
+#-- use the built-in script to run
+
+#-- Customize these environment variables for each target
+export SST_INSTALL=/Users/builduser/jenkins/install/sst-$BRANCH-macos26.1-clang17.0-EXP
+export PATH=/opt/homebrew/bin:/opt/homebrew/opt/libtool/libexec/gnubin:$PATH
+
+###
+### DO NOT EDIT BELOW THIS LINE
+###
+
+#--  sst-ext-tests contains script to execute tests for this target
+#--  Always clone sst-ext-tests but conditionally run
+
+rm -Rf ./sst-ext-tests
+git clone https://github.com/tactcomplabs/sst-ext-tests.git
+cd sst-ext-tests || exit 1
+git checkout $EXTTESTBRANCH
+cd ..
+
+# Run Target Specific Override Script if it exists
+runscript="sst-ext-tests/jenkins/${JOB_BASE_NAME}.sh"
+if [[ -x ${runscript} ]]; then
+  ${runscript}
+  echo "Completed ${JOB_BASE_NAME} using ${runscript}"
+  exit 0
+fi
+
+# Run common run script if it exists
+runscript="sst-ext-tests/jenkins/run.sh"
+if [[ ! -x ${runscript} ]]; then
+  echo "Warning: ${runscript} not found. Skipping this run"
+  exit 0
+fi
+
+${runscript}
+echo "Completed ${JOB_BASE_NAME} using ${runscript}"


### PR DESCRIPTION
This is the final PR before I start modifying the jenkins targets themselves.

Referring to http://jenkins.dev.tactcomplabs.com:8080/job/SST/job/Targets/job/sstcore-macos26.1-Aarch64-clang17.0-EXP/configure

1. The server side script is now provided in the repository for easier maintenance. You still need to cut/paste it into the command text box in Jenkins and modify two target specific environment variables: SST_INSTALL and SST_PATH

2. Provided  a common run script, `run.sh`, which should work for all the targets but I need to go through each one individually and verify that.

3. The server side script will allow you to override `run.sh` but providing a script called ${JOB_BASE_NAME}.sh in the same directory as `run.sh`.  An example is provided in the `examples` subdirectory.

4. VALGRIND and SANITY are now mutually exclusive and will select SANITY if both are set by the user.

5. Added an environment variable, `SST_TEST_CORE`, to allow us to enable/disable running `sst-test-core`. This is handy when we want to quickly verify a PR on some specific tests in `sst-ext-tests` using `ctest -R regex`. Also good if we want to limit a valgrind regression to a short test list.

Once approved, I'd like to make incremental changes without PRs as I convert each Jenkins target to these new scripts.

