### PR TITLE
Basic component for focused object map testing

### DIFF
--- a/components/core-debug/CMakeLists.txt
+++ b/components/core-debug/CMakeLists.txt
@@ -8,6 +8,8 @@
 #
 
 set(DbgSST15Srcs
+  basic.cc
+  basic.h
   dbgsst15.cc
   dbgsst15.h
   probe.cc

--- a/components/core-debug/basic.cc
+++ b/components/core-debug/basic.cc
@@ -1,0 +1,108 @@
+//
+// basic.cc
+//
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "basic.h"
+
+namespace SST::ExtTest{
+
+OMSimpleComponent::OMSimpleComponent(ComponentId_t id, const SST::Params& params) : SST::Component(id)
+{
+    // SST output
+    uint32_t verbosity = params.find<uint32_t>("verbose", 2);
+    sstout_.init(getName() + ":@p:@t]: ",verbosity, 0, SST::Output::STDOUT );
+    
+    // SST clocking
+    clockHandler_  = new SST::Clock::Handler2<OMSimpleComponent,&OMSimpleComponent::clockTick>(this);
+    timeConverter_ = registerClock("1GHz", clockHandler_);
+
+    // SubComponents
+    p_omsimplecomp_function0_ = loadUserSubComponent<OMSubComponentAPI>("function0");
+    assert(p_omsimplecomp_function0_);
+
+    // Links
+    port0link_ = configureLink("port0",
+              new Event::Handler2<OMSimpleComponent, &OMSimpleComponent::port0rcv>(this));
+
+    // Primary Controller
+    primary = params.find<bool>("primary", false);
+    if (primary) {
+        registerAsPrimaryComponent();
+        primaryComponentDoNotEndSim();
+    } else {
+        // Primary will send data over link to wake up other components
+        unregisterClock(timeConverter_, clockHandler_);
+    }
+}
+
+
+void OMSimpleComponent::serialize_order(SST::Core::Serialization::serializer &ser)
+{
+    Component::serialize_order(ser);
+
+    // SST Handlers
+    // SST_SER(sstout_);
+    // SST_SER(timeConverter_);
+    // SST_SER(clockHandler_);
+
+    // TODO function0_ is serialized with slot0 of the component but not with sst_ser::as_ptr
+    // Does this actually work with checkpointing?
+    #if 1
+    SST_SER(p_omsimplecomp_function0_);
+    #endif
+
+}
+
+// Link handlers
+void OMSimpleComponent::port0rcv(SST::Event *ev) {
+    OMEvent* omev = static_cast<OMEvent*>(ev);
+    payload_port0 = omev->payload();
+    reregisterClock(timeConverter_, clockHandler_);
+}
+
+// Clock handler
+bool OMSimpleComponent::clockTick(SST::Cycle_t currentCycle)
+{
+    // TODO for component sleep/wake-up testing
+    // Only enable clock when we receive data.
+    // Update the received payload using a slot 'function'
+    // Send it back over the link
+
+    // slot function provides differentiated behaviors for testing
+    p_omsimplecomp_function0_->update( payload_port0 );
+
+    #ifdef EVENT_SLEEP
+    sstout_.verbose(CALL_INFO, 0, 0, 
+        "[%s] payload_port0.data=%" PRId64 "\n", getName().c_str(), payload_port0.data);
+    #endif
+    
+    if (primary && getCurrentSimCycle()>=10000000) {
+        sstout_.verbose(CALL_INFO,0,0,"[%s] finished after 10000000 clocks\n", getName().c_str());
+        primaryComponentOKToEndSim();
+        return true;
+    }
+
+    #ifdef EVENT_SLEEP
+    port0link_->send(new OMEvent(payload_port0));
+    return true;
+    #else
+    return false;
+    #endif
+}
+
+OMSubComponentAPI::OMSubComponentAPI(ComponentId_t id, Params &params) : SubComponent(id)
+{
+    v_queue_unsigned_.push(100);
+    v_queue_unsigned_.push(200);
+    v_queue_unsigned_.push(300);
+}
+
+} // namespace SST::ExtTest
+
+// EOF

--- a/components/core-debug/basic.h
+++ b/components/core-debug/basic.h
@@ -65,7 +65,7 @@ public:
   virtual ~OMSubComponentAPI() {}
   virtual void update(payload_t& p) {
     // if ( subcompapi_counter_ % 13 ) {
-        // perturb one element but keep the size the same
+        // change the queue state
         unsigned front = v_queue_unsigned_.front() + 1;
         v_queue_unsigned_.pop();
         v_queue_unsigned_.push(front);

--- a/components/core-debug/basic.h
+++ b/components/core-debug/basic.h
@@ -1,0 +1,204 @@
+//
+// basic.h
+//
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+// Intent: Minimalist low level object map testing. 
+// Subcomponents are used to differentiate behaviors
+// so we can focus on a single type or provide more
+// complex behaviors by simply providing the subcomponent
+// at runtime.
+
+#ifndef _SST_EXT_TESTS_BASIC_
+#define _SST_EXT_TESTS_BASIC_
+
+// clang-format off
+// -- Standard Headers
+#include "SST.h"
+#include <map>
+// clang-format on
+
+namespace SST::ExtTest {
+
+// ---------------------------------------------
+// payload_t
+// ---------------------------------------------
+struct payload_t {
+  uint64_t data = 0;
+}; //struct payload_t
+
+// ---------------------------------------------
+// OMEvent
+// ---------------------------------------------
+class OMEvent : public SST::Event {
+public:
+  OMEvent(const payload_t& p) : SST::Event(), payload_(p) {}
+  virtual ~OMEvent() {}
+  const payload_t& payload(){ return payload_; }
+private:
+  payload_t payload_;
+public:
+  // Serialization
+  OMEvent() : Event() {}
+  void serialize_order(SST::Core::Serialization::serializer& ser) override {
+    SST::Event::serialize_order(ser);
+    // SST_SER(payload_); //TODO can I see in-flight events in debugger?
+  }
+  ImplementSerializable(SST::ExtTest::OMEvent);
+}; // class OMEvent
+
+// -------------------------------------------------------
+// OMSubComponentAPI (not registered)
+// -------------------------------------------------------
+class OMSubComponentAPI : public SST::SubComponent {
+public:
+  SST_ELI_REGISTER_SUBCOMPONENT_API(SST::ExtTest::OMSubComponentAPI);
+  // SST_ELI_DOCUMENT_PARAMS(
+  //   {"verbose",         "Sets the verbosity level of output",   "0" }
+  // )
+  OMSubComponentAPI(ComponentId_t id, Params& params);
+  virtual ~OMSubComponentAPI() {}
+  virtual void update(payload_t& p) {
+    // if ( subcompapi_counter_ % 13 ) {
+        // perturb one element but keep the size the same
+        unsigned front = v_queue_unsigned_.front() + 1;
+        v_queue_unsigned_.pop();
+        v_queue_unsigned_.push(front);
+        // sstout_.verbose(CALL_INFO, 0, 0, "v_queue_unsigned_.front()=%d\n", v_queue_unsigned_.front());
+        std::cout << this->getCurrentSimCycle() << ": v_queue_unsigned_.front()=" << v_queue_unsigned_.front() << std::endl;
+    // }
+
+    //TODO event payload customization
+    for (size_t i=0; i<8; i++) 
+      array_[i] = subcompapi_counter_ + i;
+    subcompapi_counter_++;
+  };
+protected:
+  SST::Output sstout_;
+  uint64_t subcompapi_counter_ = 0; // ObjectMapFundamental
+  uint64_t array_[8] = {0};         // ObjectMapArray
+
+  // Testing std::queue
+  std::queue<uint32_t> v_queue_unsigned_;
+
+public:
+  // minimum serialization for testing object map
+  OMSubComponentAPI() : SubComponent() {}
+  void serialize_order(SST::Core::Serialization::serializer& ser) override {
+    SubComponent::serialize_order(ser);
+    SST_SER(v_queue_unsigned_);
+  }
+  ImplementVirtualSerializable(SST::ExtTest::OMSubComponentAPI)
+}; //class OMSubComponentAPI
+
+// -------------------------------------------------------
+// OMSimpleSubComponent
+// -------------------------------------------------------
+class OMSimpleSubComponent : public OMSubComponentAPI {
+public:
+  SST_ELI_REGISTER_SUBCOMPONENT(
+        OMSimpleSubComponent,            // Class name
+        "dbgsst15",                         // Library name
+        "OMSimpleSubComponent",          // Subcomponent name
+        SST_ELI_ELEMENT_VERSION(1,0,0),  // A version number
+        "Simple subcomponent for object map evaluation", 
+        SST::ExtTest::OMSimpleSubComponent) // Fully qualified API name
+  // SST_ELI_DOCUMENT_PARAMS(
+  //   {"param",    "desc", "default" }
+  // )
+  OMSimpleSubComponent(ComponentId_t id, Params& params) : OMSubComponentAPI(id,params) {}
+  virtual ~OMSimpleSubComponent() {}
+  virtual void update(payload_t& p) final {
+    OMSubComponentAPI::update(p);
+    p.data += 1;
+  }
+public:
+    // serialization support
+    OMSimpleSubComponent() : OMSubComponentAPI() {}
+    void serialize_order(SST::Core::Serialization::serializer& ser) override {
+      OMSubComponentAPI::serialize_order(ser);
+    }
+    ImplementSerializable(SST::ExtTest::OMSimpleSubComponent)
+}; //class OMSimpleSubComponent
+
+// ---------------------------------------------
+// OMSimpleComponent
+// ---------------------------------------------
+class OMSimpleComponent : public SST::Component{
+
+public:
+  SST_ELI_REGISTER_COMPONENT( OMSimpleComponent,   // component class
+                            "dbgsst15",       // component library
+                            "OMSimpleComponent",   // component name
+                            SST_ELI_ELEMENT_VERSION( 1, 0, 0 ),
+                            "Simple Object Map Evalulation Component",
+                            COMPONENT_CATEGORY_UNCATEGORIZED )
+  SST_ELI_DOCUMENT_PARAMS(
+    {"verbose", "Sets the verbosity level of output",   "1" },
+    {"primary", "Sets component as primary controller", "0" },
+  )
+  SST_ELI_DOCUMENT_PORTS(
+    { "port0",  "generic port 0",   {"omap.OMEvent"} },
+  )
+  SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS(
+    { "function0", 
+      "generic function 0",
+      "SST::ExtTest::OMSubComponentAPI" },
+  )
+
+  explicit OMSimpleComponent(ComponentId_t id, const SST::Params& params);
+  ~OMSimpleComponent() {}
+
+  // Component Lifecycle
+  void init( unsigned int phase ) override {};     // post-construction, polled events
+  void setup() override {};                        // pre-simulation, called once per component
+  void complete( unsigned int phase ) override {}; // post-simulation, polled events
+  void finish() override {};                       // pre-destruction, called once per component
+  void emergencyShutdown() override {};            // SIGINT, SIGTERM
+  void printStatus(Output& out) override {};       // SIGUSR2
+
+  // Clocking
+  bool clockTick( SST::Cycle_t currentCycle );  // return true if clock should be disabled
+
+private:
+  // Subcomponent pointers
+  OMSubComponentAPI* p_omsimplecomp_function0_ = nullptr;
+
+  // SST Handlers
+  SST::Output sstout_;
+  SST::TimeConverter* timeConverter_;
+  SST::Clock::HandlerBase* clockHandler_;
+
+  // Links
+  SST::Link* port0link_;
+
+  // Link handlers
+  void port0rcv(SST::Event *ev);
+  
+  // Internals
+  bool primary = false;
+  payload_t payload_port0;
+
+public:
+  // -------------------------------------------------------
+  // Serialization support
+  // -------------------------------------------------------
+  // Default constructor required for serialization
+  OMSimpleComponent() : SST::Component() {}
+  // Serialization function 
+  void serialize_order(SST::Core::Serialization::serializer& ser) override;
+  // Serialization implementation
+  ImplementSerializable(SST::ExtTest::OMSimpleComponent)
+
+}; //class OMSimpleComponent
+
+} //namespace SST::ExtTest
+
+#endif  // _SST_EXT_TESTS_BASIC_
+
+// EOF

--- a/components/core-debug/dbgsst15.cc
+++ b/components/core-debug/dbgsst15.cc
@@ -328,11 +328,15 @@ DbgSST15::tickleBits()
         //TODO watch point on size change
     }
     if (tickle_counter % 13 == 0 ) {
-        // replace the front element
+        // perturb one element but keep the size the same
         unsigned front = v_queue_unsigned.front() + 1;
         v_queue_unsigned.pop();
         v_queue_unsigned.push(front);
-        // std::cout << getCurrentSimCycle() << ": v_queue_unsigned.front()=" << v_queue_unsigned.front() << std::endl;
+        #if 1
+        if (this->getName()=="cp0") {
+            output.verbose(CALL_INFO, 0, 0, "v_queue_unsigned.front()=%d\n", v_queue_unsigned.front());
+        }
+        #endif
     }
     if (tickle_counter % 17 == 0 ) {
         // replace the front element

--- a/components/core-debug/dbgsst15.cc
+++ b/components/core-debug/dbgsst15.cc
@@ -332,7 +332,7 @@ DbgSST15::tickleBits()
         unsigned front = v_queue_unsigned.front() + 1;
         v_queue_unsigned.pop();
         v_queue_unsigned.push(front);
-        #if 1
+        #if 0
         if (this->getName()=="cp0") {
             output.verbose(CALL_INFO, 0, 0, "v_queue_unsigned.front()=%d\n", v_queue_unsigned.front());
         }

--- a/tests/core-debug/basic.py
+++ b/tests/core-debug/basic.py
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# basic.py
+#
+
+import argparse
+import sst
+
+parser = argparse.ArgumentParser(description="basic")
+parser.add_argument("--verbose",              type=int,   help="verbosity", default=2)
+
+args = parser.parse_args()
+
+# single component
+class Simple():
+  def __init__(self):
+
+    self.c0 =  sst.Component(f"c0",  "dbgsst15.OMSimpleComponent")
+    self.c0.addParams({
+      "verbose" : args.verbose,
+      "primary" : 1
+      })
+    self.c0f0 = self.c0.setSubComponent( "function0", "dbgsst15.OMSimpleSubComponent")
+
+# 2 components sharing a link
+class Simple2():
+  def __init__(self):
+
+    self.c0 =  sst.Component(f"c0",  "omap.OMSimpleComponent")
+    self.c0.addParams({
+      "verbose" : args.verbose,
+      "primary" : 1
+      })
+    self.c0f0 = self.c0.setSubComponent( "function0", "omap.OMSimpleSubComponent")
+
+    self.c1 =  sst.Component(f"c1",  "omap.OMSimpleComponent")
+    self.c1.addParams({"verbose" : args.verbose})
+    self.c1f0 = self.c1.setSubComponent( "function0", "omap.OMSimpleSubComponent")
+
+    self.link0 = sst.Link("f0")
+    self.link0.connect( (self.c0, "port0", "10ns"), (self.c1, "port0", "10ns") ) 
+
+# Instantiation
+simple = Simple();
+
+#EOF

--- a/tests/core-debug/type-queue-1.sh
+++ b/tests/core-debug/type-queue-1.sh
@@ -35,7 +35,7 @@ confirm false
 # regexp and have multiple \n characters but not a trailing \n
 
 cd c0
-cd component
+cd function0/
 cd v_queue_unsigned_/
 cd container/
 ls

--- a/tests/core-debug/type-queue-1.sh
+++ b/tests/core-debug/type-queue-1.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER DEV
+#EXT_TEST TEST_FILE_DESC "Exercise std::queue<unsigned> with one component"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Settings
+CLEANUP=1
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="basic.py"
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+cat << EOF > $CMDFILE
+confirm false
+
+# The checking convention is: CHECK <id> <regexp>
+# regexp and have multiple \n characters but not a trailing \n
+
+cd c0
+cd component
+cd v_queue_unsigned_/
+cd container/
+ls
+# 0 = 100 (unsigned int)
+# 1 = 200 (unsigned int)
+# 2 = 300 (unsigned int)
+run 10ns
+# 1000: v_queue_unsigned_.front()=200
+# 2000: v_queue_unsigned_.front()=300
+# 3000: v_queue_unsigned_.front()=101
+# 4000: v_queue_unsigned_.front()=201
+# 5000: v_queue_unsigned_.front()=301
+# 6000: v_queue_unsigned_.front()=102
+# 7000: v_queue_unsigned_.front()=202
+# 8000: v_queue_unsigned_.front()=302
+# 9000: v_queue_unsigned_.front()=103
+# Entering interactive mode at time 10000 
+# Ran clock for 10000 sim cycles
+
+ls
+# 0 = 100 (unsigned int)
+# 1 = 200 (unsigned int)
+# 2 = 300 (unsigned int)
+
+shutdown
+
+EOF
+
+# Update this whenever adding checks in the command comments above
+NUMCHECKS=0
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
+echo $LAUNCH
+revVal=0
+$LAUNCH << EOF  | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/core-debug/type-queue.sh
+++ b/tests/core-debug/type-queue.sh
@@ -74,22 +74,14 @@ ls
 # advance simulator sufficiently to observe change in front data
 run 10400ns
 
-# What we see is very strange. The value of the front is changing
-# in a seemingly erratic way
-# 1300000: v_queue_unsigned.front()=1200
-# 1300000: v_queue_unsigned.front()=200
-# 2600000: v_queue_unsigned.front()=1300
-# 2600000: v_queue_unsigned.front()=300
-# 3900000: v_queue_unsigned.front()=1101
-# 3900000: v_queue_unsigned.front()=101
-# 5200000: v_queue_unsigned.front()=1201
-# 5200000: v_queue_unsigned.front()=201
-# 6500000: v_queue_unsigned.front()=1301
-# 6500000: v_queue_unsigned.front()=301
-# 7800000: v_queue_unsigned.front()=1102
-# 7800000: v_queue_unsigned.front()=102
-# 9100000: v_queue_unsigned.front()=1202
-# 9100000: v_queue_unsigned.front()=202
+# confirm cp0 front value is changing
+# DbgSST15[cp0:tickleBits:1300000]: v_queue_unsigned.front()=1200
+# DbgSST15[cp0:tickleBits:2600000]: v_queue_unsigned.front()=1300
+# DbgSST15[cp0:tickleBits:3900000]: v_queue_unsigned.front()=1101
+# DbgSST15[cp0:tickleBits:5200000]: v_queue_unsigned.front()=1201
+# DbgSST15[cp0:tickleBits:6500000]: v_queue_unsigned.front()=1301
+# DbgSST15[cp0:tickleBits:7800000]: v_queue_unsigned.front()=1102
+# DbgSST15[cp0:tickleBits:9100000]: v_queue_unsigned.front()=1202
 
 # CHECK 8 pwd\ncp0/v_queue_unsigned/container \(
 pwd


### PR DESCRIPTION
I had developed a component in sst-tools which I used for studying the interactive debugger and object map behaviors. The idea is to use subcomponents to provide custom (simple) behaviors where we can focus on one aspect of the object map behavior. Lee requested a test that only had `std::queue` in a single component to debug a problem we are working on. I think this will be a common scenario so rather than continue to hack up the existing components with customizations I thought to put a little more effort into something reusable.

This is a work in progress. You'll see I have #ifdef's around use of events/links which I intent to have an ELI parameter to control at a future point.

There is one test added `type-queue-1.sh` that reproduces a bug but does not checks so it passes. 

@leekillough  the comments in that test tell you how to run but I will also add the information to that issue.


