### PR TITLE
Guard15.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,11 @@ if (ENABLE_VALGRIND)
   endif()
 endif()
 
+# -- Prefer modular components over using version specific compile options
+if ( (${SST_VERSION} STREQUAL "DEV") OR (${SST_VERSION} VERSION_GREATER "15.1") )
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSST_VER_GT_15_1")
+endif()
+
 # -- setup override files
 find_program(SST NAMES "sst")
 find_program(SSTREGISTER NAMES "sst-register")

--- a/audit/251222/13.0.0.ctest
+++ b/audit/251222/13.0.0.ctest
@@ -1,0 +1,70 @@
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+      Start  1: sst_base
+      Start  2: sstconfig_help
+      Start  3: sstconfig_list_CXXFLAGS
+      Start  4: sstconfig_list
+      Start  5: sst_heartbeat_0.1.30
+      Start  6: sst_help-13.0
+      Start  7: sst_help
+      Start  8: sstinfo_help
+      Start  9: sstinfo_list_elem
+      Start 10: sstinfo_list_env
+      Start 11: sstinfo_list_nodisplay
+      Start 12: sstinfo_list_quiet
+      Start 13: sstinfo_list
+      Start 14: sstinfo_list_xml_file
+      Start 15: sstinfo_list_xml
+      Start 16: sstinfo_sst
+      Start 17: sst_numthreads
+      Start 18: sst_output_config
+      Start 19: sst_output_dot
+      Start 20: sst_output_dot_verbosity
+ 1/31 Test  #2: sstconfig_help ...................   Passed    0.19 sec
+      Start 21: sst_output_json
+ 2/31 Test  #4: sstconfig_list ...................   Passed    0.21 sec
+      Start 22: sst_output_prefix
+ 3/31 Test  #3: sstconfig_list_CXXFLAGS ..........   Passed    0.22 sec
+      Start 23: sst_print_timing_info
+ 4/31 Test  #8: sstinfo_help .....................   Passed    0.29 sec
+      Start 24: sstregister_a
+ 5/31 Test #16: sstinfo_sst ......................   Passed    0.30 sec
+      Start 25: sst_register_list
+ 6/31 Test #25: sst_register_list ................   Passed    0.13 sec
+      Start 26: sst_sdlfile
+ 7/31 Test #12: sstinfo_list_quiet ...............   Passed    0.49 sec
+      Start 27: sst_version
+ 8/31 Test #11: sstinfo_list_nodisplay ...........   Passed    0.49 sec
+      Start 28: testinfo
+ 9/31 Test #13: sstinfo_list .....................   Passed    0.49 sec
+      Start 29: testinfo
+10/31 Test #14: sstinfo_list_xml_file ............   Passed    0.50 sec
+      Start 30: testinfo
+11/31 Test #10: sstinfo_list_env .................   Passed    0.51 sec
+      Start 31: testinfo
+12/31 Test #15: sstinfo_list_xml .................   Passed    0.50 sec
+13/31 Test #24: sstregister_a ....................   Passed    0.38 sec
+14/31 Test #29: testinfo .........................   Passed    0.19 sec
+15/31 Test #30: testinfo .........................   Passed    0.20 sec
+16/31 Test #31: testinfo .........................   Passed    0.20 sec
+17/31 Test #28: testinfo .........................   Passed    0.22 sec
+18/31 Test  #5: sst_heartbeat_0.1.30 .............   Passed    1.52 sec
+19/31 Test #27: sst_version ......................   Passed    1.55 sec
+20/31 Test  #7: sst_help .........................   Passed    2.54 sec
+21/31 Test  #6: sst_help-13.0 ....................   Passed    2.56 sec
+22/31 Test  #9: sstinfo_list_elem ................   Passed    3.06 sec
+23/31 Test  #1: sst_base .........................   Passed    6.68 sec
+24/31 Test #19: sst_output_dot ...................   Passed    6.71 sec
+25/31 Test #18: sst_output_config ................   Passed    6.71 sec
+26/31 Test #23: sst_print_timing_info ............   Passed    6.68 sec
+27/31 Test #21: sst_output_json ..................   Passed    6.73 sec
+28/31 Test #22: sst_output_prefix ................   Passed    6.74 sec
+29/31 Test #26: sst_sdlfile ......................   Passed    6.65 sec
+30/31 Test #17: sst_numthreads ...................   Passed    8.85 sec
+31/31 Test #20: sst_output_dot_verbosity .........   Passed   55.81 sec
+
+100% tests passed, 0 tests failed out of 31
+
+Label Time Summary:
+13.0    = 128.28 sec*proc (31 tests)
+
+Total Test time (real) =  55.86 sec

--- a/audit/251222/13.1.0.ctest
+++ b/audit/251222/13.1.0.ctest
@@ -1,0 +1,70 @@
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+      Start  1: sst_base
+      Start  2: sstconfig_help
+      Start  3: sstconfig_list_CXXFLAGS
+      Start  4: sstconfig_list
+      Start  5: sst_heartbeat_0.1.30
+      Start  6: sst_help-13.1
+      Start  7: sst_help
+      Start  8: sstinfo_help
+      Start  9: sstinfo_list_elem
+      Start 10: sstinfo_list_env
+      Start 11: sstinfo_list_nodisplay
+      Start 12: sstinfo_list_quiet
+      Start 13: sstinfo_list
+      Start 14: sstinfo_list_xml_file
+      Start 15: sstinfo_list_xml
+      Start 16: sstinfo_sst
+      Start 17: sst_numthreads
+      Start 18: sst_output_config
+      Start 19: sst_output_dot
+      Start 20: sst_output_dot_verbosity
+ 1/31 Test  #3: sstconfig_list_CXXFLAGS ..........   Passed    0.19 sec
+      Start 21: sst_output_json
+ 2/31 Test  #2: sstconfig_help ...................   Passed    0.21 sec
+      Start 22: sst_output_prefix
+ 3/31 Test  #4: sstconfig_list ...................   Passed    0.21 sec
+      Start 23: sst_print_timing_info
+ 4/31 Test  #8: sstinfo_help .....................   Passed    0.31 sec
+      Start 24: sstregister_a
+ 5/31 Test #16: sstinfo_sst ......................   Passed    0.31 sec
+      Start 25: sst_register_list
+ 6/31 Test #25: sst_register_list ................   Passed    0.15 sec
+      Start 26: sst_sdlfile
+ 7/31 Test #11: sstinfo_list_nodisplay ...........   Passed    0.47 sec
+      Start 27: sst_version
+ 8/31 Test #10: sstinfo_list_env .................   Passed    0.49 sec
+      Start 28: testinfo
+ 9/31 Test #12: sstinfo_list_quiet ...............   Passed    0.49 sec
+      Start 29: testinfo
+10/31 Test #14: sstinfo_list_xml_file ............   Passed    0.49 sec
+      Start 30: testinfo
+11/31 Test #13: sstinfo_list .....................   Passed    0.53 sec
+      Start 31: testinfo
+12/31 Test #15: sstinfo_list_xml .................   Passed    0.54 sec
+13/31 Test #29: testinfo .........................   Passed    0.18 sec
+14/31 Test #28: testinfo .........................   Passed    0.20 sec
+15/31 Test #31: testinfo .........................   Passed    0.18 sec
+16/31 Test #30: testinfo .........................   Passed    0.24 sec
+17/31 Test #24: sstregister_a ....................   Passed    0.45 sec
+18/31 Test  #5: sst_heartbeat_0.1.30 .............   Passed    1.87 sec
+19/31 Test #27: sst_version ......................   Passed    1.42 sec
+20/31 Test  #6: sst_help-13.1 ....................   Passed    2.78 sec
+21/31 Test  #7: sst_help .........................   Passed    2.80 sec
+22/31 Test  #9: sstinfo_list_elem ................   Passed    3.09 sec
+23/31 Test  #1: sst_base .........................   Passed    6.90 sec
+24/31 Test #18: sst_output_config ................   Passed    6.96 sec
+25/31 Test #23: sst_print_timing_info ............   Passed    6.77 sec
+26/31 Test #19: sst_output_dot ...................   Passed    6.98 sec
+27/31 Test #26: sst_sdlfile ......................   Passed    6.55 sec
+28/31 Test #21: sst_output_json ..................   Passed    6.84 sec
+29/31 Test #22: sst_output_prefix ................   Passed    6.84 sec
+30/31 Test #17: sst_numthreads ...................   Passed    9.11 sec
+31/31 Test #20: sst_output_dot_verbosity .........   Passed   56.43 sec
+
+100% tests passed, 0 tests failed out of 31
+
+Label Time Summary:
+13.1    = 130.99 sec*proc (31 tests)
+
+Total Test time (real) =  56.48 sec

--- a/audit/251222/14.0.0.ctest
+++ b/audit/251222/14.0.0.ctest
@@ -1,0 +1,72 @@
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+      Start  1: sst_base
+      Start  2: sstconfig_help
+      Start  3: sstconfig_list_CXXFLAGS
+      Start  4: sstconfig_list
+      Start  5: sst_heartbeat_0.1.30
+      Start  6: sst_help-14.0
+      Start  7: sst_help-MIN14.0
+      Start  8: sst_help
+      Start  9: sstinfo_help
+      Start 10: sstinfo_list_elem
+      Start 11: sstinfo_list_env
+      Start 12: sstinfo_list_nodisplay
+      Start 13: sstinfo_list_quiet
+      Start 14: sstinfo_list
+      Start 15: sstinfo_list_xml_file
+      Start 16: sstinfo_list_xml
+      Start 17: sstinfo_sst
+      Start 18: sst_numthreads
+      Start 19: sst_output_config
+      Start 20: sst_output_dot
+ 1/32 Test  #2: sstconfig_help ...................   Passed    0.19 sec
+      Start 21: sst_output_dot_verbosity
+ 2/32 Test  #4: sstconfig_list ...................   Passed    0.21 sec
+      Start 22: sst_output_json
+ 3/32 Test  #3: sstconfig_list_CXXFLAGS ..........   Passed    0.21 sec
+      Start 23: sst_output_prefix
+ 4/32 Test  #9: sstinfo_help .....................   Passed    0.32 sec
+      Start 24: sst_print_timing_info
+ 5/32 Test #17: sstinfo_sst ......................   Passed    0.33 sec
+      Start 25: sstregister_a
+ 6/32 Test #12: sstinfo_list_nodisplay ...........   Passed    0.50 sec
+      Start 26: sst_register_list
+ 7/32 Test #14: sstinfo_list .....................   Passed    0.52 sec
+      Start 27: sst_sdlfile
+ 8/32 Test #13: sstinfo_list_quiet ...............   Passed    0.53 sec
+      Start 28: sst_version
+ 9/32 Test #16: sstinfo_list_xml .................   Passed    0.52 sec
+      Start 29: testinfo
+10/32 Test #15: sstinfo_list_xml_file ............   Passed    0.53 sec
+      Start 30: testinfo
+11/32 Test #11: sstinfo_list_env .................   Passed    0.56 sec
+      Start 31: testinfo
+12/32 Test #26: sst_register_list ................   Passed    0.14 sec
+      Start 32: testinfo
+13/32 Test #29: testinfo .........................   Passed    0.18 sec
+14/32 Test #30: testinfo .........................   Passed    0.20 sec
+15/32 Test #31: testinfo .........................   Passed    0.19 sec
+16/32 Test #25: sstregister_a ....................   Passed    0.43 sec
+17/32 Test #32: testinfo .........................   Passed    0.19 sec
+18/32 Test  #5: sst_heartbeat_0.1.30 .............   Passed    1.78 sec
+19/32 Test #28: sst_version ......................   Passed    1.29 sec
+20/32 Test  #7: sst_help-MIN14.0 .................   Passed    2.63 sec
+21/32 Test  #8: sst_help .........................   Passed    2.65 sec
+22/32 Test  #6: sst_help-14.0 ....................   Passed    2.73 sec
+23/32 Test #10: sstinfo_list_elem ................   Passed    3.71 sec
+24/32 Test  #1: sst_base .........................   Passed    6.74 sec
+25/32 Test #22: sst_output_json ..................   Passed    6.68 sec
+26/32 Test #20: sst_output_dot ...................   Passed    6.88 sec
+27/32 Test #23: sst_output_prefix ................   Passed    6.73 sec
+28/32 Test #19: sst_output_config ................   Passed    6.92 sec
+29/32 Test #24: sst_print_timing_info ............   Passed    6.63 sec
+30/32 Test #27: sst_sdlfile ......................   Passed    6.43 sec
+31/32 Test #18: sst_numthreads ...................   Passed    9.11 sec
+32/32 Test #21: sst_output_dot_verbosity .........   Passed   56.89 sec
+
+100% tests passed, 0 tests failed out of 32
+
+Label Time Summary:
+14.0    = 133.56 sec*proc (32 tests)
+
+Total Test time (real) =  57.10 sec

--- a/audit/251222/14.1.0.ctest
+++ b/audit/251222/14.1.0.ctest
@@ -1,0 +1,84 @@
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+      Start  1: sst_base
+      Start  2: sstconfig_help
+      Start  3: sstconfig_list_CXXFLAGS
+      Start  4: sstconfig_list
+      Start  5: sst_heartbeat_0.1.30
+      Start  6: sst_heartbeat_1s
+      Start  7: sst_help-14.1
+      Start  8: sst_help-MIN14.0
+      Start  9: sst_help
+      Start 10: sstinfo_help
+      Start 11: sstinfo_list_elem
+      Start 12: sstinfo_list_env
+      Start 13: sstinfo_list_nodisplay
+      Start 14: sstinfo_list_quiet
+      Start 15: sstinfo_list
+      Start 16: sstinfo_list_xml_file
+      Start 17: sstinfo_list_xml
+      Start 18: sstinfo_sst
+      Start 19: sst_numthreads
+      Start 20: sst_output_config
+ 1/38 Test  #2: sstconfig_help ...................   Passed    0.19 sec
+      Start 21: sst_output_dot
+ 2/38 Test  #3: sstconfig_list_CXXFLAGS ..........   Passed    0.22 sec
+      Start 22: sst_output_dot_verbosity
+ 3/38 Test  #4: sstconfig_list ...................   Passed    0.22 sec
+      Start 23: sst_output_json
+ 4/38 Test #10: sstinfo_help .....................   Passed    0.32 sec
+      Start 24: sst_output_prefix
+ 5/38 Test #18: sstinfo_sst ......................   Passed    0.31 sec
+      Start 25: sst_print_timing_info
+ 6/38 Test #14: sstinfo_list_quiet ...............   Passed    0.50 sec
+      Start 26: sstregister_a
+ 7/38 Test #13: sstinfo_list_nodisplay ...........   Passed    0.51 sec
+      Start 27: sst_register_list
+ 8/38 Test #12: sstinfo_list_env .................   Passed    0.53 sec
+      Start 28: sst_sdlfile
+ 9/38 Test #15: sstinfo_list .....................   Passed    0.53 sec
+      Start 29: sst_version
+10/38 Test #17: sstinfo_list_xml .................   Passed    0.56 sec
+      Start 30: testinfo
+11/38 Test #16: sstinfo_list_xml_file ............   Passed    0.57 sec
+      Start 31: restart-heartbeat-14.1
+12/38 Test #27: sst_register_list ................   Passed    0.13 sec
+      Start 32: restart-interactive-14.1
+13/38 Test #30: testinfo .........................   Passed    0.20 sec
+      Start 33: restart-sigalrm-14.1
+14/38 Test #26: sstregister_a ....................   Passed    0.38 sec
+      Start 34: sigalrm_ckpt_comb
+15/38 Test #29: sst_version ......................   Passed    1.56 sec
+      Start 35: sigalrm
+16/38 Test  #7: sst_help-14.1 ....................   Passed    3.09 sec
+      Start 36: testinfo
+17/38 Test  #8: sst_help-MIN14.0 .................   Passed    3.14 sec
+      Start 37: testinfo
+18/38 Test  #9: sst_help .........................   Passed    3.17 sec
+      Start 38: testinfo
+19/38 Test #36: testinfo .........................   Passed    0.18 sec
+20/38 Test #37: testinfo .........................   Passed    0.17 sec
+21/38 Test #38: testinfo .........................   Passed    0.16 sec
+22/38 Test #11: sstinfo_list_elem ................   Passed    3.48 sec
+23/38 Test  #5: sst_heartbeat_0.1.30 .............   Passed    7.23 sec
+24/38 Test #20: sst_output_config ................   Passed    7.22 sec
+25/38 Test #23: sst_output_json ..................   Passed    7.06 sec
+26/38 Test #28: sst_sdlfile ......................   Passed    6.75 sec
+27/38 Test  #1: sst_base .........................   Passed    7.32 sec
+28/38 Test #25: sst_print_timing_info ............   Passed    6.99 sec
+29/38 Test #21: sst_output_dot ...................   Passed    7.13 sec
+30/38 Test #24: sst_output_prefix ................   Passed    7.04 sec
+31/38 Test #19: sst_numthreads ...................   Passed    9.45 sec
+32/38 Test #31: restart-heartbeat-14.1 ...........   Passed    9.23 sec
+33/38 Test #32: restart-interactive-14.1 .........   Passed   10.18 sec
+34/38 Test  #6: sst_heartbeat_1s .................   Passed   15.13 sec
+35/38 Test #34: sigalrm_ckpt_comb ................   Passed   22.46 sec
+36/38 Test #33: restart-sigalrm-14.1 .............   Passed   24.84 sec
+37/38 Test #35: sigalrm ..........................   Passed   23.70 sec
+38/38 Test #22: sst_output_dot_verbosity .........   Passed   56.23 sec
+
+100% tests passed, 0 tests failed out of 38
+
+Label Time Summary:
+14.1    = 248.09 sec*proc (38 tests)
+
+Total Test time (real) =  56.48 sec

--- a/audit/251222/15.0.0.ctest
+++ b/audit/251222/15.0.0.ctest
@@ -1,0 +1,102 @@
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+      Start  1: sst_base
+      Start  2: sst_checkpoint_name_format
+      Start  3: sstconfig_help
+      Start  4: sstconfig_list_CXXFLAGS
+      Start  5: sstconfig_list
+      Start  6: sst_heartbeat_0.1.30
+      Start  7: sst_heartbeat_1s
+      Start  8: sst_heartbeat_90s
+      Start  9: sst_help-15.0
+      Start 10: sst_help-MIN14.0
+      Start 11: sst_help
+      Start 12: sstinfo_help
+      Start 13: sstinfo_list_elem
+      Start 14: sstinfo_list_env
+      Start 15: sstinfo_list_nodisplay
+      Start 16: sstinfo_list_quiet
+      Start 17: sstinfo_list
+      Start 18: sstinfo_list_xml_file
+      Start 19: sstinfo_list_xml
+      Start 20: sstinfo_sst
+ 1/47 Test  #3: sstconfig_help ...................   Passed    0.19 sec
+      Start 21: sst_numthreads
+ 2/47 Test  #4: sstconfig_list_CXXFLAGS ..........   Passed    0.19 sec
+      Start 22: sst_output_config
+ 3/47 Test  #5: sstconfig_list ...................   Passed    0.20 sec
+      Start 23: sst_output_dir_config
+ 4/47 Test #12: sstinfo_help .....................   Passed    0.31 sec
+      Start 24: sst_output_dir_cpt
+ 5/47 Test #20: sstinfo_sst ......................   Passed    0.31 sec
+      Start 25: sst_output_dir_json
+ 6/47 Test #16: sstinfo_list_quiet ...............   Passed    0.53 sec
+      Start 26: sst_output_dir
+ 7/47 Test #15: sstinfo_list_nodisplay ...........   Passed    0.55 sec
+      Start 27: sst_output_dir_stats
+ 8/47 Test #14: sstinfo_list_env .................   Passed    0.56 sec
+      Start 28: sst_output_dot
+ 9/47 Test #17: sstinfo_list .....................   Passed    0.55 sec
+      Start 29: sst_output_dot_verbosity
+10/47 Test #19: sstinfo_list_xml .................   Passed    0.55 sec
+      Start 30: sst_output_json
+11/47 Test #18: sstinfo_list_xml_file ............   Passed    0.59 sec
+      Start 31: sst_output_prefix
+12/47 Test #11: sst_help .........................   Passed    3.18 sec
+      Start 32: sst_print_timing_info
+13/47 Test  #9: sst_help-15.0 ....................   Passed    3.22 sec
+      Start 33: sstregister_a
+14/47 Test #10: sst_help-MIN14.0 .................   Passed    3.23 sec
+      Start 34: sst_register_list
+15/47 Test #34: sst_register_list ................   Passed    0.12 sec
+      Start 35: sst_sdlfile
+16/47 Test #33: sstregister_a ....................   Passed    0.29 sec
+      Start 36: sst_version
+17/47 Test #13: sstinfo_list_elem ................   Passed    3.92 sec
+      Start 37: testinfo
+18/47 Test #37: testinfo .........................   Passed    0.19 sec
+      Start 38: restart-ckpt-with-sigalrm-15.0
+19/47 Test #36: sst_version ......................   Passed    1.07 sec
+      Start 39: restart-heartbeat
+20/47 Test  #1: sst_base .........................   Passed    7.29 sec
+      Start 40: restart-interactive
+21/47 Test  #6: sst_heartbeat_0.1.30 .............   Passed    7.42 sec
+      Start 41: restart-sigalrm-15.0
+22/47 Test  #8: sst_heartbeat_90s ................   Passed    7.42 sec
+      Start 42: sigalrm_ckpt_comb
+23/47 Test #22: sst_output_config ................   Passed    7.26 sec
+      Start 43: sigalrm
+24/47 Test #30: sst_output_json ..................   Passed    6.90 sec
+      Start 44: sigusr_interactive-15.0
+25/47 Test #31: sst_output_prefix ................   Passed    6.88 sec
+      Start 45: testinfo
+26/47 Test #28: sst_output_dot ...................   Passed    6.93 sec
+      Start 46: testinfo
+27/47 Test #46: testinfo .........................   Passed    0.20 sec
+      Start 47: testinfo
+28/47 Test #45: testinfo .........................   Passed    0.22 sec
+29/47 Test #47: testinfo .........................   Passed    0.17 sec
+30/47 Test #32: sst_print_timing_info ............   Passed    6.45 sec
+31/47 Test #35: sst_sdlfile ......................   Passed    6.36 sec
+32/47 Test #21: sst_numthreads ...................   Passed    9.56 sec
+33/47 Test  #2: sst_checkpoint_name_format .......   Passed   13.93 sec
+34/47 Test #39: restart-heartbeat ................   Passed   10.41 sec
+35/47 Test  #7: sst_heartbeat_1s .................   Passed   15.09 sec
+36/47 Test #44: sigusr_interactive-15.0 ..........   Passed    9.98 sec
+37/47 Test #40: restart-interactive ..............   Passed   10.45 sec
+38/47 Test #26: sst_output_dir ...................   Passed   25.64 sec
+39/47 Test #25: sst_output_dir_json ..............   Passed   25.97 sec
+40/47 Test #27: sst_output_dir_stats .............   Passed   25.75 sec
+41/47 Test #23: sst_output_dir_config ............   Passed   26.12 sec
+42/47 Test #24: sst_output_dir_cpt ...............   Passed   26.15 sec
+43/47 Test #38: restart-ckpt-with-sigalrm-15.0 ...   Passed   23.38 sec
+44/47 Test #42: sigalrm_ckpt_comb ................   Passed   22.57 sec
+45/47 Test #43: sigalrm ..........................   Passed   24.25 sec
+46/47 Test #41: restart-sigalrm-15.0 .............   Passed   24.49 sec
+47/47 Test #29: sst_output_dot_verbosity .........   Passed   56.95 sec
+
+100% tests passed, 0 tests failed out of 47
+
+Label Time Summary:
+15.0    = 433.93 sec*proc (47 tests)
+
+Total Test time (real) =  57.56 sec

--- a/audit/251222/15.1.0.ctest
+++ b/audit/251222/15.1.0.ctest
@@ -1,0 +1,140 @@
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+      Start  1: sst_base
+      Start  2: sst_checkpoint_name_format
+      Start  3: sstconfig_help
+      Start  4: sstconfig_list_CXXFLAGS
+      Start  5: sstconfig_list
+      Start  6: sst_heartbeat_0.1.30
+      Start  7: sst_heartbeat_1s
+      Start  8: sst_heartbeat_90s
+      Start  9: sst-help-15.1
+      Start 10: sst_help-MIN14.0
+      Start 11: sst_help
+      Start 12: sstinfo_help
+      Start 13: sstinfo_list_elem
+      Start 14: sstinfo_list_env
+      Start 15: sstinfo_list_nodisplay
+      Start 16: sstinfo_list_quiet
+      Start 17: sstinfo_list
+      Start 18: sstinfo_list_xml_file
+      Start 19: sstinfo_list_xml
+      Start 20: sstinfo_sst
+ 1/66 Test  #3: sstconfig_help ...................   Passed    0.22 sec
+      Start 21: sst_numthreads
+ 2/66 Test  #4: sstconfig_list_CXXFLAGS ..........   Passed    0.23 sec
+      Start 22: sst_output_config
+ 3/66 Test  #5: sstconfig_list ...................   Passed    0.28 sec
+      Start 23: sst_output_dir_config
+ 4/66 Test #12: sstinfo_help .....................   Passed    0.35 sec
+      Start 24: sst_output_dir_cpt
+ 5/66 Test #20: sstinfo_sst ......................   Passed    0.36 sec
+      Start 25: sst_output_dir_json
+ 6/66 Test #15: sstinfo_list_nodisplay ...........   Passed    0.59 sec
+      Start 26: sst_output_dir
+ 7/66 Test #17: sstinfo_list .....................   Passed    0.59 sec
+      Start 27: sst_output_dir_stats
+ 8/66 Test #16: sstinfo_list_quiet ...............   Passed    0.61 sec
+      Start 28: sst_output_dot
+ 9/66 Test #14: sstinfo_list_env .................   Passed    0.62 sec
+      Start 29: sst_output_dot_verbosity
+10/66 Test #18: sstinfo_list_xml_file ............   Passed    0.64 sec
+      Start 30: sst_output_json
+11/66 Test #19: sstinfo_list_xml .................   Passed    0.64 sec
+      Start 31: sst_output_prefix
+12/66 Test #11: sst_help .........................   Passed    3.44 sec
+      Start 32: sst_print_timing_info
+13/66 Test #10: sst_help-MIN14.0 .................   Passed    3.45 sec
+      Start 33: sstregister_a
+14/66 Test  #9: sst-help-15.1 ....................   Passed    3.45 sec
+      Start 34: sst_register_list
+15/66 Test #34: sst_register_list ................   Passed    0.13 sec
+      Start 35: sst_sdlfile
+16/66 Test #33: sstregister_a ....................   Passed    0.32 sec
+      Start 36: sst_version
+17/66 Test #13: sstinfo_list_elem ................   Passed    4.16 sec
+      Start 37: testinfo
+18/66 Test #37: testinfo .........................   Passed    0.26 sec
+      Start 38: restart-ckpt-with-heartbeat
+19/66 Test #36: sst_version ......................   Passed    1.12 sec
+      Start 39: restart-ckpt-with-interactive
+20/66 Test  #1: sst_base .........................   Passed    7.50 sec
+      Start 40: restart-heartbeat
+21/66 Test #22: sst_output_config ................   Passed    7.41 sec
+      Start 41: restart-interactive
+22/66 Test  #6: sst_heartbeat_0.1.30 .............   Passed    7.64 sec
+      Start 42: sigalrm_combined
+23/66 Test #28: sst_output_dot ...................   Passed    7.04 sec
+      Start 43: sigusr-interactive2
+24/66 Test  #8: sst_heartbeat_90s ................   Passed    7.69 sec
+      Start 44: sigusr-interactive-ckpt
+25/66 Test #30: sst_output_json ..................   Passed    7.09 sec
+      Start 45: sigusr-interactive
+26/66 Test #31: sst_output_prefix ................   Passed    7.09 sec
+      Start 46: testinfo
+27/66 Test #46: testinfo .........................   Passed    0.29 sec
+      Start 47: CaptCrunch_Interactive
+28/66 Test #32: sst_print_timing_info ............   Passed    6.48 sec
+      Start 48: CaptCrunch_Simple1
+29/66 Test #35: sst_sdlfile ......................   Passed    6.42 sec
+      Start 49: testinfo
+30/66 Test #21: sst_numthreads ...................   Passed    9.86 sec
+      Start 50: cmd-basic
+31/66 Test #49: testinfo .........................   Passed    0.24 sec
+      Start 51: cmd-ckptaction-err
+32/66 Test #47: CaptCrunch_Interactive ...........   Passed    2.31 sec
+      Start 52: cmd-cmp-types-false
+33/66 Test #51: cmd-ckptaction-err ...............   Passed    2.32 sec
+      Start 53: cmd-comments-short
+34/66 Test #50: cmd-basic ........................   Passed    2.56 sec
+      Start 54: cmd-comments-ws
+35/66 Test #52: cmd-cmp-types-false ..............   Passed    3.69 sec
+      Start 55: cmd-cond
+36/66 Test  #2: sst_checkpoint_name_format .......   Passed   14.60 sec
+      Start 56: cmd-default-ic
+37/66 Test #53: cmd-comments-short ...............   Passed    2.25 sec
+      Start 57: cmd-history
+38/66 Test #38: restart-ckpt-with-heartbeat ......   Passed   10.40 sec
+      Start 58: cmd-logging
+39/66 Test #39: restart-ckpt-with-interactive ....   Passed    9.97 sec
+      Start 59: cmd-replay2
+40/66 Test  #7: sst_heartbeat_1s .................   Passed   15.31 sec
+      Start 60: cmd-replay3
+41/66 Test #55: cmd-cond .........................   Passed    2.51 sec
+      Start 61: cmd-replay
+42/66 Test #56: cmd-default-ic ...................   Passed    2.51 sec
+      Start 62: cmd-replay-sync
+43/66 Test #57: cmd-history ......................   Passed    2.41 sec
+      Start 63: cmd-sanity
+44/66 Test #40: restart-heartbeat ................   Passed   10.38 sec
+      Start 64: cmd-set
+45/66 Test #41: restart-interactive ..............   Passed   10.54 sec
+      Start 65: cmd-setstr
+46/66 Test #44: sigusr-interactive-ckpt ..........   Passed   11.07 sec
+      Start 66: testinfo
+47/66 Test #45: sigusr-interactive ...............   Passed   11.06 sec
+48/66 Test #43: sigusr-interactive2 ..............   Passed   11.15 sec
+49/66 Test #66: testinfo .........................   Passed    0.37 sec
+50/66 Test #62: cmd-replay-sync ..................   Passed    2.56 sec
+51/66 Test #54: cmd-comments-ws ..................   Passed    7.73 sec
+52/66 Test #65: cmd-setstr .......................   Passed    2.61 sec
+53/66 Test #64: cmd-set ..........................   Passed    3.42 sec
+54/66 Test #23: sst_output_dir_config ............   Passed   26.71 sec
+55/66 Test #25: sst_output_dir_json ..............   Passed   26.60 sec
+56/66 Test #26: sst_output_dir ...................   Passed   26.38 sec
+57/66 Test #27: sst_output_dir_stats .............   Passed   26.44 sec
+58/66 Test #24: sst_output_dir_cpt ...............   Passed   26.74 sec
+59/66 Test #58: cmd-logging ......................   Passed   14.58 sec
+60/66 Test #48: CaptCrunch_Simple1 ...............   Passed   20.01 sec
+61/66 Test #61: cmd-replay .......................   Passed   13.87 sec
+62/66 Test #59: cmd-replay2 ......................   Passed   16.02 sec
+63/66 Test #63: cmd-sanity .......................   Passed   14.89 sec
+64/66 Test #60: cmd-replay3 ......................   Passed   17.22 sec
+65/66 Test #29: sst_output_dot_verbosity .........   Passed   56.98 sec
+66/66 Test #42: sigalrm_combined .................   Passed   65.73 sec
+
+100% tests passed, 0 tests failed out of 66
+
+Label Time Summary:
+15.1    = 590.14 sec*proc (66 tests)
+
+Total Test time (real) =  73.40 sec

--- a/audit/251222/info.audit
+++ b/audit/251222/info.audit
@@ -1,0 +1,13 @@
+Mon Dec 22 14:34:10 CST 2025
+gizmo.dev.tactcomplabs.com
+Linux gizmo.dev.tactcomplabs.com 4.18.0-477.10.1.el8_8.x86_64 #1 SMP Tue May 16 11:38:37 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
+On branch guard15.1
+Your branch is up to date with 'origin/guard15.1'.
+
+Untracked files:
+  (use "git add <file>..." to include in what will be committed)
+	./
+	../log
+
+nothing added to commit but untracked files present (use "git add" to track)
+9f5271e Special compile option for CaptCrunch so that newly supported mappable types do not break legacy testing.

--- a/audit/251222/log
+++ b/audit/251222/log
@@ -1,0 +1,1537 @@
+Running audit on gizmo.dev.tactcomplabs.com
+Audit directory is /scratch/kgriesser/work/sst-ext-tests/audit/251222/scratch/kgriesser/work/sst-ext-tests/audit/251222 /scratch/kgriesser/work/sst-ext-tests/audit/251222
+Current version of the local SST config is: 
+SST local configuration not found for verison 15.1.0. Creating one.
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| Test                                          | MinVer | MaxVer | Desc                                                                                                           |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| sst-help-15.1                                 | 15.1   | 15.1   | Displays the help menu of SST 15.1                                                                             |
+| sst_base                                      | 13.0   | None   | Basic execution test suitable for all versions of SST                                                          |
+| sst_checkpoint_name_format                    | 15.0   | None   | Tests custom naming of checkpoint directories and files                                                        |
+| sst_heartbeat_0.1.30                          | 13.0   | None   | Tests a 90 second heartbeat using %H:%M:%S syntax                                                              |
+| sst_heartbeat_90s                             | 15.0   | None   | Tests a 90 second heartbeat using seconds-only syntax                                                          |
+| sst_help-13.0                                 | 13.0   | 13.0   | Displays help menu for SST 13.0                                                                                |
+| sst_help-13.1                                 | 13.1   | 13.1   | Displays the help menu of SST 13.1                                                                             |
+| sst_help-14.0                                 | 14.0   | 14.0   | Displays the help menu of the SST 14.0                                                                         |
+| sst_help-14.1                                 | 14.1   | 14.1   | Displays the help menu of SST 14.1                                                                             |
+| sst_help-15.0                                 | 15.0   | 15.0   | Displays the help menu of SST 15.0                                                                             |
+| sst_help-MIN14.0                              | 14.0   | None   | Displays the help menu for SST versions of minimum of SST 14.0                                                 |
+| sst_help                                      | 13.0   | None   | Displays the help menu for all versions of SST                                                                 |
+| sst_numthreads                                | 13.0   | None   | Tests the num_threads option for executing a basic SDL file                                                    |
+| sst_output_config                             | 13.0   | None   | Tests outputting the config file back to a python script                                                       |
+| sst_output_dir                                | 15.0   | None   | Tests basic directory creation using --output-directory                                                        |
+| sst_output_dir_config                         | 15.0   | None   | Tests relocation of config files                                                                               |
+| sst_output_dir_cpt                            | 15.0   | None   | Tests relocation of checkpoint files                                                                           |
+| sst_output_dir_json                           | 15.0   | None   | Tests relocation of JSON config files                                                                          |
+| sst_output_dir_stats                          | 15.0   | None   | Tests statistics output file creation using --output-directory                                                 |
+| sst_output_dot                                | 13.0   | None   | Tests outputting the config graph as a dot file                                                                |
+| sst_output_dot_verbosity                      | 13.0   | None   | Tests outputting config graph graph data to a dot file with verbosity                                          |
+| sst_output_json                               | 13.0   | None   | Tests outptting the config graph to JSON                                                                       |
+| sst_output_prefix                             | 13.0   | None   | Tests outputting files with a prefix                                                                           |
+| sst_print_timing_info                         | 13.0   | None   | Tests printing the runtime timing info                                                                         |
+| sst_register_list                             | 13.0   | None   | Tests listing the registered sst component libraries                                                           |
+| sst_sdlfile                                   | 13.0   | None   | Tests the SDL file runtime option                                                                              |
+| sst_version                                   | 13.0   | None   | Tests printing the SST version info                                                                            |
+| sstconfig_help                                | 13.0   | None   | Tests printing the sst-config help menu                                                                        |
+| sstconfig_list                                | 13.0   | None   | Tests the baseline sst-config                                                                                  |
+| sstconfig_list_CXXFLAGS                       | 13.0   | None   | Tests printing the CXXFLAGS sst-config option                                                                  |
+| sstinfo_help                                  | 13.0   | None   | Tests the sst-info help menu                                                                                   |
+| sstinfo_list                                  | 13.0   | None   | Tests the output of the basic sst-info command                                                                 |
+| sstinfo_list_elem                             | 13.0   | None   | Tests printing sst-info for all the appropriate ELEMENT LIBRARY values                                         |
+| sstinfo_list_env                              | 13.0   | None   | Tests the sst-info print-env command option                                                                    |
+| sstinfo_list_nodisplay                        | 13.0   | None   | Tests the sst-info no info option                                                                              |
+| sstinfo_list_quiet                            | 13.0   | None   | Tests the sst-info quiet option                                                                                |
+| sstinfo_list_xml                              | 13.0   | None   | Tests the sst-info xml output                                                                                  |
+| sstinfo_list_xml_file                         | 13.0   | None   | Tests the sst-info XML output with a specified file                                                            |
+| sstinfo_sst                                   | 13.0   | None   | Tests the output of the basic sst-info sst command                                                             |
+| sstregister_a                                 | 13.0   | None   | Tests the known failure of the sst-register -a option                                                          |
+| testinfo                                      | None   | None   | Provide information on local tests                                                                             |
+| sst_heartbeat_1s                              | 14.1   | None   | Tests a 1 second heartbeat                                                                                     |
+| test_Checkpoint-DEV                           | None   | None   | Tests checkpointing                                                                                            |
+| test_Component-DEV                            | None   | None   | Tests component loading with checkpointing                                                                     |
+| test_Component_createStats-DEV                | None   | None   | Tests statistics with checkpointing                                                                            |
+| test_Component_enableAllStats-DEV             | None   | None   | Tests enabling all stats with checkpointing                                                                    |
+| test_Component_setStats-DEV                   | None   | None   | Tests setting stats with checkpointing                                                                         |
+| test_Component_time_overflow-DEV              | None   | None   | Tests time overflow with checkpointing                                                                         |
+| test_Links-DEV                                | None   | None   | Tests link handlers with checkpointing                                                                         |
+| test_MemPool_overflow-DEV                     | None   | None   | Tests mempooling overflowo with checkpointing                                                                  |
+| test_MemPool_undeleted_items-DEV              | None   | None   | Tests mempooling undeleted items with checkpointing                                                            |
+| test_MessageMesh-DEV                          | None   | None   | Tests message mesh routing with checkpointing                                                                  |
+| test_Module-DEV                               | None   | None   | Tests the module loader with checkpointing                                                                     |
+| test_Output-DEV                               | None   | None   | Tests the outputter with checkpointing                                                                         |
+| test_ParallelLoad-DEV                         | None   | None   | Tests parallel loading with checkpointing                                                                      |
+| test_ParamComponent-DEV                       | None   | None   | Tests component parameter loading with checkpointing                                                           |
+| test_PerfComponent-DEV                        | None   | None   | Tests perf component with checkpointing                                                                        |
+| test_PythonUnitAlgebra-DEV                    | None   | None   | Tests Python unit algebra with checkpointing                                                                   |
+| test_RNGComponent_marsaglia-DEV               | None   | None   | Tests the RNG marsaglia with checkpointing                                                                     |
+| test_RNGComponent_mersenne-DEV                | None   | None   | Tests the RNG mersenne with checkpointing                                                                      |
+| test_RNGComponent_xorshift-DEV                | None   | None   | Tests RNG xorshift with checkpointing                                                                          |
+| test_Serialization_ATOMIC-DEV                 | None   | None   | Tests the basic serialization with ATOMIC types and checkpointing                                              |
+| test_Serialization_COMPONENTINFO-DEV          | None   | None   | Tests the basic serialization with COMPONENT INFO types and checkpointing                                      |
+| test_Serialization_HANDLER-DEV                | None   | None   | Tests the basic serialization with HANDLER types and checkpointing                                             |
+| test_Serialization_MAPTOVECTOR-DEV            | None   | None   | Tests the basic serialization with MAP TO VECTOR types and checkpointing                                       |
+| test_Serialization_ORDERED_CONTAINERS-DEV     | None   | None   | Tests the basic serialization with ORDERED CONTAINERS types and checkpointing                                  |
+| test_Serialization_POD-DEV                    | None   | None   | Tests the basic serialization with POD types and checkpointing                                                 |
+| test_Serialization_PODPTR-DEV                 | None   | None   | Tests the basic serialization with PODPTR types and checkpointing                                              |
+| test_Serialization_POINTERTRACKING-DEV        | None   | None   | Tests the basic serialization with POINTER TRACKING types and checkpointing                                    |
+| test_Serialization_UNORDERED_CONTAINERS-DEV   | None   | None   | Tests the basic serialization with UNORDERED CONTAINERS types and checkpointing                                |
+| test_SharedObject-DEV                         | None   | None   | Tests shared object loading with checkpointing                                                                 |
+| test_StatisticsComponent-DEV                  | None   | None   | Tests statistics with integers and checkpointing                                                               |
+| test_StatisticsComponent_basic-DEV            | None   | None   | None                                                                                                           |
+| test_SubComponent-DEV                         | None   | None   | Tests subcomponent loading with checkpointing                                                                  |
+| test_SubComponent_2-DEV                       | None   | None   | None                                                                                                           |
+| cmd-replay3                                   | 15.1   | None   | Debug replay from file and check we get a prompt                                                               |
+| cmd-setstr                                    | 15.1   | None   | Check set string with spaces                                                                                   |
+| type-pair                                     | DEV    | None   | short std::pair watch test                                                                                     |
+| cmd-ckptaction                                | NEW    | None   | Check that trace checkpoint action triggers checkpoints                                                        |
+| cmd-watch                                     | NEW    | None   | Check watch commands with different trigger types                                                              |
+| cmd-multithread-NEW                           | NEW    | None   | Test basic thread commands: thread, info                                                                       |
+| type-aggregate                                | DEV    | None   | Exercise aggregate types                                                                                       |
+| type-stack                                    | DEV    | None   | Exercise std::stack<unsigned>                                                                                  |
+| type-queue                                    | DEV    | None   | Exercise std::queue<unsigned>                                                                                  |
+| cmd-cond                                      | 15.1   | None   | Basic check for simple conditional watch trigger                                                               |
+| cmd-replay                                    | 15.1   | None   | Replay file from inside debug console                                                                          |
+| cmd-sanity                                    | 15.1   | None   | Enter interactive mode, change an internal variable and confirm it has been change                             |
+| testinfo                                      | None   | None   | Provide information on local tests                                                                             |
+| type-tuple                                    | DEV    | None   | Exercise std::pair and std::tuple                                                                              |
+| cmd-actions                                   | NEW    | None   | Check for interactive, printTrace, printStatus, and set actions                                                |
+| cmd-handler                                   | NEW    | None   | Check setHandler commands with trace                                                                           |
+| cmd-unwatch                                   | NEW    | None   | Check interactive console unwatch command                                                                      |
+| cmd-basic                                     | 15.1   | None   | Basic interactive command check: cd, ls, pwd, run, continue                                                    |
+| cmd-multithread-serial-NEW                    | NEW    | None   | Test basic thread commands in serial exec: thread, info                                                        |
+| type-queue-1                                  | DEV    | None   | Exercise std::queue<unsigned> with one component                                                               |
+| cmd-ckptaction-err                            | 15.1   | None   | Check checkpoint action triggers error when checkpoint not enabled                                             |
+| cmd-cmp-types-false                           | 15.1   | None   | Test comparisons for different types: all false                                                                |
+| cmd-comments-ws                               | 15.1   | None   | Check that comments have no effect in replay file                                                              |
+| cmd-default-ic                                | 15.1   | None   | Tests use of default IC with interactive-start                                                                 |
+| cmd-define                                    | NEW    | None   | Exercise std::bitset and std::vector<bool>                                                                     |
+| cmd-help                                      | NEW    | None   | Walk through help commands                                                                                     |
+| cmd-history                                   | 15.1   | None   | Log history to file and check it                                                                               |
+| cmd-logging                                   | 15.1   | None   | Log debug commands to an external file                                                                         |
+| cmd-multithread-8thds-NEW                     | NEW    | None   | Test basic thread commands: thread, info                                                                       |
+| cmd-multithread-actions-NEW                   | NEW    | None   | Test trace actions in thread1                                                                                  |
+| cmd-multithread-shutdown-NEW                  | NEW    | None   | Test trace actions in thread1                                                                                  |
+| cmd-print-NEW                                 | NEW    | None   | Check for seg fault with recursive print                                                                       |
+| cmd-replay-sync                               | 15.1   | None   | Conditional watch trigger replayed from file                                                                   |
+| cmd-replay2                                   | 15.1   | None   | Replay session using SST command line option                                                                   |
+| cmd-set                                       | 15.1   | None   | Check for set and print commands                                                                               |
+| type-bitset                                   | NEW    | None   | Exercise std::bitset and std::vector<bool>                                                                     |
+| cmd-cmp-types-true                            | NEW    | None   | Test comparisons for different types: all true                                                                 |
+| cmd-trace                                     | NEW    | None   | Check for trace commands: trace, printWatchpoint, addTraceVar, printTrace, resetTrace, unwatch, quit           |
+| cmd-comments-short                            | 15.1   | None   | Check that comments have no effect in replay file                                                              |
+| type-priority-queue                           | DEV    | None   | Exercise std::priority_queue<unsigned>                                                                         |
+| mpi-sdl-ALL                                   | None   | None   | Sample test input file                                                                                         |
+| mpi-sdl-DEV                                   | None   | None   | Sample test input file                                                                                         |
+| restart-ckpt-with-sigalrm-15.0                | 15.0   | 15.0   | Tests checkpoint with sigalrm to see if the sigalrm is carried over to restart (i.e. load-checkpoint)          |
+| restart-heartbeat-14.1                        | 14.1   | 14.1   | Tests using sigalrm with restart (i.e. load checkpoint)                                                        |
+| restart-interactive-14.1                      | 14.1   | 14.1   | Tests using interactive console with restart (i.e. load checkpoint)                                            |
+| restart-sigalrm-14.1                          | 14.1   | 14.1   | Tests using sigalrm with restart (i.e. load checkpoint)                                                        |
+| testinfo                                      | None   | None   | Provide information on local tests                                                                             |
+| restart-ckpt-with-heartbeat                   | 15.1   | None   | Tests restart for a checkpoint that had heartbeat to see if the heartbeat is carried over.                     |
+| restart-ckpt-with-sigalrm-NEW                 | NEW    | None   | Tests checkpoint with sigalrm to see if the sigalrm is carried over to restart (i.e. load-checkpoint)          |
+| restart-ckpt-with-interactive-prefix-path-NEW | NEW    | None   | Tests expected fail for passing path to checkpoint-prefix.                                                     |
+| restart-ckpt-with-interactive                 | 15.1   | None   | Tests restart for a checkpoint that had interactive console to see if the interactive console is carried over. |
+| restart-sigalrm-15.0                          | 15.0   | 15.0   | Tests using sigalrm with restart (i.e. load checkpoint)                                                        |
+| restart-sigalrm-NEW                           | NEW    | None   | Tests using sigalrm with restart (i.e. load checkpoint)                                                        |
+| sigalrm-NEW                                   | NEW    | None   | Tests sigalrm for single real time actions                                                                     |
+| sigalrm                                       | 14.1   | 15.0   | Tests sigalrm for single real time actions                                                                     |
+| sigalrm_ckpt_comb-NEW                         | NEW    | None   | Tests sigalrm for checkpoint combined with other real time actions                                             |
+| sigalrm_ckpt_comb                             | 14.1   | 15.0   | Tests sigalrm for checkpoint combined with other real time actions                                             |
+| sigusr-NEW                                    | NEW    | None   | Tests sigusr1/2 for single real time actions                                                                   |
+| restart-heartbeat                             | 15.0   | None   | Tests using sigalrm with restart (i.e. load checkpoint)                                                        |
+| restart-interactive                           | 15.0   | None   | Tests using interactive console with restart (i.e. load checkpoint)                                            |
+| sigalrm_combined                              | 15.1   | None   | Tests sigalrm for combinations of two real time actions (checkpoint not included)                              |
+| restart-ckpt-with-sigalrm                     | NEW    | None   | Tests checkpoint with sigalrm to see if the sigalrm is carried over to restart (i.e. load-checkpoint)          |
+| sigusr-interactive-ckpt                       | 15.1   | None   | Tests sigusr1/2 with default interactive console w/checkpoint                                                  |
+| sigusr-interactive                            | 15.1   | None   | Tests sigusr1/2 with interactive console real time action                                                      |
+| sigusr-interactive2                           | 15.1   | None   | Tests sigusr1/2 with default interactive console & real time action                                            |
+| sigusr-prefix-path-NEW                        | NEW    | None   | Tests sigusr1/2 expected fail when passing path to checkpoint-directory                                        |
+| sigusr_interactive-15.0                       | 15.0   | 15.0   | Tests sigusr1/2 with interactive console real time action                                                      |
+| CaptCrunch_Interactive                        | 15.1   | None   | Tests CaptCrunch simple data integrity                                                                         |
+| CaptCrunch_Simple1                            | 15.1   | None   | Tests CaptCrunch simple data integrity                                                                         |
+| testinfo                                      | None   | None   | Provide information on local tests                                                                             |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+/scratch/kgriesser/work/sst-ext-tests/build
+
+### Checking test selection for sst version 13.0 ###
+
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+  Test  #1: sst_base
+  Test  #2: sstconfig_help
+  Test  #3: sstconfig_list_CXXFLAGS
+  Test  #4: sstconfig_list
+  Test  #5: sst_heartbeat_0.1.30
+  Test  #6: sst_help-13.0
+  Test  #7: sst_help
+  Test  #8: sstinfo_help
+  Test  #9: sstinfo_list_elem
+  Test #10: sstinfo_list_env
+  Test #11: sstinfo_list_nodisplay
+  Test #12: sstinfo_list_quiet
+  Test #13: sstinfo_list
+  Test #14: sstinfo_list_xml_file
+  Test #15: sstinfo_list_xml
+  Test #16: sstinfo_sst
+  Test #17: sst_numthreads
+  Test #18: sst_output_config
+  Test #19: sst_output_dot
+  Test #20: sst_output_dot_verbosity
+  Test #21: sst_output_json
+  Test #22: sst_output_prefix
+  Test #23: sst_print_timing_info
+  Test #24: sstregister_a
+  Test #25: sst_register_list
+  Test #26: sst_sdlfile
+  Test #27: sst_version
+  Test #28: testinfo
+  Test #29: testinfo
+  Test #30: testinfo
+  Test #31: testinfo
+
+Total Tests: 31
+
+### Checking test selection for sst version 13.1 ###
+
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+  Test  #1: sst_base
+  Test  #2: sstconfig_help
+  Test  #3: sstconfig_list_CXXFLAGS
+  Test  #4: sstconfig_list
+  Test  #5: sst_heartbeat_0.1.30
+  Test  #6: sst_help-13.1
+  Test  #7: sst_help
+  Test  #8: sstinfo_help
+  Test  #9: sstinfo_list_elem
+  Test #10: sstinfo_list_env
+  Test #11: sstinfo_list_nodisplay
+  Test #12: sstinfo_list_quiet
+  Test #13: sstinfo_list
+  Test #14: sstinfo_list_xml_file
+  Test #15: sstinfo_list_xml
+  Test #16: sstinfo_sst
+  Test #17: sst_numthreads
+  Test #18: sst_output_config
+  Test #19: sst_output_dot
+  Test #20: sst_output_dot_verbosity
+  Test #21: sst_output_json
+  Test #22: sst_output_prefix
+  Test #23: sst_print_timing_info
+  Test #24: sstregister_a
+  Test #25: sst_register_list
+  Test #26: sst_sdlfile
+  Test #27: sst_version
+  Test #28: testinfo
+  Test #29: testinfo
+  Test #30: testinfo
+  Test #31: testinfo
+
+Total Tests: 31
+
+### Checking test selection for sst version 14.0 ###
+
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+  Test  #1: sst_base
+  Test  #2: sstconfig_help
+  Test  #3: sstconfig_list_CXXFLAGS
+  Test  #4: sstconfig_list
+  Test  #5: sst_heartbeat_0.1.30
+  Test  #6: sst_help-14.0
+  Test  #7: sst_help-MIN14.0
+  Test  #8: sst_help
+  Test  #9: sstinfo_help
+  Test #10: sstinfo_list_elem
+  Test #11: sstinfo_list_env
+  Test #12: sstinfo_list_nodisplay
+  Test #13: sstinfo_list_quiet
+  Test #14: sstinfo_list
+  Test #15: sstinfo_list_xml_file
+  Test #16: sstinfo_list_xml
+  Test #17: sstinfo_sst
+  Test #18: sst_numthreads
+  Test #19: sst_output_config
+  Test #20: sst_output_dot
+  Test #21: sst_output_dot_verbosity
+  Test #22: sst_output_json
+  Test #23: sst_output_prefix
+  Test #24: sst_print_timing_info
+  Test #25: sstregister_a
+  Test #26: sst_register_list
+  Test #27: sst_sdlfile
+  Test #28: sst_version
+  Test #29: testinfo
+  Test #30: testinfo
+  Test #31: testinfo
+  Test #32: testinfo
+
+Total Tests: 32
+
+### Checking test selection for sst version 14.1 ###
+
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+  Test  #1: sst_base
+  Test  #2: sstconfig_help
+  Test  #3: sstconfig_list_CXXFLAGS
+  Test  #4: sstconfig_list
+  Test  #5: sst_heartbeat_0.1.30
+  Test  #6: sst_heartbeat_1s
+  Test  #7: sst_help-14.1
+  Test  #8: sst_help-MIN14.0
+  Test  #9: sst_help
+  Test #10: sstinfo_help
+  Test #11: sstinfo_list_elem
+  Test #12: sstinfo_list_env
+  Test #13: sstinfo_list_nodisplay
+  Test #14: sstinfo_list_quiet
+  Test #15: sstinfo_list
+  Test #16: sstinfo_list_xml_file
+  Test #17: sstinfo_list_xml
+  Test #18: sstinfo_sst
+  Test #19: sst_numthreads
+  Test #20: sst_output_config
+  Test #21: sst_output_dot
+  Test #22: sst_output_dot_verbosity
+  Test #23: sst_output_json
+  Test #24: sst_output_prefix
+  Test #25: sst_print_timing_info
+  Test #26: sstregister_a
+  Test #27: sst_register_list
+  Test #28: sst_sdlfile
+  Test #29: sst_version
+  Test #30: testinfo
+  Test #31: restart-heartbeat-14.1
+  Test #32: restart-interactive-14.1
+  Test #33: restart-sigalrm-14.1
+  Test #34: sigalrm_ckpt_comb
+  Test #35: sigalrm
+  Test #36: testinfo
+  Test #37: testinfo
+  Test #38: testinfo
+
+Total Tests: 38
+
+### Checking test selection for sst version 15.0 ###
+
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+  Test  #1: sst_base
+  Test  #2: sst_checkpoint_name_format
+  Test  #3: sstconfig_help
+  Test  #4: sstconfig_list_CXXFLAGS
+  Test  #5: sstconfig_list
+  Test  #6: sst_heartbeat_0.1.30
+  Test  #7: sst_heartbeat_1s
+  Test  #8: sst_heartbeat_90s
+  Test  #9: sst_help-15.0
+  Test #10: sst_help-MIN14.0
+  Test #11: sst_help
+  Test #12: sstinfo_help
+  Test #13: sstinfo_list_elem
+  Test #14: sstinfo_list_env
+  Test #15: sstinfo_list_nodisplay
+  Test #16: sstinfo_list_quiet
+  Test #17: sstinfo_list
+  Test #18: sstinfo_list_xml_file
+  Test #19: sstinfo_list_xml
+  Test #20: sstinfo_sst
+  Test #21: sst_numthreads
+  Test #22: sst_output_config
+  Test #23: sst_output_dir_config
+  Test #24: sst_output_dir_cpt
+  Test #25: sst_output_dir_json
+  Test #26: sst_output_dir
+  Test #27: sst_output_dir_stats
+  Test #28: sst_output_dot
+  Test #29: sst_output_dot_verbosity
+  Test #30: sst_output_json
+  Test #31: sst_output_prefix
+  Test #32: sst_print_timing_info
+  Test #33: sstregister_a
+  Test #34: sst_register_list
+  Test #35: sst_sdlfile
+  Test #36: sst_version
+  Test #37: testinfo
+  Test #38: restart-ckpt-with-sigalrm-15.0
+  Test #39: restart-heartbeat
+  Test #40: restart-interactive
+  Test #41: restart-sigalrm-15.0
+  Test #42: sigalrm_ckpt_comb
+  Test #43: sigalrm
+  Test #44: sigusr_interactive-15.0
+  Test #45: testinfo
+  Test #46: testinfo
+  Test #47: testinfo
+
+Total Tests: 47
+
+### Checking test selection for sst version 15.1 ###
+
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+  Test  #1: sst_base
+  Test  #2: sst_checkpoint_name_format
+  Test  #3: sstconfig_help
+  Test  #4: sstconfig_list_CXXFLAGS
+  Test  #5: sstconfig_list
+  Test  #6: sst_heartbeat_0.1.30
+  Test  #7: sst_heartbeat_1s
+  Test  #8: sst_heartbeat_90s
+  Test  #9: sst-help-15.1
+  Test #10: sst_help-MIN14.0
+  Test #11: sst_help
+  Test #12: sstinfo_help
+  Test #13: sstinfo_list_elem
+  Test #14: sstinfo_list_env
+  Test #15: sstinfo_list_nodisplay
+  Test #16: sstinfo_list_quiet
+  Test #17: sstinfo_list
+  Test #18: sstinfo_list_xml_file
+  Test #19: sstinfo_list_xml
+  Test #20: sstinfo_sst
+  Test #21: sst_numthreads
+  Test #22: sst_output_config
+  Test #23: sst_output_dir_config
+  Test #24: sst_output_dir_cpt
+  Test #25: sst_output_dir_json
+  Test #26: sst_output_dir
+  Test #27: sst_output_dir_stats
+  Test #28: sst_output_dot
+  Test #29: sst_output_dot_verbosity
+  Test #30: sst_output_json
+  Test #31: sst_output_prefix
+  Test #32: sst_print_timing_info
+  Test #33: sstregister_a
+  Test #34: sst_register_list
+  Test #35: sst_sdlfile
+  Test #36: sst_version
+  Test #37: testinfo
+  Test #38: restart-ckpt-with-heartbeat
+  Test #39: restart-ckpt-with-interactive
+  Test #40: restart-heartbeat
+  Test #41: restart-interactive
+  Test #42: sigalrm_combined
+  Test #43: sigusr-interactive2
+  Test #44: sigusr-interactive-ckpt
+  Test #45: sigusr-interactive
+  Test #46: testinfo
+  Test #47: CaptCrunch_Interactive
+  Test #48: CaptCrunch_Simple1
+  Test #49: testinfo
+  Test #50: cmd-basic
+  Test #51: cmd-ckptaction-err
+  Test #52: cmd-cmp-types-false
+  Test #53: cmd-comments-short
+  Test #54: cmd-comments-ws
+  Test #55: cmd-cond
+  Test #56: cmd-default-ic
+  Test #57: cmd-history
+  Test #58: cmd-logging
+  Test #59: cmd-replay2
+  Test #60: cmd-replay3
+  Test #61: cmd-replay
+  Test #62: cmd-replay-sync
+  Test #63: cmd-sanity
+  Test #64: cmd-set
+  Test #65: cmd-setstr
+  Test #66: testinfo
+
+Total Tests: 66
+
+### Checking test selection for sst version DEV ###
+
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+  Test  #1: sst_base
+  Test  #2: sst_checkpoint_name_format
+  Test  #3: sstconfig_help
+  Test  #4: sstconfig_list_CXXFLAGS
+  Test  #5: sstconfig_list
+  Test  #6: sst_heartbeat_0.1.30
+  Test  #7: sst_heartbeat_1s
+  Test  #8: sst_heartbeat_90s
+  Test  #9: sst_help-MIN14.0
+  Test #10: sst_help
+  Test #11: sstinfo_help
+  Test #12: sstinfo_list_elem
+  Test #13: sstinfo_list_env
+  Test #14: sstinfo_list_nodisplay
+  Test #15: sstinfo_list_quiet
+  Test #16: sstinfo_list
+  Test #17: sstinfo_list_xml_file
+  Test #18: sstinfo_list_xml
+  Test #19: sstinfo_sst
+  Test #20: sst_numthreads
+  Test #21: sst_output_config
+  Test #22: sst_output_dir_config
+  Test #23: sst_output_dir_cpt
+  Test #24: sst_output_dir_json
+  Test #25: sst_output_dir
+  Test #26: sst_output_dir_stats
+  Test #27: sst_output_dot
+  Test #28: sst_output_dot_verbosity
+  Test #29: sst_output_json
+  Test #30: sst_output_prefix
+  Test #31: sst_print_timing_info
+  Test #32: sstregister_a
+  Test #33: sst_register_list
+  Test #34: sst_sdlfile
+  Test #35: sst_version
+  Test #36: testinfo
+  Test #37: restart-ckpt-with-heartbeat
+  Test #38: restart-ckpt-with-interactive
+  Test #39: restart-heartbeat
+  Test #40: restart-interactive
+  Test #41: sigalrm_combined
+  Test #42: sigusr-interactive2
+  Test #43: sigusr-interactive-ckpt
+  Test #44: sigusr-interactive
+  Test #45: testinfo
+  Test #46: CaptCrunch_Interactive
+  Test #47: CaptCrunch_Simple1
+  Test #48: testinfo
+  Test #49: cmd-basic
+  Test #50: cmd-ckptaction-err
+  Test #51: cmd-cmp-types-false
+  Test #52: cmd-comments-short
+  Test #53: cmd-comments-ws
+  Test #54: cmd-cond
+  Test #55: cmd-default-ic
+  Test #56: cmd-history
+  Test #57: cmd-logging
+  Test #58: cmd-replay2
+  Test #59: cmd-replay3
+  Test #60: cmd-replay
+  Test #61: cmd-replay-sync
+  Test #62: cmd-sanity
+  Test #63: cmd-set
+  Test #64: cmd-setstr
+  Test #65: testinfo
+  Test #66: type-aggregate
+  Test #67: type-pair
+  Test #68: type-priority-queue
+  Test #69: type-queue-1
+  Test #70: type-queue
+  Test #71: type-stack
+  Test #72: type-tuple
+
+Total Tests: 72
+/scratch/kgriesser/work/sst-ext-tests/audit/251222
+/scratch/kgriesser/work/sst-ext-tests/build /scratch/kgriesser/work/sst-ext-tests/audit/251222
+
+### Loading sst/13.0.0 ###
+
+Current version of the local SST config is: 
+SST local configuration not found for verison 13.0.0. Creating one.
+SST-Core Version (13.0.0)
+13.0.0
+-- The CXX compiler identification is GNU 12.2.0
+-- Detecting CXX compiler ABI info
+-- Detecting CXX compiler ABI info - done
+-- Check for working CXX compiler: /opt/ohpc/pub/compiler/gcc/12.2.0/bin/c++ - skipped
+-- Detecting CXX compile features
+-- Detecting CXX compile features - done
+-- SST-Core Version (13.0.0)
+-- SST MAJOR VERSION=13
+-- SST MINOR VERSION=0
+-- SST FULL VERSION=13.0
+-- Found MPI_CXX: /scratch/opt/ohpc/pub/mpi/openmpi4-gnu12/4.1.4/lib/libmpi_cxx.so (found version "3.1") 
+-- Found MPI: TRUE (found version "3.1")  
+-- MPI RUN COMMAND=/opt/ohpc/pub/mpi/openmpi4-gnu12/4.1.4/bin/mpiexec
+-- SST-EXT-TESTS ENV{SST_COMPONENT_BASE}=/scratch/kgriesser/work/sst-ext-tests/build/components
+-- CaptCrunch is supported only for sst 15.0 or newer
+-- core-debug component is supported only for sst 15.1 or newer
+-- Checking /scratch/kgriesser/work/sst-ext-tests/tests/cli for tests supporting 13.0
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/cli: sst_base.sh;sstconfig_help.sh;sstconfig_list_CXXFLAGS.sh;sstconfig_list.sh;sst_heartbeat_0.1.30.sh;sst_help-13.0.sh;sst_help.sh;sstinfo_help.sh;sstinfo_list_elem.sh;sstinfo_list_env.sh;sstinfo_list_nodisplay.sh;sstinfo_list_quiet.sh;sstinfo_list.sh;sstinfo_list_xml_file.sh;sstinfo_list_xml.sh;sstinfo_sst.sh;sst_numthreads.sh;sst_output_config.sh;sst_output_dot.sh;sst_output_dot_verbosity.sh;sst_output_json.sh;sst_output_prefix.sh;sst_print_timing_info.sh;sstregister_a.sh;sst_register_list.sh;sst_sdlfile.sh;sst_version.sh;testinfo.sh
+-- Dep Check sst_base.sh = RUN
+-- Dep Check sstconfig_help.sh = RUN
+-- Dep Check sstconfig_list_CXXFLAGS.sh = RUN
+-- Dep Check sstconfig_list.sh = RUN
+-- Dep Check sst_heartbeat_0.1.30.sh = RUN
+-- Dep Check sst_help-13.0.sh = RUN
+-- Dep Check sst_help.sh = RUN
+-- Dep Check sstinfo_help.sh = RUN
+-- Dep Check sstinfo_list_elem.sh = RUN
+-- Dep Check sstinfo_list_env.sh = RUN
+-- Dep Check sstinfo_list_nodisplay.sh = RUN
+-- Dep Check sstinfo_list_quiet.sh = RUN
+-- Dep Check sstinfo_list.sh = RUN
+-- Dep Check sstinfo_list_xml_file.sh = RUN
+-- Dep Check sstinfo_list_xml.sh = RUN
+-- Dep Check sstinfo_sst.sh = RUN
+-- Dep Check sst_numthreads.sh = RUN
+-- Dep Check sst_output_config.sh = RUN
+-- Dep Check sst_output_dot.sh = RUN
+-- Dep Check sst_output_dot_verbosity.sh = RUN
+-- Runtime sst_output_dot_verbosity.sh = 500
+-- Dep Check sst_output_json.sh = RUN
+-- Dep Check sst_output_prefix.sh = RUN
+-- Dep Check sst_print_timing_info.sh = RUN
+-- Dep Check sstregister_a.sh = RUN
+-- Dep Check sst_register_list.sh = RUN
+-- Dep Check sst_sdlfile.sh = RUN
+-- Dep Check sst_version.sh = RUN
+-- Dep Check testinfo.sh = RUN
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/rt_action: testinfo.sh
+-- Dep Check testinfo.sh = RUN
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/CaptCrunch: testinfo.sh
+-- Dep Check testinfo.sh = RUN
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/core-debug: testinfo.sh
+-- Dep Check testinfo.sh = RUN
+-- Configuring done
+-- Generating done
+-- Build files have been written to: /scratch/kgriesser/work/sst-ext-tests/build
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+      Start  1: sst_base
+      Start  2: sstconfig_help
+      Start  3: sstconfig_list_CXXFLAGS
+      Start  4: sstconfig_list
+      Start  5: sst_heartbeat_0.1.30
+      Start  6: sst_help-13.0
+      Start  7: sst_help
+      Start  8: sstinfo_help
+      Start  9: sstinfo_list_elem
+      Start 10: sstinfo_list_env
+      Start 11: sstinfo_list_nodisplay
+      Start 12: sstinfo_list_quiet
+      Start 13: sstinfo_list
+      Start 14: sstinfo_list_xml_file
+      Start 15: sstinfo_list_xml
+      Start 16: sstinfo_sst
+      Start 17: sst_numthreads
+      Start 18: sst_output_config
+      Start 19: sst_output_dot
+      Start 20: sst_output_dot_verbosity
+ 1/31 Test  #2: sstconfig_help ...................   Passed    0.19 sec
+      Start 21: sst_output_json
+ 2/31 Test  #4: sstconfig_list ...................   Passed    0.21 sec
+      Start 22: sst_output_prefix
+ 3/31 Test  #3: sstconfig_list_CXXFLAGS ..........   Passed    0.22 sec
+      Start 23: sst_print_timing_info
+ 4/31 Test  #8: sstinfo_help .....................   Passed    0.29 sec
+      Start 24: sstregister_a
+ 5/31 Test #16: sstinfo_sst ......................   Passed    0.30 sec
+      Start 25: sst_register_list
+ 6/31 Test #25: sst_register_list ................   Passed    0.13 sec
+      Start 26: sst_sdlfile
+ 7/31 Test #12: sstinfo_list_quiet ...............   Passed    0.49 sec
+      Start 27: sst_version
+ 8/31 Test #11: sstinfo_list_nodisplay ...........   Passed    0.49 sec
+      Start 28: testinfo
+ 9/31 Test #13: sstinfo_list .....................   Passed    0.49 sec
+      Start 29: testinfo
+10/31 Test #14: sstinfo_list_xml_file ............   Passed    0.50 sec
+      Start 30: testinfo
+11/31 Test #10: sstinfo_list_env .................   Passed    0.51 sec
+      Start 31: testinfo
+12/31 Test #15: sstinfo_list_xml .................   Passed    0.50 sec
+13/31 Test #24: sstregister_a ....................   Passed    0.38 sec
+14/31 Test #29: testinfo .........................   Passed    0.19 sec
+15/31 Test #30: testinfo .........................   Passed    0.20 sec
+16/31 Test #31: testinfo .........................   Passed    0.20 sec
+17/31 Test #28: testinfo .........................   Passed    0.22 sec
+18/31 Test  #5: sst_heartbeat_0.1.30 .............   Passed    1.52 sec
+19/31 Test #27: sst_version ......................   Passed    1.55 sec
+20/31 Test  #7: sst_help .........................   Passed    2.54 sec
+21/31 Test  #6: sst_help-13.0 ....................   Passed    2.56 sec
+22/31 Test  #9: sstinfo_list_elem ................   Passed    3.06 sec
+23/31 Test  #1: sst_base .........................   Passed    6.68 sec
+24/31 Test #19: sst_output_dot ...................   Passed    6.71 sec
+25/31 Test #18: sst_output_config ................   Passed    6.71 sec
+26/31 Test #23: sst_print_timing_info ............   Passed    6.68 sec
+27/31 Test #21: sst_output_json ..................   Passed    6.73 sec
+28/31 Test #22: sst_output_prefix ................   Passed    6.74 sec
+29/31 Test #26: sst_sdlfile ......................   Passed    6.65 sec
+30/31 Test #17: sst_numthreads ...................   Passed    8.85 sec
+31/31 Test #20: sst_output_dot_verbosity .........   Passed   55.81 sec
+
+100% tests passed, 0 tests failed out of 31
+
+Label Time Summary:
+13.0    = 128.28 sec*proc (31 tests)
+
+Total Test time (real) =  55.86 sec
+
+### Loading sst/13.1.0 ###
+
+Current version of the local SST config is: 
+SST local configuration not found for verison 13.1.0. Creating one.
+SST-Core Version (13.1.0)
+13.1.0
+-- The CXX compiler identification is GNU 12.2.0
+-- Detecting CXX compiler ABI info
+-- Detecting CXX compiler ABI info - done
+-- Check for working CXX compiler: /opt/ohpc/pub/compiler/gcc/12.2.0/bin/c++ - skipped
+-- Detecting CXX compile features
+-- Detecting CXX compile features - done
+-- SST-Core Version (13.1.0)
+-- SST MAJOR VERSION=13
+-- SST MINOR VERSION=1
+-- SST FULL VERSION=13.1
+-- Found MPI_CXX: /scratch/opt/ohpc/pub/mpi/openmpi4-gnu12/4.1.4/lib/libmpi_cxx.so (found version "3.1") 
+-- Found MPI: TRUE (found version "3.1")  
+-- MPI RUN COMMAND=/opt/ohpc/pub/mpi/openmpi4-gnu12/4.1.4/bin/mpiexec
+-- SST-EXT-TESTS ENV{SST_COMPONENT_BASE}=/scratch/kgriesser/work/sst-ext-tests/build/components
+-- CaptCrunch is supported only for sst 15.0 or newer
+-- core-debug component is supported only for sst 15.1 or newer
+-- Checking /scratch/kgriesser/work/sst-ext-tests/tests/cli for tests supporting 13.1
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/cli: sst_base.sh;sstconfig_help.sh;sstconfig_list_CXXFLAGS.sh;sstconfig_list.sh;sst_heartbeat_0.1.30.sh;sst_help-13.1.sh;sst_help.sh;sstinfo_help.sh;sstinfo_list_elem.sh;sstinfo_list_env.sh;sstinfo_list_nodisplay.sh;sstinfo_list_quiet.sh;sstinfo_list.sh;sstinfo_list_xml_file.sh;sstinfo_list_xml.sh;sstinfo_sst.sh;sst_numthreads.sh;sst_output_config.sh;sst_output_dot.sh;sst_output_dot_verbosity.sh;sst_output_json.sh;sst_output_prefix.sh;sst_print_timing_info.sh;sstregister_a.sh;sst_register_list.sh;sst_sdlfile.sh;sst_version.sh;testinfo.sh
+-- Dep Check sst_base.sh = RUN
+-- Dep Check sstconfig_help.sh = RUN
+-- Dep Check sstconfig_list_CXXFLAGS.sh = RUN
+-- Dep Check sstconfig_list.sh = RUN
+-- Dep Check sst_heartbeat_0.1.30.sh = RUN
+-- Dep Check sst_help-13.1.sh = RUN
+-- Dep Check sst_help.sh = RUN
+-- Dep Check sstinfo_help.sh = RUN
+-- Dep Check sstinfo_list_elem.sh = RUN
+-- Dep Check sstinfo_list_env.sh = RUN
+-- Dep Check sstinfo_list_nodisplay.sh = RUN
+-- Dep Check sstinfo_list_quiet.sh = RUN
+-- Dep Check sstinfo_list.sh = RUN
+-- Dep Check sstinfo_list_xml_file.sh = RUN
+-- Dep Check sstinfo_list_xml.sh = RUN
+-- Dep Check sstinfo_sst.sh = RUN
+-- Dep Check sst_numthreads.sh = RUN
+-- Dep Check sst_output_config.sh = RUN
+-- Dep Check sst_output_dot.sh = RUN
+-- Dep Check sst_output_dot_verbosity.sh = RUN
+-- Runtime sst_output_dot_verbosity.sh = 500
+-- Dep Check sst_output_json.sh = RUN
+-- Dep Check sst_output_prefix.sh = RUN
+-- Dep Check sst_print_timing_info.sh = RUN
+-- Dep Check sstregister_a.sh = RUN
+-- Dep Check sst_register_list.sh = RUN
+-- Dep Check sst_sdlfile.sh = RUN
+-- Dep Check sst_version.sh = RUN
+-- Dep Check testinfo.sh = RUN
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/rt_action: testinfo.sh
+-- Dep Check testinfo.sh = RUN
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/CaptCrunch: testinfo.sh
+-- Dep Check testinfo.sh = RUN
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/core-debug: testinfo.sh
+-- Dep Check testinfo.sh = RUN
+-- Configuring done
+-- Generating done
+-- Build files have been written to: /scratch/kgriesser/work/sst-ext-tests/build
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+      Start  1: sst_base
+      Start  2: sstconfig_help
+      Start  3: sstconfig_list_CXXFLAGS
+      Start  4: sstconfig_list
+      Start  5: sst_heartbeat_0.1.30
+      Start  6: sst_help-13.1
+      Start  7: sst_help
+      Start  8: sstinfo_help
+      Start  9: sstinfo_list_elem
+      Start 10: sstinfo_list_env
+      Start 11: sstinfo_list_nodisplay
+      Start 12: sstinfo_list_quiet
+      Start 13: sstinfo_list
+      Start 14: sstinfo_list_xml_file
+      Start 15: sstinfo_list_xml
+      Start 16: sstinfo_sst
+      Start 17: sst_numthreads
+      Start 18: sst_output_config
+      Start 19: sst_output_dot
+      Start 20: sst_output_dot_verbosity
+ 1/31 Test  #3: sstconfig_list_CXXFLAGS ..........   Passed    0.19 sec
+      Start 21: sst_output_json
+ 2/31 Test  #2: sstconfig_help ...................   Passed    0.21 sec
+      Start 22: sst_output_prefix
+ 3/31 Test  #4: sstconfig_list ...................   Passed    0.21 sec
+      Start 23: sst_print_timing_info
+ 4/31 Test  #8: sstinfo_help .....................   Passed    0.31 sec
+      Start 24: sstregister_a
+ 5/31 Test #16: sstinfo_sst ......................   Passed    0.31 sec
+      Start 25: sst_register_list
+ 6/31 Test #25: sst_register_list ................   Passed    0.15 sec
+      Start 26: sst_sdlfile
+ 7/31 Test #11: sstinfo_list_nodisplay ...........   Passed    0.47 sec
+      Start 27: sst_version
+ 8/31 Test #10: sstinfo_list_env .................   Passed    0.49 sec
+      Start 28: testinfo
+ 9/31 Test #12: sstinfo_list_quiet ...............   Passed    0.49 sec
+      Start 29: testinfo
+10/31 Test #14: sstinfo_list_xml_file ............   Passed    0.49 sec
+      Start 30: testinfo
+11/31 Test #13: sstinfo_list .....................   Passed    0.53 sec
+      Start 31: testinfo
+12/31 Test #15: sstinfo_list_xml .................   Passed    0.54 sec
+13/31 Test #29: testinfo .........................   Passed    0.18 sec
+14/31 Test #28: testinfo .........................   Passed    0.20 sec
+15/31 Test #31: testinfo .........................   Passed    0.18 sec
+16/31 Test #30: testinfo .........................   Passed    0.24 sec
+17/31 Test #24: sstregister_a ....................   Passed    0.45 sec
+18/31 Test  #5: sst_heartbeat_0.1.30 .............   Passed    1.87 sec
+19/31 Test #27: sst_version ......................   Passed    1.42 sec
+20/31 Test  #6: sst_help-13.1 ....................   Passed    2.78 sec
+21/31 Test  #7: sst_help .........................   Passed    2.80 sec
+22/31 Test  #9: sstinfo_list_elem ................   Passed    3.09 sec
+23/31 Test  #1: sst_base .........................   Passed    6.90 sec
+24/31 Test #18: sst_output_config ................   Passed    6.96 sec
+25/31 Test #23: sst_print_timing_info ............   Passed    6.77 sec
+26/31 Test #19: sst_output_dot ...................   Passed    6.98 sec
+27/31 Test #26: sst_sdlfile ......................   Passed    6.55 sec
+28/31 Test #21: sst_output_json ..................   Passed    6.84 sec
+29/31 Test #22: sst_output_prefix ................   Passed    6.84 sec
+30/31 Test #17: sst_numthreads ...................   Passed    9.11 sec
+31/31 Test #20: sst_output_dot_verbosity .........   Passed   56.43 sec
+
+100% tests passed, 0 tests failed out of 31
+
+Label Time Summary:
+13.1    = 130.99 sec*proc (31 tests)
+
+Total Test time (real) =  56.48 sec
+
+### Loading sst/14.0.0 ###
+
+Current version of the local SST config is: 
+SST local configuration not found for verison 14.0.0. Creating one.
+SST-Core Version (14.0.0)
+14.0.0
+-- The CXX compiler identification is GNU 12.2.0
+-- Detecting CXX compiler ABI info
+-- Detecting CXX compiler ABI info - done
+-- Check for working CXX compiler: /opt/ohpc/pub/compiler/gcc/12.2.0/bin/c++ - skipped
+-- Detecting CXX compile features
+-- Detecting CXX compile features - done
+-- SST-Core Version (14.0.0)
+-- SST MAJOR VERSION=14
+-- SST MINOR VERSION=0
+-- SST FULL VERSION=14.0
+-- Found MPI_CXX: /scratch/opt/ohpc/pub/mpi/openmpi4-gnu12/4.1.4/lib/libmpi_cxx.so (found version "3.1") 
+-- Found MPI: TRUE (found version "3.1")  
+-- MPI RUN COMMAND=/opt/ohpc/pub/mpi/openmpi4-gnu12/4.1.4/bin/mpiexec
+-- SST-EXT-TESTS ENV{SST_COMPONENT_BASE}=/scratch/kgriesser/work/sst-ext-tests/build/components
+-- CaptCrunch is supported only for sst 15.0 or newer
+-- core-debug component is supported only for sst 15.1 or newer
+-- Checking /scratch/kgriesser/work/sst-ext-tests/tests/cli for tests supporting 14.0
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/cli: sst_base.sh;sstconfig_help.sh;sstconfig_list_CXXFLAGS.sh;sstconfig_list.sh;sst_heartbeat_0.1.30.sh;sst_help-14.0.sh;sst_help-MIN14.0.sh;sst_help.sh;sstinfo_help.sh;sstinfo_list_elem.sh;sstinfo_list_env.sh;sstinfo_list_nodisplay.sh;sstinfo_list_quiet.sh;sstinfo_list.sh;sstinfo_list_xml_file.sh;sstinfo_list_xml.sh;sstinfo_sst.sh;sst_numthreads.sh;sst_output_config.sh;sst_output_dot.sh;sst_output_dot_verbosity.sh;sst_output_json.sh;sst_output_prefix.sh;sst_print_timing_info.sh;sstregister_a.sh;sst_register_list.sh;sst_sdlfile.sh;sst_version.sh;testinfo.sh
+-- Dep Check sst_base.sh = RUN
+-- Dep Check sstconfig_help.sh = RUN
+-- Dep Check sstconfig_list_CXXFLAGS.sh = RUN
+-- Dep Check sstconfig_list.sh = RUN
+-- Dep Check sst_heartbeat_0.1.30.sh = RUN
+-- Dep Check sst_help-14.0.sh = RUN
+-- Dep Check sst_help-MIN14.0.sh = RUN
+-- Dep Check sst_help.sh = RUN
+-- Dep Check sstinfo_help.sh = RUN
+-- Dep Check sstinfo_list_elem.sh = RUN
+-- Dep Check sstinfo_list_env.sh = RUN
+-- Dep Check sstinfo_list_nodisplay.sh = RUN
+-- Dep Check sstinfo_list_quiet.sh = RUN
+-- Dep Check sstinfo_list.sh = RUN
+-- Dep Check sstinfo_list_xml_file.sh = RUN
+-- Dep Check sstinfo_list_xml.sh = RUN
+-- Dep Check sstinfo_sst.sh = RUN
+-- Dep Check sst_numthreads.sh = RUN
+-- Dep Check sst_output_config.sh = RUN
+-- Dep Check sst_output_dot.sh = RUN
+-- Dep Check sst_output_dot_verbosity.sh = RUN
+-- Runtime sst_output_dot_verbosity.sh = 500
+-- Dep Check sst_output_json.sh = RUN
+-- Dep Check sst_output_prefix.sh = RUN
+-- Dep Check sst_print_timing_info.sh = RUN
+-- Dep Check sstregister_a.sh = RUN
+-- Dep Check sst_register_list.sh = RUN
+-- Dep Check sst_sdlfile.sh = RUN
+-- Dep Check sst_version.sh = RUN
+-- Dep Check testinfo.sh = RUN
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/rt_action: testinfo.sh
+-- Dep Check testinfo.sh = RUN
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/CaptCrunch: testinfo.sh
+-- Dep Check testinfo.sh = RUN
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/core-debug: testinfo.sh
+-- Dep Check testinfo.sh = RUN
+-- Configuring done
+-- Generating done
+-- Build files have been written to: /scratch/kgriesser/work/sst-ext-tests/build
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+      Start  1: sst_base
+      Start  2: sstconfig_help
+      Start  3: sstconfig_list_CXXFLAGS
+      Start  4: sstconfig_list
+      Start  5: sst_heartbeat_0.1.30
+      Start  6: sst_help-14.0
+      Start  7: sst_help-MIN14.0
+      Start  8: sst_help
+      Start  9: sstinfo_help
+      Start 10: sstinfo_list_elem
+      Start 11: sstinfo_list_env
+      Start 12: sstinfo_list_nodisplay
+      Start 13: sstinfo_list_quiet
+      Start 14: sstinfo_list
+      Start 15: sstinfo_list_xml_file
+      Start 16: sstinfo_list_xml
+      Start 17: sstinfo_sst
+      Start 18: sst_numthreads
+      Start 19: sst_output_config
+      Start 20: sst_output_dot
+ 1/32 Test  #2: sstconfig_help ...................   Passed    0.19 sec
+      Start 21: sst_output_dot_verbosity
+ 2/32 Test  #4: sstconfig_list ...................   Passed    0.21 sec
+      Start 22: sst_output_json
+ 3/32 Test  #3: sstconfig_list_CXXFLAGS ..........   Passed    0.21 sec
+      Start 23: sst_output_prefix
+ 4/32 Test  #9: sstinfo_help .....................   Passed    0.32 sec
+      Start 24: sst_print_timing_info
+ 5/32 Test #17: sstinfo_sst ......................   Passed    0.33 sec
+      Start 25: sstregister_a
+ 6/32 Test #12: sstinfo_list_nodisplay ...........   Passed    0.50 sec
+      Start 26: sst_register_list
+ 7/32 Test #14: sstinfo_list .....................   Passed    0.52 sec
+      Start 27: sst_sdlfile
+ 8/32 Test #13: sstinfo_list_quiet ...............   Passed    0.53 sec
+      Start 28: sst_version
+ 9/32 Test #16: sstinfo_list_xml .................   Passed    0.52 sec
+      Start 29: testinfo
+10/32 Test #15: sstinfo_list_xml_file ............   Passed    0.53 sec
+      Start 30: testinfo
+11/32 Test #11: sstinfo_list_env .................   Passed    0.56 sec
+      Start 31: testinfo
+12/32 Test #26: sst_register_list ................   Passed    0.14 sec
+      Start 32: testinfo
+13/32 Test #29: testinfo .........................   Passed    0.18 sec
+14/32 Test #30: testinfo .........................   Passed    0.20 sec
+15/32 Test #31: testinfo .........................   Passed    0.19 sec
+16/32 Test #25: sstregister_a ....................   Passed    0.43 sec
+17/32 Test #32: testinfo .........................   Passed    0.19 sec
+18/32 Test  #5: sst_heartbeat_0.1.30 .............   Passed    1.78 sec
+19/32 Test #28: sst_version ......................   Passed    1.29 sec
+20/32 Test  #7: sst_help-MIN14.0 .................   Passed    2.63 sec
+21/32 Test  #8: sst_help .........................   Passed    2.65 sec
+22/32 Test  #6: sst_help-14.0 ....................   Passed    2.73 sec
+23/32 Test #10: sstinfo_list_elem ................   Passed    3.71 sec
+24/32 Test  #1: sst_base .........................   Passed    6.74 sec
+25/32 Test #22: sst_output_json ..................   Passed    6.68 sec
+26/32 Test #20: sst_output_dot ...................   Passed    6.88 sec
+27/32 Test #23: sst_output_prefix ................   Passed    6.73 sec
+28/32 Test #19: sst_output_config ................   Passed    6.92 sec
+29/32 Test #24: sst_print_timing_info ............   Passed    6.63 sec
+30/32 Test #27: sst_sdlfile ......................   Passed    6.43 sec
+31/32 Test #18: sst_numthreads ...................   Passed    9.11 sec
+32/32 Test #21: sst_output_dot_verbosity .........   Passed   56.89 sec
+
+100% tests passed, 0 tests failed out of 32
+
+Label Time Summary:
+14.0    = 133.56 sec*proc (32 tests)
+
+Total Test time (real) =  57.10 sec
+
+### Loading sst/14.1.0 ###
+
+Current version of the local SST config is: 
+SST local configuration not found for verison 14.1. Creating one.
+SST-Core Version (14.1)
+14.1.0
+-- The CXX compiler identification is GNU 12.2.0
+-- Detecting CXX compiler ABI info
+-- Detecting CXX compiler ABI info - done
+-- Check for working CXX compiler: /opt/ohpc/pub/compiler/gcc/12.2.0/bin/c++ - skipped
+-- Detecting CXX compile features
+-- Detecting CXX compile features - done
+-- SST-Core Version (14.1)
+-- SST MAJOR VERSION=14
+-- SST MINOR VERSION=1
+-- SST FULL VERSION=14.1
+-- Found MPI_CXX: /scratch/opt/ohpc/pub/mpi/openmpi4-gnu12/4.1.4/lib/libmpi_cxx.so (found version "3.1") 
+-- Found MPI: TRUE (found version "3.1")  
+-- MPI RUN COMMAND=/opt/ohpc/pub/mpi/openmpi4-gnu12/4.1.4/bin/mpiexec
+-- SST-EXT-TESTS ENV{SST_COMPONENT_BASE}=/scratch/kgriesser/work/sst-ext-tests/build/components
+-- CaptCrunch is supported only for sst 15.0 or newer
+-- core-debug component is supported only for sst 15.1 or newer
+-- Checking /scratch/kgriesser/work/sst-ext-tests/tests/cli for tests supporting 14.1
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/cli: sst_base.sh;sstconfig_help.sh;sstconfig_list_CXXFLAGS.sh;sstconfig_list.sh;sst_heartbeat_0.1.30.sh;sst_heartbeat_1s.sh;sst_help-14.1.sh;sst_help-MIN14.0.sh;sst_help.sh;sstinfo_help.sh;sstinfo_list_elem.sh;sstinfo_list_env.sh;sstinfo_list_nodisplay.sh;sstinfo_list_quiet.sh;sstinfo_list.sh;sstinfo_list_xml_file.sh;sstinfo_list_xml.sh;sstinfo_sst.sh;sst_numthreads.sh;sst_output_config.sh;sst_output_dot.sh;sst_output_dot_verbosity.sh;sst_output_json.sh;sst_output_prefix.sh;sst_print_timing_info.sh;sstregister_a.sh;sst_register_list.sh;sst_sdlfile.sh;sst_version.sh;testinfo.sh
+-- Dep Check sst_base.sh = RUN
+-- Dep Check sstconfig_help.sh = RUN
+-- Dep Check sstconfig_list_CXXFLAGS.sh = RUN
+-- Dep Check sstconfig_list.sh = RUN
+-- Dep Check sst_heartbeat_0.1.30.sh = RUN
+-- Dep Check sst_heartbeat_1s.sh = RUN
+-- Runtime sst_heartbeat_1s.sh = 90
+-- Dep Check sst_help-14.1.sh = RUN
+-- Dep Check sst_help-MIN14.0.sh = RUN
+-- Dep Check sst_help.sh = RUN
+-- Dep Check sstinfo_help.sh = RUN
+-- Dep Check sstinfo_list_elem.sh = RUN
+-- Dep Check sstinfo_list_env.sh = RUN
+-- Dep Check sstinfo_list_nodisplay.sh = RUN
+-- Dep Check sstinfo_list_quiet.sh = RUN
+-- Dep Check sstinfo_list.sh = RUN
+-- Dep Check sstinfo_list_xml_file.sh = RUN
+-- Dep Check sstinfo_list_xml.sh = RUN
+-- Dep Check sstinfo_sst.sh = RUN
+-- Dep Check sst_numthreads.sh = RUN
+-- Dep Check sst_output_config.sh = RUN
+-- Dep Check sst_output_dot.sh = RUN
+-- Dep Check sst_output_dot_verbosity.sh = RUN
+-- Runtime sst_output_dot_verbosity.sh = 500
+-- Dep Check sst_output_json.sh = RUN
+-- Dep Check sst_output_prefix.sh = RUN
+-- Dep Check sst_print_timing_info.sh = RUN
+-- Dep Check sstregister_a.sh = RUN
+-- Dep Check sst_register_list.sh = RUN
+-- Dep Check sst_sdlfile.sh = RUN
+-- Dep Check sst_version.sh = RUN
+-- Dep Check testinfo.sh = RUN
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/rt_action: restart-heartbeat-14.1.sh;restart-interactive-14.1.sh;restart-sigalrm-14.1.sh;sigalrm_ckpt_comb.sh;sigalrm.sh;testinfo.sh
+-- Dep Check restart-heartbeat-14.1.sh = RUN
+-- Dep Check restart-interactive-14.1.sh = RUN
+-- Dep Check restart-sigalrm-14.1.sh = RUN
+-- Dep Check sigalrm_ckpt_comb.sh = RUN
+-- Dep Check sigalrm.sh = RUN
+-- Dep Check testinfo.sh = RUN
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/CaptCrunch: testinfo.sh
+-- Dep Check testinfo.sh = RUN
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/core-debug: testinfo.sh
+-- Dep Check testinfo.sh = RUN
+-- Configuring done
+-- Generating done
+-- Build files have been written to: /scratch/kgriesser/work/sst-ext-tests/build
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+      Start  1: sst_base
+      Start  2: sstconfig_help
+      Start  3: sstconfig_list_CXXFLAGS
+      Start  4: sstconfig_list
+      Start  5: sst_heartbeat_0.1.30
+      Start  6: sst_heartbeat_1s
+      Start  7: sst_help-14.1
+      Start  8: sst_help-MIN14.0
+      Start  9: sst_help
+      Start 10: sstinfo_help
+      Start 11: sstinfo_list_elem
+      Start 12: sstinfo_list_env
+      Start 13: sstinfo_list_nodisplay
+      Start 14: sstinfo_list_quiet
+      Start 15: sstinfo_list
+      Start 16: sstinfo_list_xml_file
+      Start 17: sstinfo_list_xml
+      Start 18: sstinfo_sst
+      Start 19: sst_numthreads
+      Start 20: sst_output_config
+ 1/38 Test  #2: sstconfig_help ...................   Passed    0.19 sec
+      Start 21: sst_output_dot
+ 2/38 Test  #3: sstconfig_list_CXXFLAGS ..........   Passed    0.22 sec
+      Start 22: sst_output_dot_verbosity
+ 3/38 Test  #4: sstconfig_list ...................   Passed    0.22 sec
+      Start 23: sst_output_json
+ 4/38 Test #10: sstinfo_help .....................   Passed    0.32 sec
+      Start 24: sst_output_prefix
+ 5/38 Test #18: sstinfo_sst ......................   Passed    0.31 sec
+      Start 25: sst_print_timing_info
+ 6/38 Test #14: sstinfo_list_quiet ...............   Passed    0.50 sec
+      Start 26: sstregister_a
+ 7/38 Test #13: sstinfo_list_nodisplay ...........   Passed    0.51 sec
+      Start 27: sst_register_list
+ 8/38 Test #12: sstinfo_list_env .................   Passed    0.53 sec
+      Start 28: sst_sdlfile
+ 9/38 Test #15: sstinfo_list .....................   Passed    0.53 sec
+      Start 29: sst_version
+10/38 Test #17: sstinfo_list_xml .................   Passed    0.56 sec
+      Start 30: testinfo
+11/38 Test #16: sstinfo_list_xml_file ............   Passed    0.57 sec
+      Start 31: restart-heartbeat-14.1
+12/38 Test #27: sst_register_list ................   Passed    0.13 sec
+      Start 32: restart-interactive-14.1
+13/38 Test #30: testinfo .........................   Passed    0.20 sec
+      Start 33: restart-sigalrm-14.1
+14/38 Test #26: sstregister_a ....................   Passed    0.38 sec
+      Start 34: sigalrm_ckpt_comb
+15/38 Test #29: sst_version ......................   Passed    1.56 sec
+      Start 35: sigalrm
+16/38 Test  #7: sst_help-14.1 ....................   Passed    3.09 sec
+      Start 36: testinfo
+17/38 Test  #8: sst_help-MIN14.0 .................   Passed    3.14 sec
+      Start 37: testinfo
+18/38 Test  #9: sst_help .........................   Passed    3.17 sec
+      Start 38: testinfo
+19/38 Test #36: testinfo .........................   Passed    0.18 sec
+20/38 Test #37: testinfo .........................   Passed    0.17 sec
+21/38 Test #38: testinfo .........................   Passed    0.16 sec
+22/38 Test #11: sstinfo_list_elem ................   Passed    3.48 sec
+23/38 Test  #5: sst_heartbeat_0.1.30 .............   Passed    7.23 sec
+24/38 Test #20: sst_output_config ................   Passed    7.22 sec
+25/38 Test #23: sst_output_json ..................   Passed    7.06 sec
+26/38 Test #28: sst_sdlfile ......................   Passed    6.75 sec
+27/38 Test  #1: sst_base .........................   Passed    7.32 sec
+28/38 Test #25: sst_print_timing_info ............   Passed    6.99 sec
+29/38 Test #21: sst_output_dot ...................   Passed    7.13 sec
+30/38 Test #24: sst_output_prefix ................   Passed    7.04 sec
+31/38 Test #19: sst_numthreads ...................   Passed    9.45 sec
+32/38 Test #31: restart-heartbeat-14.1 ...........   Passed    9.23 sec
+33/38 Test #32: restart-interactive-14.1 .........   Passed   10.18 sec
+34/38 Test  #6: sst_heartbeat_1s .................   Passed   15.13 sec
+35/38 Test #34: sigalrm_ckpt_comb ................   Passed   22.46 sec
+36/38 Test #33: restart-sigalrm-14.1 .............   Passed   24.84 sec
+37/38 Test #35: sigalrm ..........................   Passed   23.70 sec
+38/38 Test #22: sst_output_dot_verbosity .........   Passed   56.23 sec
+
+100% tests passed, 0 tests failed out of 38
+
+Label Time Summary:
+14.1    = 248.09 sec*proc (38 tests)
+
+Total Test time (real) =  56.48 sec
+
+### Loading sst/15.0.0 ###
+
+Current version of the local SST config is: 
+SST local configuration not found for verison 15.0.0. Creating one.
+SST-Core Version (15.0.0)
+15.0.0
+-- The CXX compiler identification is GNU 12.2.0
+-- Detecting CXX compiler ABI info
+-- Detecting CXX compiler ABI info - done
+-- Check for working CXX compiler: /opt/ohpc/pub/compiler/gcc/12.2.0/bin/c++ - skipped
+-- Detecting CXX compile features
+-- Detecting CXX compile features - done
+-- SST-Core Version (15.0.0)
+-- SST MAJOR VERSION=15
+-- SST MINOR VERSION=0
+-- SST FULL VERSION=15.0
+-- Found MPI_CXX: /scratch/opt/ohpc/pub/mpi/openmpi4-gnu12/4.1.4/lib/libmpi_cxx.so (found version "3.1") 
+-- Found MPI: TRUE (found version "3.1")  
+-- MPI RUN COMMAND=/opt/ohpc/pub/mpi/openmpi4-gnu12/4.1.4/bin/mpiexec
+-- SST-EXT-TESTS ENV{SST_COMPONENT_BASE}=/scratch/kgriesser/work/sst-ext-tests/build/components
+-- CaptCrunch is supported only for sst 15.0 or newer
+-- core-debug component is supported only for sst 15.1 or newer
+-- Checking /scratch/kgriesser/work/sst-ext-tests/tests/cli for tests supporting 15.0
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/cli: sst_base.sh;sst_checkpoint_name_format.sh;sstconfig_help.sh;sstconfig_list_CXXFLAGS.sh;sstconfig_list.sh;sst_heartbeat_0.1.30.sh;sst_heartbeat_1s.sh;sst_heartbeat_90s.sh;sst_help-15.0.sh;sst_help-MIN14.0.sh;sst_help.sh;sstinfo_help.sh;sstinfo_list_elem.sh;sstinfo_list_env.sh;sstinfo_list_nodisplay.sh;sstinfo_list_quiet.sh;sstinfo_list.sh;sstinfo_list_xml_file.sh;sstinfo_list_xml.sh;sstinfo_sst.sh;sst_numthreads.sh;sst_output_config.sh;sst_output_dir_config.sh;sst_output_dir_cpt.sh;sst_output_dir_json.sh;sst_output_dir.sh;sst_output_dir_stats.sh;sst_output_dot.sh;sst_output_dot_verbosity.sh;sst_output_json.sh;sst_output_prefix.sh;sst_print_timing_info.sh;sstregister_a.sh;sst_register_list.sh;sst_sdlfile.sh;sst_version.sh;testinfo.sh
+-- Dep Check sst_base.sh = RUN
+-- Dep Check sst_checkpoint_name_format.sh = RUN
+-- Runtime sst_checkpoint_name_format.sh = 120
+-- Dep Check sstconfig_help.sh = RUN
+-- Dep Check sstconfig_list_CXXFLAGS.sh = RUN
+-- Dep Check sstconfig_list.sh = RUN
+-- Dep Check sst_heartbeat_0.1.30.sh = RUN
+-- Dep Check sst_heartbeat_1s.sh = RUN
+-- Runtime sst_heartbeat_1s.sh = 90
+-- Dep Check sst_heartbeat_90s.sh = RUN
+-- Dep Check sst_help-15.0.sh = RUN
+-- Dep Check sst_help-MIN14.0.sh = RUN
+-- Dep Check sst_help.sh = RUN
+-- Dep Check sstinfo_help.sh = RUN
+-- Dep Check sstinfo_list_elem.sh = RUN
+-- Dep Check sstinfo_list_env.sh = RUN
+-- Dep Check sstinfo_list_nodisplay.sh = RUN
+-- Dep Check sstinfo_list_quiet.sh = RUN
+-- Dep Check sstinfo_list.sh = RUN
+-- Dep Check sstinfo_list_xml_file.sh = RUN
+-- Dep Check sstinfo_list_xml.sh = RUN
+-- Dep Check sstinfo_sst.sh = RUN
+-- Dep Check sst_numthreads.sh = RUN
+-- Dep Check sst_output_config.sh = RUN
+-- Dep Check sst_output_dir_config.sh = RUN
+-- Runtime sst_output_dir_config.sh = 240
+-- Dep Check sst_output_dir_cpt.sh = RUN
+-- Runtime sst_output_dir_cpt.sh = 240
+-- Dep Check sst_output_dir_json.sh = RUN
+-- Runtime sst_output_dir_json.sh = 240
+-- Dep Check sst_output_dir.sh = RUN
+-- Runtime sst_output_dir.sh = 240
+-- Dep Check sst_output_dir_stats.sh = RUN
+-- Runtime sst_output_dir_stats.sh = 240
+-- Dep Check sst_output_dot.sh = RUN
+-- Dep Check sst_output_dot_verbosity.sh = RUN
+-- Runtime sst_output_dot_verbosity.sh = 500
+-- Dep Check sst_output_json.sh = RUN
+-- Dep Check sst_output_prefix.sh = RUN
+-- Dep Check sst_print_timing_info.sh = RUN
+-- Dep Check sstregister_a.sh = RUN
+-- Dep Check sst_register_list.sh = RUN
+-- Dep Check sst_sdlfile.sh = RUN
+-- Dep Check sst_version.sh = RUN
+-- Dep Check testinfo.sh = RUN
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/rt_action: restart-ckpt-with-sigalrm-15.0.sh;restart-heartbeat.sh;restart-interactive.sh;restart-sigalrm-15.0.sh;sigalrm_ckpt_comb.sh;sigalrm.sh;sigusr_interactive-15.0.sh;testinfo.sh
+-- Dep Check restart-ckpt-with-sigalrm-15.0.sh = RUN
+-- Dep Check restart-heartbeat.sh = RUN
+-- Dep Check restart-interactive.sh = RUN
+-- Dep Check restart-sigalrm-15.0.sh = RUN
+-- Dep Check sigalrm_ckpt_comb.sh = RUN
+-- Dep Check sigalrm.sh = RUN
+-- Dep Check sigusr_interactive-15.0.sh = RUN
+-- Runtime sigusr_interactive-15.0.sh = 90
+-- Dep Check testinfo.sh = RUN
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/CaptCrunch: testinfo.sh
+-- Dep Check testinfo.sh = RUN
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/core-debug: testinfo.sh
+-- Dep Check testinfo.sh = RUN
+-- Configuring done
+-- Generating done
+-- Build files have been written to: /scratch/kgriesser/work/sst-ext-tests/build
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+      Start  1: sst_base
+      Start  2: sst_checkpoint_name_format
+      Start  3: sstconfig_help
+      Start  4: sstconfig_list_CXXFLAGS
+      Start  5: sstconfig_list
+      Start  6: sst_heartbeat_0.1.30
+      Start  7: sst_heartbeat_1s
+      Start  8: sst_heartbeat_90s
+      Start  9: sst_help-15.0
+      Start 10: sst_help-MIN14.0
+      Start 11: sst_help
+      Start 12: sstinfo_help
+      Start 13: sstinfo_list_elem
+      Start 14: sstinfo_list_env
+      Start 15: sstinfo_list_nodisplay
+      Start 16: sstinfo_list_quiet
+      Start 17: sstinfo_list
+      Start 18: sstinfo_list_xml_file
+      Start 19: sstinfo_list_xml
+      Start 20: sstinfo_sst
+ 1/47 Test  #3: sstconfig_help ...................   Passed    0.19 sec
+      Start 21: sst_numthreads
+ 2/47 Test  #4: sstconfig_list_CXXFLAGS ..........   Passed    0.19 sec
+      Start 22: sst_output_config
+ 3/47 Test  #5: sstconfig_list ...................   Passed    0.20 sec
+      Start 23: sst_output_dir_config
+ 4/47 Test #12: sstinfo_help .....................   Passed    0.31 sec
+      Start 24: sst_output_dir_cpt
+ 5/47 Test #20: sstinfo_sst ......................   Passed    0.31 sec
+      Start 25: sst_output_dir_json
+ 6/47 Test #16: sstinfo_list_quiet ...............   Passed    0.53 sec
+      Start 26: sst_output_dir
+ 7/47 Test #15: sstinfo_list_nodisplay ...........   Passed    0.55 sec
+      Start 27: sst_output_dir_stats
+ 8/47 Test #14: sstinfo_list_env .................   Passed    0.56 sec
+      Start 28: sst_output_dot
+ 9/47 Test #17: sstinfo_list .....................   Passed    0.55 sec
+      Start 29: sst_output_dot_verbosity
+10/47 Test #19: sstinfo_list_xml .................   Passed    0.55 sec
+      Start 30: sst_output_json
+11/47 Test #18: sstinfo_list_xml_file ............   Passed    0.59 sec
+      Start 31: sst_output_prefix
+12/47 Test #11: sst_help .........................   Passed    3.18 sec
+      Start 32: sst_print_timing_info
+13/47 Test  #9: sst_help-15.0 ....................   Passed    3.22 sec
+      Start 33: sstregister_a
+14/47 Test #10: sst_help-MIN14.0 .................   Passed    3.23 sec
+      Start 34: sst_register_list
+15/47 Test #34: sst_register_list ................   Passed    0.12 sec
+      Start 35: sst_sdlfile
+16/47 Test #33: sstregister_a ....................   Passed    0.29 sec
+      Start 36: sst_version
+17/47 Test #13: sstinfo_list_elem ................   Passed    3.92 sec
+      Start 37: testinfo
+18/47 Test #37: testinfo .........................   Passed    0.19 sec
+      Start 38: restart-ckpt-with-sigalrm-15.0
+19/47 Test #36: sst_version ......................   Passed    1.07 sec
+      Start 39: restart-heartbeat
+20/47 Test  #1: sst_base .........................   Passed    7.29 sec
+      Start 40: restart-interactive
+21/47 Test  #6: sst_heartbeat_0.1.30 .............   Passed    7.42 sec
+      Start 41: restart-sigalrm-15.0
+22/47 Test  #8: sst_heartbeat_90s ................   Passed    7.42 sec
+      Start 42: sigalrm_ckpt_comb
+23/47 Test #22: sst_output_config ................   Passed    7.26 sec
+      Start 43: sigalrm
+24/47 Test #30: sst_output_json ..................   Passed    6.90 sec
+      Start 44: sigusr_interactive-15.0
+25/47 Test #31: sst_output_prefix ................   Passed    6.88 sec
+      Start 45: testinfo
+26/47 Test #28: sst_output_dot ...................   Passed    6.93 sec
+      Start 46: testinfo
+27/47 Test #46: testinfo .........................   Passed    0.20 sec
+      Start 47: testinfo
+28/47 Test #45: testinfo .........................   Passed    0.22 sec
+29/47 Test #47: testinfo .........................   Passed    0.17 sec
+30/47 Test #32: sst_print_timing_info ............   Passed    6.45 sec
+31/47 Test #35: sst_sdlfile ......................   Passed    6.36 sec
+32/47 Test #21: sst_numthreads ...................   Passed    9.56 sec
+33/47 Test  #2: sst_checkpoint_name_format .......   Passed   13.93 sec
+34/47 Test #39: restart-heartbeat ................   Passed   10.41 sec
+35/47 Test  #7: sst_heartbeat_1s .................   Passed   15.09 sec
+36/47 Test #44: sigusr_interactive-15.0 ..........   Passed    9.98 sec
+37/47 Test #40: restart-interactive ..............   Passed   10.45 sec
+38/47 Test #26: sst_output_dir ...................   Passed   25.64 sec
+39/47 Test #25: sst_output_dir_json ..............   Passed   25.97 sec
+40/47 Test #27: sst_output_dir_stats .............   Passed   25.75 sec
+41/47 Test #23: sst_output_dir_config ............   Passed   26.12 sec
+42/47 Test #24: sst_output_dir_cpt ...............   Passed   26.15 sec
+43/47 Test #38: restart-ckpt-with-sigalrm-15.0 ...   Passed   23.38 sec
+44/47 Test #42: sigalrm_ckpt_comb ................   Passed   22.57 sec
+45/47 Test #43: sigalrm ..........................   Passed   24.25 sec
+46/47 Test #41: restart-sigalrm-15.0 .............   Passed   24.49 sec
+47/47 Test #29: sst_output_dot_verbosity .........   Passed   56.95 sec
+
+100% tests passed, 0 tests failed out of 47
+
+Label Time Summary:
+15.0    = 433.93 sec*proc (47 tests)
+
+Total Test time (real) =  57.56 sec
+
+### Loading sst/15.1.0 ###
+
+Current version of the local SST config is: 
+SST local configuration not found for verison 15.1.0. Creating one.
+SST-Core Version (15.1.0)
+15.1.0
+-- The CXX compiler identification is GNU 12.2.0
+-- Detecting CXX compiler ABI info
+-- Detecting CXX compiler ABI info - done
+-- Check for working CXX compiler: /opt/ohpc/pub/compiler/gcc/12.2.0/bin/c++ - skipped
+-- Detecting CXX compile features
+-- Detecting CXX compile features - done
+-- SST-Core Version (15.1.0)
+-- SST MAJOR VERSION=15
+-- SST MINOR VERSION=1
+-- SST FULL VERSION=15.1
+-- Found MPI_CXX: /scratch/opt/ohpc/pub/mpi/openmpi4-gnu12/4.1.4/lib/libmpi_cxx.so (found version "3.1") 
+-- Found MPI: TRUE (found version "3.1")  
+-- MPI RUN COMMAND=/opt/ohpc/pub/mpi/openmpi4-gnu12/4.1.4/bin/mpiexec
+-- SST-EXT-TESTS ENV{SST_COMPONENT_BASE}=/scratch/kgriesser/work/sst-ext-tests/build/components
+-- Adding CaptCrunch SST Component
+-- Adding core-debug SST Components
+-- Checking /scratch/kgriesser/work/sst-ext-tests/tests/cli for tests supporting 15.1
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/cli: sst_base.sh;sst_checkpoint_name_format.sh;sstconfig_help.sh;sstconfig_list_CXXFLAGS.sh;sstconfig_list.sh;sst_heartbeat_0.1.30.sh;sst_heartbeat_1s.sh;sst_heartbeat_90s.sh;sst-help-15.1.sh;sst_help-MIN14.0.sh;sst_help.sh;sstinfo_help.sh;sstinfo_list_elem.sh;sstinfo_list_env.sh;sstinfo_list_nodisplay.sh;sstinfo_list_quiet.sh;sstinfo_list.sh;sstinfo_list_xml_file.sh;sstinfo_list_xml.sh;sstinfo_sst.sh;sst_numthreads.sh;sst_output_config.sh;sst_output_dir_config.sh;sst_output_dir_cpt.sh;sst_output_dir_json.sh;sst_output_dir.sh;sst_output_dir_stats.sh;sst_output_dot.sh;sst_output_dot_verbosity.sh;sst_output_json.sh;sst_output_prefix.sh;sst_print_timing_info.sh;sstregister_a.sh;sst_register_list.sh;sst_sdlfile.sh;sst_version.sh;testinfo.sh
+-- Dep Check sst_base.sh = RUN
+-- Dep Check sst_checkpoint_name_format.sh = RUN
+-- Runtime sst_checkpoint_name_format.sh = 120
+-- Dep Check sstconfig_help.sh = RUN
+-- Dep Check sstconfig_list_CXXFLAGS.sh = RUN
+-- Dep Check sstconfig_list.sh = RUN
+-- Dep Check sst_heartbeat_0.1.30.sh = RUN
+-- Dep Check sst_heartbeat_1s.sh = RUN
+-- Runtime sst_heartbeat_1s.sh = 90
+-- Dep Check sst_heartbeat_90s.sh = RUN
+-- Dep Check sst-help-15.1.sh = RUN
+-- Dep Check sst_help-MIN14.0.sh = RUN
+-- Dep Check sst_help.sh = RUN
+-- Dep Check sstinfo_help.sh = RUN
+-- Dep Check sstinfo_list_elem.sh = RUN
+-- Dep Check sstinfo_list_env.sh = RUN
+-- Dep Check sstinfo_list_nodisplay.sh = RUN
+-- Dep Check sstinfo_list_quiet.sh = RUN
+-- Dep Check sstinfo_list.sh = RUN
+-- Dep Check sstinfo_list_xml_file.sh = RUN
+-- Dep Check sstinfo_list_xml.sh = RUN
+-- Dep Check sstinfo_sst.sh = RUN
+-- Dep Check sst_numthreads.sh = RUN
+-- Dep Check sst_output_config.sh = RUN
+-- Dep Check sst_output_dir_config.sh = RUN
+-- Runtime sst_output_dir_config.sh = 240
+-- Dep Check sst_output_dir_cpt.sh = RUN
+-- Runtime sst_output_dir_cpt.sh = 240
+-- Dep Check sst_output_dir_json.sh = RUN
+-- Runtime sst_output_dir_json.sh = 240
+-- Dep Check sst_output_dir.sh = RUN
+-- Runtime sst_output_dir.sh = 240
+-- Dep Check sst_output_dir_stats.sh = RUN
+-- Runtime sst_output_dir_stats.sh = 240
+-- Dep Check sst_output_dot.sh = RUN
+-- Dep Check sst_output_dot_verbosity.sh = RUN
+-- Runtime sst_output_dot_verbosity.sh = 500
+-- Dep Check sst_output_json.sh = RUN
+-- Dep Check sst_output_prefix.sh = RUN
+-- Dep Check sst_print_timing_info.sh = RUN
+-- Dep Check sstregister_a.sh = RUN
+-- Dep Check sst_register_list.sh = RUN
+-- Dep Check sst_sdlfile.sh = RUN
+-- Dep Check sst_version.sh = RUN
+-- Dep Check testinfo.sh = RUN
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/rt_action: restart-ckpt-with-heartbeat.sh;restart-ckpt-with-interactive.sh;restart-heartbeat.sh;restart-interactive.sh;sigalrm_combined.sh;sigusr-interactive2.sh;sigusr-interactive-ckpt.sh;sigusr-interactive.sh;testinfo.sh
+-- Dep Check restart-ckpt-with-heartbeat.sh = RUN
+-- Runtime restart-ckpt-with-heartbeat.sh = 120
+-- Dep Check restart-ckpt-with-interactive.sh = RUN
+-- Runtime restart-ckpt-with-interactive.sh = 120
+-- Dep Check restart-heartbeat.sh = RUN
+-- Dep Check restart-interactive.sh = RUN
+-- Dep Check sigalrm_combined.sh = RUN
+-- Runtime sigalrm_combined.sh = 90
+-- Dep Check sigusr-interactive2.sh = RUN
+-- Runtime sigusr-interactive2.sh = 90
+-- Dep Check sigusr-interactive-ckpt.sh = RUN
+-- Runtime sigusr-interactive-ckpt.sh = 90
+-- Dep Check sigusr-interactive.sh = RUN
+-- Runtime sigusr-interactive.sh = 90
+-- Dep Check testinfo.sh = RUN
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/CaptCrunch: CaptCrunch_Interactive.sh;CaptCrunch_Simple1.sh;testinfo.sh
+-- Dep Check CaptCrunch_Interactive.sh = RUN
+-- Dep Check CaptCrunch_Simple1.sh = RUN
+-- Dep Check testinfo.sh = RUN
+-- Included tests from /scratch/kgriesser/work/sst-ext-tests/tests/core-debug: cmd-basic.sh;cmd-ckptaction-err.sh;cmd-cmp-types-false.sh;cmd-comments-short.sh;cmd-comments-ws.sh;cmd-cond.sh;cmd-default-ic.sh;cmd-history.sh;cmd-logging.sh;cmd-replay2.sh;cmd-replay3.sh;cmd-replay.sh;cmd-replay-sync.sh;cmd-sanity.sh;cmd-set.sh;cmd-setstr.sh;testinfo.sh
+-- Dep Check cmd-basic.sh = RUN
+-- Runtime cmd-basic.sh = 30
+-- Dep Check cmd-ckptaction-err.sh = RUN
+-- Runtime cmd-ckptaction-err.sh = 30
+-- Dep Check cmd-cmp-types-false.sh = RUN
+-- Runtime cmd-cmp-types-false.sh = 30
+-- Dep Check cmd-comments-short.sh = RUN
+-- Runtime cmd-comments-short.sh = 30
+-- Dep Check cmd-comments-ws.sh = RUN
+-- Runtime cmd-comments-ws.sh = 30
+-- Dep Check cmd-cond.sh = RUN
+-- Runtime cmd-cond.sh = 30
+-- Dep Check cmd-default-ic.sh = RUN
+-- Runtime cmd-default-ic.sh = 30
+-- Dep Check cmd-history.sh = RUN
+-- Runtime cmd-history.sh = 30
+-- Dep Check cmd-logging.sh = RUN
+-- Runtime cmd-logging.sh = 30
+-- Dep Check cmd-replay2.sh = RUN
+-- Runtime cmd-replay2.sh = 30
+-- Dep Check cmd-replay3.sh = RUN
+-- Runtime cmd-replay3.sh = 30
+-- Dep Check cmd-replay.sh = RUN
+-- Runtime cmd-replay.sh = 30
+-- Dep Check cmd-replay-sync.sh = RUN
+-- Runtime cmd-replay-sync.sh = 30
+-- Dep Check cmd-sanity.sh = RUN
+-- Runtime cmd-sanity.sh = 30
+-- Dep Check cmd-set.sh = RUN
+-- Runtime cmd-set.sh = 30
+-- Dep Check cmd-setstr.sh = RUN
+-- Runtime cmd-setstr.sh = 30
+-- Dep Check testinfo.sh = RUN
+-- Configuring done
+-- Generating done
+-- Build files have been written to: /scratch/kgriesser/work/sst-ext-tests/build
+[ 50%] Building CXX object components/core-debug/CMakeFiles/dbgsst15.dir/probe.cc.o
+[ 50%] Building CXX object components/core-debug/CMakeFiles/dbgsst15.dir/dbgsst15.cc.o
+[ 50%] Building CXX object components/core-debug/CMakeFiles/dbgsst15.dir/basic.cc.o
+[ 66%] Building CXX object components/CaptCrunch/CMakeFiles/captcrunch.dir/CaptCrunch.cc.o
+[ 83%] Linking CXX shared library libdbgsst15.so
+[ 83%] Built target dbgsst15
+[100%] Linking CXX shared library libcaptcrunch.so
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+      Start  1: sst_base
+      Start  2: sst_checkpoint_name_format
+      Start  3: sstconfig_help
+      Start  4: sstconfig_list_CXXFLAGS
+      Start  5: sstconfig_list
+      Start  6: sst_heartbeat_0.1.30
+      Start  7: sst_heartbeat_1s
+      Start  8: sst_heartbeat_90s
+      Start  9: sst-help-15.1
+      Start 10: sst_help-MIN14.0
+      Start 11: sst_help
+      Start 12: sstinfo_help
+      Start 13: sstinfo_list_elem
+      Start 14: sstinfo_list_env
+      Start 15: sstinfo_list_nodisplay
+      Start 16: sstinfo_list_quiet
+      Start 17: sstinfo_list
+      Start 18: sstinfo_list_xml_file
+      Start 19: sstinfo_list_xml
+      Start 20: sstinfo_sst
+ 1/66 Test  #3: sstconfig_help ...................   Passed    0.22 sec
+      Start 21: sst_numthreads
+ 2/66 Test  #4: sstconfig_list_CXXFLAGS ..........   Passed    0.23 sec
+      Start 22: sst_output_config
+ 3/66 Test  #5: sstconfig_list ...................   Passed    0.28 sec
+      Start 23: sst_output_dir_config
+ 4/66 Test #12: sstinfo_help .....................   Passed    0.35 sec
+      Start 24: sst_output_dir_cpt
+ 5/66 Test #20: sstinfo_sst ......................   Passed    0.36 sec
+      Start 25: sst_output_dir_json
+ 6/66 Test #15: sstinfo_list_nodisplay ...........   Passed    0.59 sec
+      Start 26: sst_output_dir
+ 7/66 Test #17: sstinfo_list .....................   Passed    0.59 sec
+      Start 27: sst_output_dir_stats
+ 8/66 Test #16: sstinfo_list_quiet ...............   Passed    0.61 sec
+      Start 28: sst_output_dot
+ 9/66 Test #14: sstinfo_list_env .................   Passed    0.62 sec
+      Start 29: sst_output_dot_verbosity
+10/66 Test #18: sstinfo_list_xml_file ............   Passed    0.64 sec
+      Start 30: sst_output_json
+11/66 Test #19: sstinfo_list_xml .................   Passed    0.64 sec
+      Start 31: sst_output_prefix
+12/66 Test #11: sst_help .........................   Passed    3.44 sec
+      Start 32: sst_print_timing_info
+13/66 Test #10: sst_help-MIN14.0 .................   Passed    3.45 sec
+      Start 33: sstregister_a
+14/66 Test  #9: sst-help-15.1 ....................   Passed    3.45 sec
+      Start 34: sst_register_list
+15/66 Test #34: sst_register_list ................   Passed    0.13 sec
+      Start 35: sst_sdlfile
+16/66 Test #33: sstregister_a ....................   Passed    0.32 sec
+      Start 36: sst_version
+17/66 Test #13: sstinfo_list_elem ................   Passed    4.16 sec
+      Start 37: testinfo
+18/66 Test #37: testinfo .........................   Passed    0.26 sec
+      Start 38: restart-ckpt-with-heartbeat
+19/66 Test #36: sst_version ......................   Passed    1.12 sec
+      Start 39: restart-ckpt-with-interactive
+20/66 Test  #1: sst_base .........................   Passed    7.50 sec
+      Start 40: restart-heartbeat
+21/66 Test #22: sst_output_config ................   Passed    7.41 sec
+      Start 41: restart-interactive
+22/66 Test  #6: sst_heartbeat_0.1.30 .............   Passed    7.64 sec
+      Start 42: sigalrm_combined
+23/66 Test #28: sst_output_dot ...................   Passed    7.04 sec
+      Start 43: sigusr-interactive2
+24/66 Test  #8: sst_heartbeat_90s ................   Passed    7.69 sec
+      Start 44: sigusr-interactive-ckpt
+25/66 Test #30: sst_output_json ..................   Passed    7.09 sec
+      Start 45: sigusr-interactive
+26/66 Test #31: sst_output_prefix ................   Passed    7.09 sec
+      Start 46: testinfo
+27/66 Test #46: testinfo .........................   Passed    0.29 sec
+      Start 47: CaptCrunch_Interactive
+28/66 Test #32: sst_print_timing_info ............   Passed    6.48 sec
+      Start 48: CaptCrunch_Simple1
+29/66 Test #35: sst_sdlfile ......................   Passed    6.42 sec
+      Start 49: testinfo
+30/66 Test #21: sst_numthreads ...................   Passed    9.86 sec
+      Start 50: cmd-basic
+31/66 Test #49: testinfo .........................   Passed    0.24 sec
+      Start 51: cmd-ckptaction-err
+32/66 Test #47: CaptCrunch_Interactive ...........   Passed    2.31 sec
+      Start 52: cmd-cmp-types-false
+33/66 Test #51: cmd-ckptaction-err ...............   Passed    2.32 sec
+      Start 53: cmd-comments-short
+34/66 Test #50: cmd-basic ........................   Passed    2.56 sec
+      Start 54: cmd-comments-ws
+35/66 Test #52: cmd-cmp-types-false ..............   Passed    3.69 sec
+      Start 55: cmd-cond
+36/66 Test  #2: sst_checkpoint_name_format .......   Passed   14.60 sec
+      Start 56: cmd-default-ic
+37/66 Test #53: cmd-comments-short ...............   Passed    2.25 sec
+      Start 57: cmd-history
+38/66 Test #38: restart-ckpt-with-heartbeat ......   Passed   10.40 sec
+      Start 58: cmd-logging
+39/66 Test #39: restart-ckpt-with-interactive ....   Passed    9.97 sec
+      Start 59: cmd-replay2
+40/66 Test  #7: sst_heartbeat_1s .................   Passed   15.31 sec
+      Start 60: cmd-replay3
+41/66 Test #55: cmd-cond .........................   Passed    2.51 sec
+      Start 61: cmd-replay
+42/66 Test #56: cmd-default-ic ...................   Passed    2.51 sec
+      Start 62: cmd-replay-sync
+43/66 Test #57: cmd-history ......................   Passed    2.41 sec
+      Start 63: cmd-sanity
+44/66 Test #40: restart-heartbeat ................   Passed   10.38 sec
+      Start 64: cmd-set
+45/66 Test #41: restart-interactive ..............   Passed   10.54 sec
+      Start 65: cmd-setstr
+46/66 Test #44: sigusr-interactive-ckpt ..........   Passed   11.07 sec
+      Start 66: testinfo
+47/66 Test #45: sigusr-interactive ...............   Passed   11.06 sec
+48/66 Test #43: sigusr-interactive2 ..............   Passed   11.15 sec
+49/66 Test #66: testinfo .........................   Passed    0.37 sec
+50/66 Test #62: cmd-replay-sync ..................   Passed    2.56 sec
+51/66 Test #54: cmd-comments-ws ..................   Passed    7.73 sec
+52/66 Test #65: cmd-setstr .......................   Passed    2.61 sec
+53/66 Test #64: cmd-set ..........................   Passed    3.42 sec
+54/66 Test #23: sst_output_dir_config ............   Passed   26.71 sec
+55/66 Test #25: sst_output_dir_json ..............   Passed   26.60 sec
+56/66 Test #26: sst_output_dir ...................   Passed   26.38 sec
+57/66 Test #27: sst_output_dir_stats .............   Passed   26.44 sec
+58/66 Test #24: sst_output_dir_cpt ...............   Passed   26.74 sec
+59/66 Test #58: cmd-logging ......................   Passed   14.58 sec
+60/66 Test #48: CaptCrunch_Simple1 ...............   Passed   20.01 sec
+61/66 Test #61: cmd-replay .......................   Passed   13.87 sec
+62/66 Test #59: cmd-replay2 ......................   Passed   16.02 sec
+63/66 Test #63: cmd-sanity .......................   Passed   14.89 sec
+64/66 Test #60: cmd-replay3 ......................   Passed   17.22 sec
+65/66 Test #29: sst_output_dot_verbosity .........   Passed   56.98 sec
+66/66 Test #42: sigalrm_combined .................   Passed   65.73 sec
+
+100% tests passed, 0 tests failed out of 66
+
+Label Time Summary:
+15.1    = 590.14 sec*proc (66 tests)
+
+Total Test time (real) =  73.40 sec
+/scratch/kgriesser/work/sst-ext-tests/audit/251222
+audit-gizmo.sh finished normally. See /scratch/kgriesser/work/sst-ext-tests/audit/251222

--- a/audit/251222/testlist.audit
+++ b/audit/251222/testlist.audit
@@ -1,0 +1,360 @@
+/scratch/kgriesser/work/sst-ext-tests/build
+
+### Checking test selection for sst version 13.0 ###
+
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+  Test  #1: sst_base
+  Test  #2: sstconfig_help
+  Test  #3: sstconfig_list_CXXFLAGS
+  Test  #4: sstconfig_list
+  Test  #5: sst_heartbeat_0.1.30
+  Test  #6: sst_help-13.0
+  Test  #7: sst_help
+  Test  #8: sstinfo_help
+  Test  #9: sstinfo_list_elem
+  Test #10: sstinfo_list_env
+  Test #11: sstinfo_list_nodisplay
+  Test #12: sstinfo_list_quiet
+  Test #13: sstinfo_list
+  Test #14: sstinfo_list_xml_file
+  Test #15: sstinfo_list_xml
+  Test #16: sstinfo_sst
+  Test #17: sst_numthreads
+  Test #18: sst_output_config
+  Test #19: sst_output_dot
+  Test #20: sst_output_dot_verbosity
+  Test #21: sst_output_json
+  Test #22: sst_output_prefix
+  Test #23: sst_print_timing_info
+  Test #24: sstregister_a
+  Test #25: sst_register_list
+  Test #26: sst_sdlfile
+  Test #27: sst_version
+  Test #28: testinfo
+  Test #29: testinfo
+  Test #30: testinfo
+  Test #31: testinfo
+
+Total Tests: 31
+
+### Checking test selection for sst version 13.1 ###
+
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+  Test  #1: sst_base
+  Test  #2: sstconfig_help
+  Test  #3: sstconfig_list_CXXFLAGS
+  Test  #4: sstconfig_list
+  Test  #5: sst_heartbeat_0.1.30
+  Test  #6: sst_help-13.1
+  Test  #7: sst_help
+  Test  #8: sstinfo_help
+  Test  #9: sstinfo_list_elem
+  Test #10: sstinfo_list_env
+  Test #11: sstinfo_list_nodisplay
+  Test #12: sstinfo_list_quiet
+  Test #13: sstinfo_list
+  Test #14: sstinfo_list_xml_file
+  Test #15: sstinfo_list_xml
+  Test #16: sstinfo_sst
+  Test #17: sst_numthreads
+  Test #18: sst_output_config
+  Test #19: sst_output_dot
+  Test #20: sst_output_dot_verbosity
+  Test #21: sst_output_json
+  Test #22: sst_output_prefix
+  Test #23: sst_print_timing_info
+  Test #24: sstregister_a
+  Test #25: sst_register_list
+  Test #26: sst_sdlfile
+  Test #27: sst_version
+  Test #28: testinfo
+  Test #29: testinfo
+  Test #30: testinfo
+  Test #31: testinfo
+
+Total Tests: 31
+
+### Checking test selection for sst version 14.0 ###
+
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+  Test  #1: sst_base
+  Test  #2: sstconfig_help
+  Test  #3: sstconfig_list_CXXFLAGS
+  Test  #4: sstconfig_list
+  Test  #5: sst_heartbeat_0.1.30
+  Test  #6: sst_help-14.0
+  Test  #7: sst_help-MIN14.0
+  Test  #8: sst_help
+  Test  #9: sstinfo_help
+  Test #10: sstinfo_list_elem
+  Test #11: sstinfo_list_env
+  Test #12: sstinfo_list_nodisplay
+  Test #13: sstinfo_list_quiet
+  Test #14: sstinfo_list
+  Test #15: sstinfo_list_xml_file
+  Test #16: sstinfo_list_xml
+  Test #17: sstinfo_sst
+  Test #18: sst_numthreads
+  Test #19: sst_output_config
+  Test #20: sst_output_dot
+  Test #21: sst_output_dot_verbosity
+  Test #22: sst_output_json
+  Test #23: sst_output_prefix
+  Test #24: sst_print_timing_info
+  Test #25: sstregister_a
+  Test #26: sst_register_list
+  Test #27: sst_sdlfile
+  Test #28: sst_version
+  Test #29: testinfo
+  Test #30: testinfo
+  Test #31: testinfo
+  Test #32: testinfo
+
+Total Tests: 32
+
+### Checking test selection for sst version 14.1 ###
+
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+  Test  #1: sst_base
+  Test  #2: sstconfig_help
+  Test  #3: sstconfig_list_CXXFLAGS
+  Test  #4: sstconfig_list
+  Test  #5: sst_heartbeat_0.1.30
+  Test  #6: sst_heartbeat_1s
+  Test  #7: sst_help-14.1
+  Test  #8: sst_help-MIN14.0
+  Test  #9: sst_help
+  Test #10: sstinfo_help
+  Test #11: sstinfo_list_elem
+  Test #12: sstinfo_list_env
+  Test #13: sstinfo_list_nodisplay
+  Test #14: sstinfo_list_quiet
+  Test #15: sstinfo_list
+  Test #16: sstinfo_list_xml_file
+  Test #17: sstinfo_list_xml
+  Test #18: sstinfo_sst
+  Test #19: sst_numthreads
+  Test #20: sst_output_config
+  Test #21: sst_output_dot
+  Test #22: sst_output_dot_verbosity
+  Test #23: sst_output_json
+  Test #24: sst_output_prefix
+  Test #25: sst_print_timing_info
+  Test #26: sstregister_a
+  Test #27: sst_register_list
+  Test #28: sst_sdlfile
+  Test #29: sst_version
+  Test #30: testinfo
+  Test #31: restart-heartbeat-14.1
+  Test #32: restart-interactive-14.1
+  Test #33: restart-sigalrm-14.1
+  Test #34: sigalrm_ckpt_comb
+  Test #35: sigalrm
+  Test #36: testinfo
+  Test #37: testinfo
+  Test #38: testinfo
+
+Total Tests: 38
+
+### Checking test selection for sst version 15.0 ###
+
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+  Test  #1: sst_base
+  Test  #2: sst_checkpoint_name_format
+  Test  #3: sstconfig_help
+  Test  #4: sstconfig_list_CXXFLAGS
+  Test  #5: sstconfig_list
+  Test  #6: sst_heartbeat_0.1.30
+  Test  #7: sst_heartbeat_1s
+  Test  #8: sst_heartbeat_90s
+  Test  #9: sst_help-15.0
+  Test #10: sst_help-MIN14.0
+  Test #11: sst_help
+  Test #12: sstinfo_help
+  Test #13: sstinfo_list_elem
+  Test #14: sstinfo_list_env
+  Test #15: sstinfo_list_nodisplay
+  Test #16: sstinfo_list_quiet
+  Test #17: sstinfo_list
+  Test #18: sstinfo_list_xml_file
+  Test #19: sstinfo_list_xml
+  Test #20: sstinfo_sst
+  Test #21: sst_numthreads
+  Test #22: sst_output_config
+  Test #23: sst_output_dir_config
+  Test #24: sst_output_dir_cpt
+  Test #25: sst_output_dir_json
+  Test #26: sst_output_dir
+  Test #27: sst_output_dir_stats
+  Test #28: sst_output_dot
+  Test #29: sst_output_dot_verbosity
+  Test #30: sst_output_json
+  Test #31: sst_output_prefix
+  Test #32: sst_print_timing_info
+  Test #33: sstregister_a
+  Test #34: sst_register_list
+  Test #35: sst_sdlfile
+  Test #36: sst_version
+  Test #37: testinfo
+  Test #38: restart-ckpt-with-sigalrm-15.0
+  Test #39: restart-heartbeat
+  Test #40: restart-interactive
+  Test #41: restart-sigalrm-15.0
+  Test #42: sigalrm_ckpt_comb
+  Test #43: sigalrm
+  Test #44: sigusr_interactive-15.0
+  Test #45: testinfo
+  Test #46: testinfo
+  Test #47: testinfo
+
+Total Tests: 47
+
+### Checking test selection for sst version 15.1 ###
+
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+  Test  #1: sst_base
+  Test  #2: sst_checkpoint_name_format
+  Test  #3: sstconfig_help
+  Test  #4: sstconfig_list_CXXFLAGS
+  Test  #5: sstconfig_list
+  Test  #6: sst_heartbeat_0.1.30
+  Test  #7: sst_heartbeat_1s
+  Test  #8: sst_heartbeat_90s
+  Test  #9: sst-help-15.1
+  Test #10: sst_help-MIN14.0
+  Test #11: sst_help
+  Test #12: sstinfo_help
+  Test #13: sstinfo_list_elem
+  Test #14: sstinfo_list_env
+  Test #15: sstinfo_list_nodisplay
+  Test #16: sstinfo_list_quiet
+  Test #17: sstinfo_list
+  Test #18: sstinfo_list_xml_file
+  Test #19: sstinfo_list_xml
+  Test #20: sstinfo_sst
+  Test #21: sst_numthreads
+  Test #22: sst_output_config
+  Test #23: sst_output_dir_config
+  Test #24: sst_output_dir_cpt
+  Test #25: sst_output_dir_json
+  Test #26: sst_output_dir
+  Test #27: sst_output_dir_stats
+  Test #28: sst_output_dot
+  Test #29: sst_output_dot_verbosity
+  Test #30: sst_output_json
+  Test #31: sst_output_prefix
+  Test #32: sst_print_timing_info
+  Test #33: sstregister_a
+  Test #34: sst_register_list
+  Test #35: sst_sdlfile
+  Test #36: sst_version
+  Test #37: testinfo
+  Test #38: restart-ckpt-with-heartbeat
+  Test #39: restart-ckpt-with-interactive
+  Test #40: restart-heartbeat
+  Test #41: restart-interactive
+  Test #42: sigalrm_combined
+  Test #43: sigusr-interactive2
+  Test #44: sigusr-interactive-ckpt
+  Test #45: sigusr-interactive
+  Test #46: testinfo
+  Test #47: CaptCrunch_Interactive
+  Test #48: CaptCrunch_Simple1
+  Test #49: testinfo
+  Test #50: cmd-basic
+  Test #51: cmd-ckptaction-err
+  Test #52: cmd-cmp-types-false
+  Test #53: cmd-comments-short
+  Test #54: cmd-comments-ws
+  Test #55: cmd-cond
+  Test #56: cmd-default-ic
+  Test #57: cmd-history
+  Test #58: cmd-logging
+  Test #59: cmd-replay2
+  Test #60: cmd-replay3
+  Test #61: cmd-replay
+  Test #62: cmd-replay-sync
+  Test #63: cmd-sanity
+  Test #64: cmd-set
+  Test #65: cmd-setstr
+  Test #66: testinfo
+
+Total Tests: 66
+
+### Checking test selection for sst version DEV ###
+
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+  Test  #1: sst_base
+  Test  #2: sst_checkpoint_name_format
+  Test  #3: sstconfig_help
+  Test  #4: sstconfig_list_CXXFLAGS
+  Test  #5: sstconfig_list
+  Test  #6: sst_heartbeat_0.1.30
+  Test  #7: sst_heartbeat_1s
+  Test  #8: sst_heartbeat_90s
+  Test  #9: sst_help-MIN14.0
+  Test #10: sst_help
+  Test #11: sstinfo_help
+  Test #12: sstinfo_list_elem
+  Test #13: sstinfo_list_env
+  Test #14: sstinfo_list_nodisplay
+  Test #15: sstinfo_list_quiet
+  Test #16: sstinfo_list
+  Test #17: sstinfo_list_xml_file
+  Test #18: sstinfo_list_xml
+  Test #19: sstinfo_sst
+  Test #20: sst_numthreads
+  Test #21: sst_output_config
+  Test #22: sst_output_dir_config
+  Test #23: sst_output_dir_cpt
+  Test #24: sst_output_dir_json
+  Test #25: sst_output_dir
+  Test #26: sst_output_dir_stats
+  Test #27: sst_output_dot
+  Test #28: sst_output_dot_verbosity
+  Test #29: sst_output_json
+  Test #30: sst_output_prefix
+  Test #31: sst_print_timing_info
+  Test #32: sstregister_a
+  Test #33: sst_register_list
+  Test #34: sst_sdlfile
+  Test #35: sst_version
+  Test #36: testinfo
+  Test #37: restart-ckpt-with-heartbeat
+  Test #38: restart-ckpt-with-interactive
+  Test #39: restart-heartbeat
+  Test #40: restart-interactive
+  Test #41: sigalrm_combined
+  Test #42: sigusr-interactive2
+  Test #43: sigusr-interactive-ckpt
+  Test #44: sigusr-interactive
+  Test #45: testinfo
+  Test #46: CaptCrunch_Interactive
+  Test #47: CaptCrunch_Simple1
+  Test #48: testinfo
+  Test #49: cmd-basic
+  Test #50: cmd-ckptaction-err
+  Test #51: cmd-cmp-types-false
+  Test #52: cmd-comments-short
+  Test #53: cmd-comments-ws
+  Test #54: cmd-cond
+  Test #55: cmd-default-ic
+  Test #56: cmd-history
+  Test #57: cmd-logging
+  Test #58: cmd-replay2
+  Test #59: cmd-replay3
+  Test #60: cmd-replay
+  Test #61: cmd-replay-sync
+  Test #62: cmd-sanity
+  Test #63: cmd-set
+  Test #64: cmd-setstr
+  Test #65: testinfo
+  Test #66: type-aggregate
+  Test #67: type-pair
+  Test #68: type-priority-queue
+  Test #69: type-queue-1
+  Test #70: type-queue
+  Test #71: type-stack
+  Test #72: type-tuple
+
+Total Tests: 72

--- a/audit/251222/tests.info
+++ b/audit/251222/tests.info
@@ -1,0 +1,149 @@
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| Test                                          | MinVer | MaxVer | Desc                                                                                                           |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| sst-help-15.1                                 | 15.1   | 15.1   | Displays the help menu of SST 15.1                                                                             |
+| sst_base                                      | 13.0   | None   | Basic execution test suitable for all versions of SST                                                          |
+| sst_checkpoint_name_format                    | 15.0   | None   | Tests custom naming of checkpoint directories and files                                                        |
+| sst_heartbeat_0.1.30                          | 13.0   | None   | Tests a 90 second heartbeat using %H:%M:%S syntax                                                              |
+| sst_heartbeat_90s                             | 15.0   | None   | Tests a 90 second heartbeat using seconds-only syntax                                                          |
+| sst_help-13.0                                 | 13.0   | 13.0   | Displays help menu for SST 13.0                                                                                |
+| sst_help-13.1                                 | 13.1   | 13.1   | Displays the help menu of SST 13.1                                                                             |
+| sst_help-14.0                                 | 14.0   | 14.0   | Displays the help menu of the SST 14.0                                                                         |
+| sst_help-14.1                                 | 14.1   | 14.1   | Displays the help menu of SST 14.1                                                                             |
+| sst_help-15.0                                 | 15.0   | 15.0   | Displays the help menu of SST 15.0                                                                             |
+| sst_help-MIN14.0                              | 14.0   | None   | Displays the help menu for SST versions of minimum of SST 14.0                                                 |
+| sst_help                                      | 13.0   | None   | Displays the help menu for all versions of SST                                                                 |
+| sst_numthreads                                | 13.0   | None   | Tests the num_threads option for executing a basic SDL file                                                    |
+| sst_output_config                             | 13.0   | None   | Tests outputting the config file back to a python script                                                       |
+| sst_output_dir                                | 15.0   | None   | Tests basic directory creation using --output-directory                                                        |
+| sst_output_dir_config                         | 15.0   | None   | Tests relocation of config files                                                                               |
+| sst_output_dir_cpt                            | 15.0   | None   | Tests relocation of checkpoint files                                                                           |
+| sst_output_dir_json                           | 15.0   | None   | Tests relocation of JSON config files                                                                          |
+| sst_output_dir_stats                          | 15.0   | None   | Tests statistics output file creation using --output-directory                                                 |
+| sst_output_dot                                | 13.0   | None   | Tests outputting the config graph as a dot file                                                                |
+| sst_output_dot_verbosity                      | 13.0   | None   | Tests outputting config graph graph data to a dot file with verbosity                                          |
+| sst_output_json                               | 13.0   | None   | Tests outptting the config graph to JSON                                                                       |
+| sst_output_prefix                             | 13.0   | None   | Tests outputting files with a prefix                                                                           |
+| sst_print_timing_info                         | 13.0   | None   | Tests printing the runtime timing info                                                                         |
+| sst_register_list                             | 13.0   | None   | Tests listing the registered sst component libraries                                                           |
+| sst_sdlfile                                   | 13.0   | None   | Tests the SDL file runtime option                                                                              |
+| sst_version                                   | 13.0   | None   | Tests printing the SST version info                                                                            |
+| sstconfig_help                                | 13.0   | None   | Tests printing the sst-config help menu                                                                        |
+| sstconfig_list                                | 13.0   | None   | Tests the baseline sst-config                                                                                  |
+| sstconfig_list_CXXFLAGS                       | 13.0   | None   | Tests printing the CXXFLAGS sst-config option                                                                  |
+| sstinfo_help                                  | 13.0   | None   | Tests the sst-info help menu                                                                                   |
+| sstinfo_list                                  | 13.0   | None   | Tests the output of the basic sst-info command                                                                 |
+| sstinfo_list_elem                             | 13.0   | None   | Tests printing sst-info for all the appropriate ELEMENT LIBRARY values                                         |
+| sstinfo_list_env                              | 13.0   | None   | Tests the sst-info print-env command option                                                                    |
+| sstinfo_list_nodisplay                        | 13.0   | None   | Tests the sst-info no info option                                                                              |
+| sstinfo_list_quiet                            | 13.0   | None   | Tests the sst-info quiet option                                                                                |
+| sstinfo_list_xml                              | 13.0   | None   | Tests the sst-info xml output                                                                                  |
+| sstinfo_list_xml_file                         | 13.0   | None   | Tests the sst-info XML output with a specified file                                                            |
+| sstinfo_sst                                   | 13.0   | None   | Tests the output of the basic sst-info sst command                                                             |
+| sstregister_a                                 | 13.0   | None   | Tests the known failure of the sst-register -a option                                                          |
+| testinfo                                      | None   | None   | Provide information on local tests                                                                             |
+| sst_heartbeat_1s                              | 14.1   | None   | Tests a 1 second heartbeat                                                                                     |
+| test_Checkpoint-DEV                           | None   | None   | Tests checkpointing                                                                                            |
+| test_Component-DEV                            | None   | None   | Tests component loading with checkpointing                                                                     |
+| test_Component_createStats-DEV                | None   | None   | Tests statistics with checkpointing                                                                            |
+| test_Component_enableAllStats-DEV             | None   | None   | Tests enabling all stats with checkpointing                                                                    |
+| test_Component_setStats-DEV                   | None   | None   | Tests setting stats with checkpointing                                                                         |
+| test_Component_time_overflow-DEV              | None   | None   | Tests time overflow with checkpointing                                                                         |
+| test_Links-DEV                                | None   | None   | Tests link handlers with checkpointing                                                                         |
+| test_MemPool_overflow-DEV                     | None   | None   | Tests mempooling overflowo with checkpointing                                                                  |
+| test_MemPool_undeleted_items-DEV              | None   | None   | Tests mempooling undeleted items with checkpointing                                                            |
+| test_MessageMesh-DEV                          | None   | None   | Tests message mesh routing with checkpointing                                                                  |
+| test_Module-DEV                               | None   | None   | Tests the module loader with checkpointing                                                                     |
+| test_Output-DEV                               | None   | None   | Tests the outputter with checkpointing                                                                         |
+| test_ParallelLoad-DEV                         | None   | None   | Tests parallel loading with checkpointing                                                                      |
+| test_ParamComponent-DEV                       | None   | None   | Tests component parameter loading with checkpointing                                                           |
+| test_PerfComponent-DEV                        | None   | None   | Tests perf component with checkpointing                                                                        |
+| test_PythonUnitAlgebra-DEV                    | None   | None   | Tests Python unit algebra with checkpointing                                                                   |
+| test_RNGComponent_marsaglia-DEV               | None   | None   | Tests the RNG marsaglia with checkpointing                                                                     |
+| test_RNGComponent_mersenne-DEV                | None   | None   | Tests the RNG mersenne with checkpointing                                                                      |
+| test_RNGComponent_xorshift-DEV                | None   | None   | Tests RNG xorshift with checkpointing                                                                          |
+| test_Serialization_ATOMIC-DEV                 | None   | None   | Tests the basic serialization with ATOMIC types and checkpointing                                              |
+| test_Serialization_COMPONENTINFO-DEV          | None   | None   | Tests the basic serialization with COMPONENT INFO types and checkpointing                                      |
+| test_Serialization_HANDLER-DEV                | None   | None   | Tests the basic serialization with HANDLER types and checkpointing                                             |
+| test_Serialization_MAPTOVECTOR-DEV            | None   | None   | Tests the basic serialization with MAP TO VECTOR types and checkpointing                                       |
+| test_Serialization_ORDERED_CONTAINERS-DEV     | None   | None   | Tests the basic serialization with ORDERED CONTAINERS types and checkpointing                                  |
+| test_Serialization_POD-DEV                    | None   | None   | Tests the basic serialization with POD types and checkpointing                                                 |
+| test_Serialization_PODPTR-DEV                 | None   | None   | Tests the basic serialization with PODPTR types and checkpointing                                              |
+| test_Serialization_POINTERTRACKING-DEV        | None   | None   | Tests the basic serialization with POINTER TRACKING types and checkpointing                                    |
+| test_Serialization_UNORDERED_CONTAINERS-DEV   | None   | None   | Tests the basic serialization with UNORDERED CONTAINERS types and checkpointing                                |
+| test_SharedObject-DEV                         | None   | None   | Tests shared object loading with checkpointing                                                                 |
+| test_StatisticsComponent-DEV                  | None   | None   | Tests statistics with integers and checkpointing                                                               |
+| test_StatisticsComponent_basic-DEV            | None   | None   | None                                                                                                           |
+| test_SubComponent-DEV                         | None   | None   | Tests subcomponent loading with checkpointing                                                                  |
+| test_SubComponent_2-DEV                       | None   | None   | None                                                                                                           |
+| cmd-replay3                                   | 15.1   | None   | Debug replay from file and check we get a prompt                                                               |
+| cmd-setstr                                    | 15.1   | None   | Check set string with spaces                                                                                   |
+| type-pair                                     | DEV    | None   | short std::pair watch test                                                                                     |
+| cmd-ckptaction                                | NEW    | None   | Check that trace checkpoint action triggers checkpoints                                                        |
+| cmd-watch                                     | NEW    | None   | Check watch commands with different trigger types                                                              |
+| cmd-multithread-NEW                           | NEW    | None   | Test basic thread commands: thread, info                                                                       |
+| type-aggregate                                | DEV    | None   | Exercise aggregate types                                                                                       |
+| type-stack                                    | DEV    | None   | Exercise std::stack<unsigned>                                                                                  |
+| type-queue                                    | DEV    | None   | Exercise std::queue<unsigned>                                                                                  |
+| cmd-cond                                      | 15.1   | None   | Basic check for simple conditional watch trigger                                                               |
+| cmd-replay                                    | 15.1   | None   | Replay file from inside debug console                                                                          |
+| cmd-sanity                                    | 15.1   | None   | Enter interactive mode, change an internal variable and confirm it has been change                             |
+| testinfo                                      | None   | None   | Provide information on local tests                                                                             |
+| type-tuple                                    | DEV    | None   | Exercise std::pair and std::tuple                                                                              |
+| cmd-actions                                   | NEW    | None   | Check for interactive, printTrace, printStatus, and set actions                                                |
+| cmd-handler                                   | NEW    | None   | Check setHandler commands with trace                                                                           |
+| cmd-unwatch                                   | NEW    | None   | Check interactive console unwatch command                                                                      |
+| cmd-basic                                     | 15.1   | None   | Basic interactive command check: cd, ls, pwd, run, continue                                                    |
+| cmd-multithread-serial-NEW                    | NEW    | None   | Test basic thread commands in serial exec: thread, info                                                        |
+| type-queue-1                                  | DEV    | None   | Exercise std::queue<unsigned> with one component                                                               |
+| cmd-ckptaction-err                            | 15.1   | None   | Check checkpoint action triggers error when checkpoint not enabled                                             |
+| cmd-cmp-types-false                           | 15.1   | None   | Test comparisons for different types: all false                                                                |
+| cmd-comments-ws                               | 15.1   | None   | Check that comments have no effect in replay file                                                              |
+| cmd-default-ic                                | 15.1   | None   | Tests use of default IC with interactive-start                                                                 |
+| cmd-define                                    | NEW    | None   | Exercise std::bitset and std::vector<bool>                                                                     |
+| cmd-help                                      | NEW    | None   | Walk through help commands                                                                                     |
+| cmd-history                                   | 15.1   | None   | Log history to file and check it                                                                               |
+| cmd-logging                                   | 15.1   | None   | Log debug commands to an external file                                                                         |
+| cmd-multithread-8thds-NEW                     | NEW    | None   | Test basic thread commands: thread, info                                                                       |
+| cmd-multithread-actions-NEW                   | NEW    | None   | Test trace actions in thread1                                                                                  |
+| cmd-multithread-shutdown-NEW                  | NEW    | None   | Test trace actions in thread1                                                                                  |
+| cmd-print-NEW                                 | NEW    | None   | Check for seg fault with recursive print                                                                       |
+| cmd-replay-sync                               | 15.1   | None   | Conditional watch trigger replayed from file                                                                   |
+| cmd-replay2                                   | 15.1   | None   | Replay session using SST command line option                                                                   |
+| cmd-set                                       | 15.1   | None   | Check for set and print commands                                                                               |
+| type-bitset                                   | NEW    | None   | Exercise std::bitset and std::vector<bool>                                                                     |
+| cmd-cmp-types-true                            | NEW    | None   | Test comparisons for different types: all true                                                                 |
+| cmd-trace                                     | NEW    | None   | Check for trace commands: trace, printWatchpoint, addTraceVar, printTrace, resetTrace, unwatch, quit           |
+| cmd-comments-short                            | 15.1   | None   | Check that comments have no effect in replay file                                                              |
+| type-priority-queue                           | DEV    | None   | Exercise std::priority_queue<unsigned>                                                                         |
+| mpi-sdl-ALL                                   | None   | None   | Sample test input file                                                                                         |
+| mpi-sdl-DEV                                   | None   | None   | Sample test input file                                                                                         |
+| restart-ckpt-with-sigalrm-15.0                | 15.0   | 15.0   | Tests checkpoint with sigalrm to see if the sigalrm is carried over to restart (i.e. load-checkpoint)          |
+| restart-heartbeat-14.1                        | 14.1   | 14.1   | Tests using sigalrm with restart (i.e. load checkpoint)                                                        |
+| restart-interactive-14.1                      | 14.1   | 14.1   | Tests using interactive console with restart (i.e. load checkpoint)                                            |
+| restart-sigalrm-14.1                          | 14.1   | 14.1   | Tests using sigalrm with restart (i.e. load checkpoint)                                                        |
+| testinfo                                      | None   | None   | Provide information on local tests                                                                             |
+| restart-ckpt-with-heartbeat                   | 15.1   | None   | Tests restart for a checkpoint that had heartbeat to see if the heartbeat is carried over.                     |
+| restart-ckpt-with-sigalrm-NEW                 | NEW    | None   | Tests checkpoint with sigalrm to see if the sigalrm is carried over to restart (i.e. load-checkpoint)          |
+| restart-ckpt-with-interactive-prefix-path-NEW | NEW    | None   | Tests expected fail for passing path to checkpoint-prefix.                                                     |
+| restart-ckpt-with-interactive                 | 15.1   | None   | Tests restart for a checkpoint that had interactive console to see if the interactive console is carried over. |
+| restart-sigalrm-15.0                          | 15.0   | 15.0   | Tests using sigalrm with restart (i.e. load checkpoint)                                                        |
+| restart-sigalrm-NEW                           | NEW    | None   | Tests using sigalrm with restart (i.e. load checkpoint)                                                        |
+| sigalrm-NEW                                   | NEW    | None   | Tests sigalrm for single real time actions                                                                     |
+| sigalrm                                       | 14.1   | 15.0   | Tests sigalrm for single real time actions                                                                     |
+| sigalrm_ckpt_comb-NEW                         | NEW    | None   | Tests sigalrm for checkpoint combined with other real time actions                                             |
+| sigalrm_ckpt_comb                             | 14.1   | 15.0   | Tests sigalrm for checkpoint combined with other real time actions                                             |
+| sigusr-NEW                                    | NEW    | None   | Tests sigusr1/2 for single real time actions                                                                   |
+| restart-heartbeat                             | 15.0   | None   | Tests using sigalrm with restart (i.e. load checkpoint)                                                        |
+| restart-interactive                           | 15.0   | None   | Tests using interactive console with restart (i.e. load checkpoint)                                            |
+| sigalrm_combined                              | 15.1   | None   | Tests sigalrm for combinations of two real time actions (checkpoint not included)                              |
+| restart-ckpt-with-sigalrm                     | NEW    | None   | Tests checkpoint with sigalrm to see if the sigalrm is carried over to restart (i.e. load-checkpoint)          |
+| sigusr-interactive-ckpt                       | 15.1   | None   | Tests sigusr1/2 with default interactive console w/checkpoint                                                  |
+| sigusr-interactive                            | 15.1   | None   | Tests sigusr1/2 with interactive console real time action                                                      |
+| sigusr-interactive2                           | 15.1   | None   | Tests sigusr1/2 with default interactive console & real time action                                            |
+| sigusr-prefix-path-NEW                        | NEW    | None   | Tests sigusr1/2 expected fail when passing path to checkpoint-directory                                        |
+| sigusr_interactive-15.0                       | 15.0   | 15.0   | Tests sigusr1/2 with interactive console real time action                                                      |
+| CaptCrunch_Interactive                        | 15.1   | None   | Tests CaptCrunch simple data integrity                                                                         |
+| CaptCrunch_Simple1                            | 15.1   | None   | Tests CaptCrunch simple data integrity                                                                         |
+| testinfo                                      | None   | None   | Provide information on local tests                                                                             |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/components/CaptCrunch/CaptCrunch.cc
+++ b/components/CaptCrunch/CaptCrunch.cc
@@ -94,11 +94,12 @@ CaptCrunch::serialize_order(SST::Core::Serialization::serializer& ser)
     SST_SER(sLongValue);
     SST_SER(sLongLongValue);
 
+#ifdef SST_VER_GT_15_1
     SST_SER(floatComplex);
     SST_SER(doubleComplex);
     SST_SER(CfloatComplex);
     SST_SER(CdoubleComplex);
-
+#endif
     SST_SER(fTypeStructValue);
 
     SST_SER(strValue);
@@ -190,7 +191,7 @@ CaptCrunch::serialize_order(SST::Core::Serialization::serializer& ser)
 
     SST_SER(unsignedVectVectVect);
 
-
+#ifdef SST_VER_GT_15_1
     SST_SER(sharedPtrInt);
     SST_SER_NAME(SST::Core::Serialization::shared_ptr(sharedPtrIntArray, sharedPtrIntArraySize), "sharedPtrIntArray");
     SST_SER(sharedPtrIntFixedArray);
@@ -203,6 +204,7 @@ CaptCrunch::serialize_order(SST::Core::Serialization::serializer& ser)
     SST_SER(optionalVectorInt);
 
     SST_SER(variant);
+#endif
   }
 
   template <typename T>
@@ -255,10 +257,12 @@ CaptCrunch::initData()
     uLongValue     = 1234ul;
     uLongLongValue = 1234ull;
 
+#ifdef SST_VER_GT_15_1
     floatComplex = std::complex<float>(123, 456);
     doubleComplex = std::complex<double>(789, 345);
     CfloatComplex = make_complex(1234.0f, 4567.0f);
     CdoubleComplex = make_complex(10240.0, 81920.0);
+#endif
 
 // Presumably intentional  unsigned to signed type conversions
 #pragma GCC diagnostic push
@@ -458,7 +462,7 @@ CaptCrunch::initData()
 
     unsignedVectVectVect.push_back(unsignedVectVect);
     unsignedVectVectVect.push_back(unsignedVectVect);
-
+#ifdef SST_VER_GT_15_1
     sharedPtrInt = std::make_shared<int>(123);
     sharedPtrIntArraySize = 10;
     sharedPtrIntArray = std::shared_ptr<size_t[]>(new size_t[sharedPtrIntArraySize]);
@@ -481,6 +485,7 @@ CaptCrunch::initData()
     optionalVectorInt = {5, 6, 7, 8};
 
     variant.emplace<2>(std::make_tuple(true, 123));
+#endif
 }
 
 bool

--- a/components/CaptCrunch/CaptCrunch.h
+++ b/components/CaptCrunch/CaptCrunch.h
@@ -146,10 +146,12 @@ private:
     signed long        sLongValue;
     signed long long   sLongLongValue;
 
+#ifdef SST_VER_GT_15_1
     std::complex<float> floatComplex;
     std::complex<double> doubleComplex;
     float _Complex CfloatComplex;
     double _Complex CdoubleComplex;
+#endif
 
     struct __fundamentalTypeStruct
     {
@@ -314,6 +316,7 @@ private:
 
     std::vector<std::vector<std::vector<unsigned>>> unsignedVectVectVect;
 
+#ifdef SST_VER_GT_15_1
     std::shared_ptr<int> sharedPtrInt;
     std::shared_ptr<size_t[]> sharedPtrIntArray;
     size_t sharedPtrIntArraySize;
@@ -328,6 +331,7 @@ private:
     std::optional<std::vector<int>> optionalVectorInt;
 
     std::variant<int, std::vector<int>, std::tuple<bool, int>> variant;
+#endif
 
     // ---------------------------------------
     // END SERIALIZED DATA STRUCTURES

--- a/tests/CaptCrunch/debug.py
+++ b/tests/CaptCrunch/debug.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+
+# Usage: sst --interactive-start=0 debug.py
+
+import sst
+# sst.setStatisticLoadLevel(4)
+# sst.enableAllStatisticsForAllComponents()
+# sst.setStatisticOutput("sst.statOutputCSV", { "filepath" : "$TEST_NAME.csv", "separator" : "," } )
+
+c0 = sst.Component("c0", "captcrunch.CaptCrunch")
+c0.addParams({
+  "numStats" : "100",
+  "numClocks" : "10000"
+})


### PR DESCRIPTION
Added CXX compile flag to enable CaptCrunch to run on legacy and devel branches by guarding using types introduced after sst 15.1.0 from causing compilation errors. This should fix jenkins failure http://jenkins.dev.tactcomplabs.com:8080/job/SST-EXT-TESTS/job/sst-ext-tests-release-ensemble/55/

Legacy regression audit logs included
