### PR TITLE
Add std::optional and std::variant to CaptCrunch

### DIFF
--- a/components/CaptCrunch/CaptCrunch.cc
+++ b/components/CaptCrunch/CaptCrunch.cc
@@ -184,7 +184,12 @@ CaptCrunch::serialize_order(SST::Core::Serialization::serializer& ser)
     SST_SER(unsignedMapList);
 
     SST_SER(unsignedVectVectVect);
-}
+
+    SST_SER(optionalInt);
+    SST_SER(optionalVectorInt);
+
+    SST_SER(variant);
+  }
 
 void
 CaptCrunch::initData()
@@ -402,6 +407,11 @@ CaptCrunch::initData()
 
     unsignedVectVectVect.push_back(unsignedVectVect);
     unsignedVectVectVect.push_back(unsignedVectVect);
+
+    optionalInt = 123;
+    optionalVectorInt = {5, 6, 7, 8};
+
+    variant.emplace<2>(std::make_tuple(true, 123));
 }
 
 bool

--- a/components/CaptCrunch/CaptCrunch.h
+++ b/components/CaptCrunch/CaptCrunch.h
@@ -13,23 +13,26 @@
 
 // -- Standard Headers
 #include <array>
+#include <cinttypes>
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
 #include <deque>
 #include <forward_list>
-#include <inttypes.h>
 #include <list>
 #include <map>
+#include <optional>
 #include <queue>
 #include <set>
 #include <stack>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string>
-#include <time.h>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <variant>
 #include <vector>
 
 // -- SST Headers
@@ -303,6 +306,11 @@ private:
     std::list<std::map<unsigned, unsigned>> unsignedMapList;
 
     std::vector<std::vector<std::vector<unsigned>>> unsignedVectVectVect;
+
+    std::optional<int> optionalInt;
+    std::optional<std::vector<int>> optionalVectorInt;
+
+    std::variant<int, std::vector<int>, std::tuple<bool, int>> variant;
 
     // ---------------------------------------
     // END SERIALIZED DATA STRUCTURES


### PR DESCRIPTION
I tried building this but it fails. I started from `devel` but my upstream SST Core may be stale. The branches are changing too quickly for me to follow.