### PR TITLE
reduced size of log files and fixed unbound variable errors

### DIFF
--- a/tests/CaptCrunch/CaptCrunch_Interactive.sh
+++ b/tests/CaptCrunch/CaptCrunch_Interactive.sh
@@ -18,6 +18,8 @@ c0.addParams({
 })
 EOL
 
+wait
+
 # -- for starters just enter 1 component and do not segfault
 # -- TODO print and check. Each data member through the heirarchy
 # -- run the first pass through the sim

--- a/tests/CaptCrunch/CaptCrunch_Simple1.sh
+++ b/tests/CaptCrunch/CaptCrunch_Simple1.sh
@@ -18,6 +18,8 @@ c0.addParams({
 })
 EOL
 
+wait
+
 # -- run the first pass through the sim
 echo "SST_COMPONENT_BASE=${SST_COMPONENT_BASE}"
 sst --checkpoint-period=10ns --checkpoint-prefix=$TEST_NAME-PRE --add-lib-path=$SST_COMPONENT_BASE/CaptCrunch/ $TEST_NAME.py

--- a/tests/core-debug/cmd-actions.sh
+++ b/tests/core-debug/cmd-actions.sh
@@ -54,7 +54,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 

--- a/tests/core-debug/cmd-basic.sh
+++ b/tests/core-debug/cmd-basic.sh
@@ -38,7 +38,8 @@ r 1us
 continue 1us
 tm
 c 4us
-continue
+confirm false
+shutd
 EOF
 
 retVal=$?
@@ -47,7 +48,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 
@@ -142,7 +143,7 @@ fi
 echo "Found pass string \"$PSTR\""
 
 # continue
-PSTR="Simulation is complete, simulated time: 1 ms"
+PSTR="Simulation is complete, simulated time: 7 us"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then

--- a/tests/core-debug/cmd-ckptaction-err.sh
+++ b/tests/core-debug/cmd-ckptaction-err.sh
@@ -40,7 +40,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 

--- a/tests/core-debug/cmd-ckptaction.sh
+++ b/tests/core-debug/cmd-ckptaction.sh
@@ -43,7 +43,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 

--- a/tests/core-debug/cmd-cmp-types-false.sh
+++ b/tests/core-debug/cmd-cmp-types-false.sh
@@ -250,7 +250,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 

--- a/tests/core-debug/cmd-cmp-types-true.sh
+++ b/tests/core-debug/cmd-cmp-types-true.sh
@@ -250,7 +250,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 

--- a/tests/core-debug/cmd-comments-ws.sh
+++ b/tests/core-debug/cmd-comments-ws.sh
@@ -42,14 +42,14 @@ ls
 		
 set test_string HelloMyNameIsC7AndICannotQuoteAString
 print test_string
-        quit
+        
 EOF
 
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --replay-file=$CMDFILE --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
 $LAUNCH << EOF  | tee $LOGFILE
-quit
+      shutd
 EOF
 
 retVal=$?

--- a/tests/core-debug/cmd-cond.sh
+++ b/tests/core-debug/cmd-cond.sh
@@ -26,7 +26,7 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF  | tee $LOGFILE
+$LAUNCH << EOF  | grep -v talking | tee $LOGFILE
 ls
 cd c7
 watch duty_cycle_count == 1
@@ -43,7 +43,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 

--- a/tests/core-debug/cmd-default-ic.sh
+++ b/tests/core-debug/cmd-default-ic.sh
@@ -28,7 +28,9 @@ LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug
 echo $LAUNCH
 $LAUNCH << EOF  | tee $LOGFILE
 help
-quit
+run 1us
+shutd
+yes
 EOF
 
 retVal=$?
@@ -37,7 +39,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 

--- a/tests/core-debug/cmd-handler.sh
+++ b/tests/core-debug/cmd-handler.sh
@@ -58,7 +58,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 

--- a/tests/core-debug/cmd-help.sh
+++ b/tests/core-debug/cmd-help.sh
@@ -54,7 +54,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 

--- a/tests/core-debug/cmd-history.sh
+++ b/tests/core-debug/cmd-history.sh
@@ -57,7 +57,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 

--- a/tests/core-debug/cmd-logging.sh
+++ b/tests/core-debug/cmd-logging.sh
@@ -30,7 +30,9 @@ cd c7
 ls
 set test_string HelloMyNameIsC7AndICannotQuoteAString
 print test_string
-quit
+continue 1us
+confirm false
+shutdown
 EOF
 
 # Launch the program to start interactive mode at time 0

--- a/tests/core-debug/cmd-multithread-8thds-NEW.sh
+++ b/tests/core-debug/cmd-multithread-8thds-NEW.sh
@@ -57,7 +57,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 

--- a/tests/core-debug/cmd-multithread-NEW.sh
+++ b/tests/core-debug/cmd-multithread-NEW.sh
@@ -47,7 +47,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 

--- a/tests/core-debug/cmd-multithread-actions-NEW.sh
+++ b/tests/core-debug/cmd-multithread-actions-NEW.sh
@@ -63,7 +63,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 

--- a/tests/core-debug/cmd-multithread-serial-NEW.sh
+++ b/tests/core-debug/cmd-multithread-serial-NEW.sh
@@ -48,7 +48,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 

--- a/tests/core-debug/cmd-multithread-shutdown-NEW.sh
+++ b/tests/core-debug/cmd-multithread-shutdown-NEW.sh
@@ -40,7 +40,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 PSTR="Entering interactive mode at time 0"

--- a/tests/core-debug/cmd-print-NEW.sh
+++ b/tests/core-debug/cmd-print-NEW.sh
@@ -37,7 +37,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 

--- a/tests/core-debug/cmd-replay-sync.sh
+++ b/tests/core-debug/cmd-replay-sync.sh
@@ -37,14 +37,14 @@ EOF
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --replay-file=$CMDFILE --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-$LAUNCH | tee $LOGFILE
+$LAUNCH | grep -v 'talking' | tee $LOGFILE
 retVal=$?
 
 echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 

--- a/tests/core-debug/cmd-replay.sh
+++ b/tests/core-debug/cmd-replay.sh
@@ -35,7 +35,7 @@ EOF
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF  | tee $LOGFILE
+$LAUNCH << EOF  | egrep -v "talking[a-zA-Z]" | tee $LOGFILE
 replay $CMDFILE
 EOF
 

--- a/tests/core-debug/cmd-replay2.sh
+++ b/tests/core-debug/cmd-replay2.sh
@@ -38,7 +38,7 @@ EOF
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --replay-file=$CMDFILE --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF  | tee $LOGFILE
+$LAUNCH << EOF | egrep -v "talking[a-zA-Z]" | tee $LOGFILE
 quit
 EOF
 

--- a/tests/core-debug/cmd-replay3.sh
+++ b/tests/core-debug/cmd-replay3.sh
@@ -36,7 +36,7 @@ EOF
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-console=sst.interactive.simpledebug --interactive-start=0s $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF  | tee $LOGFILE
+$LAUNCH << EOF | egrep -v "talking[a-zA-Z]" | tee $LOGFILE
 replay $CMDFILE
 set test_string HelloMyNameIsC7AndICannotQuoteAString
 print test_string

--- a/tests/core-debug/cmd-sanity.sh
+++ b/tests/core-debug/cmd-sanity.sh
@@ -26,7 +26,8 @@ cd c7
 ls
 set test_string HelloMyNameIsC7AndICannotQuoteAString
 print test_string
-quit
+confirm false
+shutdown
 EOF
 
 retVal=$?

--- a/tests/core-debug/cmd-set.sh
+++ b/tests/core-debug/cmd-set.sh
@@ -58,7 +58,9 @@ p v_ull
 p v_float
 p v_double
 p v_ldouble
-run
+run 5us
+confirm false
+shutd
 EOF
 
 retVal=$?
@@ -67,7 +69,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 

--- a/tests/core-debug/cmd-trace.sh
+++ b/tests/core-debug/cmd-trace.sh
@@ -65,7 +65,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 

--- a/tests/core-debug/cmd-unwatch.sh
+++ b/tests/core-debug/cmd-unwatch.sh
@@ -49,7 +49,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 

--- a/tests/core-debug/cmd-watch.sh
+++ b/tests/core-debug/cmd-watch.sh
@@ -49,7 +49,7 @@ echo $TNAME Complete
 
 # Check result
 if [ $retVal -ne 0 ]; then
-  echo "ERROR $NAME returned $retVal"
+  echo "ERROR $TNAME returned $retVal"
   exit $retVal
 fi
 


### PR DESCRIPTION
some log files exploded in size with recent changes to test times so made changes to reduce the output for some tests. Also fixed use of TNAME instead of NAME in some scripts which was causing an  unbound variable error. CaptCrunch test sometimes fail with 'no sdl' so attempting to resolve these by adding a `wait` statement after the sdl is generated but before sst runs.
