### PR TITLE
omni debug tester component with queue and union examples

### DIFF
--- a/components/core-debug/CMakeLists.txt
+++ b/components/core-debug/CMakeLists.txt
@@ -8,8 +8,10 @@
 #
 
 set(DbgSST15Srcs
-  basic.cc
-  basic.h
+  omni.cc
+  omni.h
+  om-unions.cc
+  om-unions.h
   dbgsst15.cc
   dbgsst15.h
   probe.cc

--- a/components/core-debug/dbgsst15.h
+++ b/components/core-debug/dbgsst15.h
@@ -26,6 +26,7 @@
 #include <string>
 #include <time.h>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 #include <vector>
 

--- a/components/core-debug/om-unions.cc
+++ b/components/core-debug/om-unions.cc
@@ -19,10 +19,10 @@ OMUnions::OMUnions(ComponentId_t id, Params& params) : OMSubComponentAPI(id,para
   #ifdef UNION_METHOD_2
   v_union_struct_method_2.v = 0x33333333;
   #endif
-  v_union_int_float_trivial.f  = 0x11111111;
-  v_union_struct_method_1.v = 0x22222222;
+  v_union_int_float_trivial.f  = 0.0;
+  v_union_struct_method_1.v = 0.0;
   #ifdef UNION_METHOD_2
-  v_union_struct_method_2.v = 0x33333333;
+  v_union_struct_method_2.v = 0.0;
   #endif
 }
 
@@ -31,6 +31,8 @@ OMUnions::~OMUnions() {}
 void OMUnions::update(payload_t& p) {
   OMSubComponentAPI::update(p);
 
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
   v_union_struct_trivial.f.b5_0   += 1;   
   v_union_struct_trivial.f.b7_6   += 1;
   v_union_struct_trivial.f.b10_8  += 1;
@@ -44,6 +46,7 @@ void OMUnions::update(payload_t& p) {
   v_union_struct_method_1.f.b26_11 += 2;
   v_union_struct_method_1.f.b30_27 += 2;
   v_union_struct_method_1.f.b31    += 2;
+  #pragma GCC diagnostic pop
 
   #ifdef UNION_METHOD_2
   v_union_struct_method_2.f.b5_0   += 3;   
@@ -54,10 +57,10 @@ void OMUnions::update(payload_t& p) {
   v_union_struct_method_2.f.b31    += 3;
   #endif
 
-  v_union_int_float_trivial.f += 1;
-  v_union_int_float_method_1.f += 2;
+  v_union_int_float_trivial.f += 1.0f;
+  v_union_int_float_method_1.f += 2.0f;
   #ifdef UNION_METHOD_2
-  v_union_int_float_method_2.f += 3;
+  v_union_int_float_method_2.f += 3.0f;
   #endif
 }
 

--- a/components/core-debug/om-unions.cc
+++ b/components/core-debug/om-unions.cc
@@ -1,0 +1,66 @@
+//
+// om-unions.cc
+//
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "om-unions.h"
+
+namespace SST::ExtTest {
+
+OMUnions::OMUnions(ComponentId_t id, Params& params) : OMSubComponentAPI(id,params) {
+  sstout_.init(getName() + ":@p:@t]: ", 0, 0, SST::Output::STDOUT );
+  v_union_struct_trivial.v  = 0x11111111;
+  v_union_struct_method_1.v = 0x22222222;
+  #ifdef UNION_METHOD_2
+  v_union_struct_method_2.v = 0x33333333;
+  #endif
+  v_union_int_float_trivial.f  = 0x11111111;
+  v_union_struct_method_1.v = 0x22222222;
+  #ifdef UNION_METHOD_2
+  v_union_struct_method_2.v = 0x33333333;
+  #endif
+}
+
+OMUnions::~OMUnions() {}
+
+void OMUnions::update(payload_t& p) {
+  OMSubComponentAPI::update(p);
+
+  v_union_struct_trivial.f.b5_0   += 1;   
+  v_union_struct_trivial.f.b7_6   += 1;
+  v_union_struct_trivial.f.b10_8  += 1;
+  v_union_struct_trivial.f.b26_11 += 1;
+  v_union_struct_trivial.f.b30_27 += 1;
+  v_union_struct_trivial.f.b31    += 1;
+
+  v_union_struct_method_1.f.b5_0   += 2;   
+  v_union_struct_method_1.f.b7_6   += 2;
+  v_union_struct_method_1.f.b10_8  += 2;
+  v_union_struct_method_1.f.b26_11 += 2;
+  v_union_struct_method_1.f.b30_27 += 2;
+  v_union_struct_method_1.f.b31    += 2;
+
+  #ifdef UNION_METHOD_2
+  v_union_struct_method_2.f.b5_0   += 3;   
+  v_union_struct_method_2.f.b7_6   += 3;
+  v_union_struct_method_2.f.b10_8  += 3;
+  v_union_struct_method_2.f.b26_11 += 3;
+  v_union_struct_method_2.f.b30_27 += 3;
+  v_union_struct_method_2.f.b31    += 3;
+  #endif
+
+  v_union_int_float_trivial.f += 1;
+  v_union_int_float_method_1.f += 2;
+  #ifdef UNION_METHOD_2
+  v_union_int_float_method_2.f += 3;
+  #endif
+}
+
+}//namespace SST::ExtTest
+
+// EOF

--- a/components/core-debug/om-unions.cc
+++ b/components/core-debug/om-unions.cc
@@ -31,30 +31,10 @@ OMUnions::~OMUnions() {}
 void OMUnions::update(payload_t& p) {
   OMSubComponentAPI::update(p);
 
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wconversion"
-  v_union_struct_trivial.f.b5_0   += 1;   
-  v_union_struct_trivial.f.b7_6   += 1;
-  v_union_struct_trivial.f.b10_8  += 1;
-  v_union_struct_trivial.f.b26_11 += 1;
-  v_union_struct_trivial.f.b30_27 += 1;
-  v_union_struct_trivial.f.b31    += 1;
-
-  v_union_struct_method_1.f.b5_0   += 2;   
-  v_union_struct_method_1.f.b7_6   += 2;
-  v_union_struct_method_1.f.b10_8  += 2;
-  v_union_struct_method_1.f.b26_11 += 2;
-  v_union_struct_method_1.f.b30_27 += 2;
-  v_union_struct_method_1.f.b31    += 2;
-  #pragma GCC diagnostic pop
-
+  v_union_struct_trivial.v  += 0x01010101;   
+  v_union_struct_method_1.v += 0x02020202;   
   #ifdef UNION_METHOD_2
-  v_union_struct_method_2.f.b5_0   += 3;   
-  v_union_struct_method_2.f.b7_6   += 3;
-  v_union_struct_method_2.f.b10_8  += 3;
-  v_union_struct_method_2.f.b26_11 += 3;
-  v_union_struct_method_2.f.b30_27 += 3;
-  v_union_struct_method_2.f.b31    += 3;
+  v_union_struct_method_2.v += 0x03030303;   
   #endif
 
   v_union_int_float_trivial.f += 1.0f;

--- a/components/core-debug/om-unions.cc
+++ b/components/core-debug/om-unions.cc
@@ -13,7 +13,7 @@
 namespace SST::ExtTest {
 
 OMUnions::OMUnions(ComponentId_t id, Params& params) : OMSubComponentAPI(id,params) {
-  sstout_.init(getName() + ":@p:@t]: ", 0, 0, SST::Output::STDOUT );
+  sstout_.init("[" + getName() + ":@p:@t]: ", 0, 0, SST::Output::STDOUT );
   v_union_struct_trivial.v  = 0x11111111;
   v_union_struct_method_1.v = 0x22222222;
   #ifdef UNION_METHOD_2

--- a/components/core-debug/om-unions.h
+++ b/components/core-debug/om-unions.h
@@ -8,6 +8,20 @@
 // See LICENSE in the top level directory for licensing details
 //
 
+// Intent:  Demonstrate support of object mapping for common
+//          cases of unions.  Unions are fraught with peril
+//          and should generally be discouraged. However,
+//          when memory footprint is critical, they are quite
+//          efficient.  Two cases are included here:
+//          1) uint32_t and bitfields: This can be used to 
+//             model hardware registers as an alternative to
+//             std::bitset (which supports object mapping).
+//          2) int and float: Handy for floating point hardware 
+// 
+//          A secondary goal is to provide an example for the 
+//          SST online documentation for a `serialize_impl`
+//          specialization.
+// 
 #ifndef _SST_EXT_TESTS_OM_UNIONS
 #define _SST_EXT_TESTS_OM_UNIONS
 

--- a/components/core-debug/om-unions.h
+++ b/components/core-debug/om-unions.h
@@ -1,0 +1,208 @@
+//
+// om-unions.h
+//
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef _SST_EXT_TESTS_OM_UNIONS
+#define _SST_EXT_TESTS_OM_UNIONS
+
+#include "omni.h"
+
+//TODO Verify method2 works. Currently does not compile
+// #define UNION_METHOD_2
+
+namespace SST::ExtTest {
+
+// A trivially serializable union will not be automatically mapped.
+// https://github.com/sstsimulator/sst-core/pull/1515
+// To suport mapping these:
+// Method 1. Define a serialize_impl<SST::ExtTest::OMUnions::v_union_struct_trivial_t> specialization.
+// Method 2. Add a constructor taking a std::string and an operator std::string() const to SST::ExtTest::OMUnions::v_union_struct_trivial_t, to allow conversion from/to std::string.
+
+union v_union_struct_trivial_t {
+    uint32_t v = 0;
+    struct {
+        uint32_t b5_0   : 6;   // [5:0]
+        uint32_t b7_6   : 2;   // [7:6] 
+        uint32_t b10_8  : 3;   // [10:8]
+        uint32_t b26_11 : 16;  // [26:11]
+        uint32_t b30_27 : 4;   // [30:27]
+        uint32_t b31    : 1;   // [31]
+    } f;
+};
+
+static_assert(std::is_aggregate_v<v_union_struct_trivial_t>);
+
+// Define a serialize_impl<SST::ExtTest::v_union_struct_method_1_t> specialization.
+union v_union_struct_method_1_t {
+    uint32_t v = 0;
+    struct {
+        uint32_t b5_0   : 6;   // [5:0]
+        uint32_t b7_6   : 2;   // [7:6] 
+        uint32_t b10_8  : 3;   // [10:8]
+        uint32_t b26_11 : 16;  // [26:11]
+        uint32_t b30_27 : 4;   // [30:27]
+        uint32_t b31    : 1;   // [31]
+    } f;
+};
+
+static_assert(std::is_aggregate_v<v_union_struct_method_1_t>);
+
+#ifdef UNION_METHOD_2
+// Add a constructor taking a std::string 
+// and an operator std::string() const to SST::ExtTest::v_union_struct_trivial_t
+// to allow conversion from/to std::string.
+union v_union_struct_method_2_t {
+    uint32_t v = 0;
+    struct {
+        uint32_t b5_0   : 6;   // [5:0]
+        uint32_t b7_6   : 2;   // [7:6] 
+        uint32_t b10_8  : 3;   // [10:8]
+        uint32_t b26_11 : 16;  // [26:11]
+        uint32_t b30_27 : 4;   // [30:27]
+        uint32_t b31    : 1;   // [31]
+    } f;
+    v_union_struct_method_2_t() {};
+    explicit v_union_struct_method_2_t(std::string str) {
+      uint32_t value;
+      auto [ptr, ec] = std::from_chars(str.data(), str.data() + str.size(), value);
+      if (ec ==std::errc{}) { 
+        this->v = value;
+      } else if (ec == std::errc::invalid_argument) {
+        std::cerr << "Conversion error: invalid argument" << std::endl;
+      } else if ( ec == std::errc::result_out_of_range) {
+        std::cerr << "Conversion error: Value out of range" << std::endl;
+      }
+    };
+    std::string operator()(v_union_struct_method_2_t& t) const {
+      std::stringstream ss;
+      ss << "0x" << std::hex << std::uppercase << t.v;
+      return ss.str();
+    };
+}; //union v_union_struct_method_2_t
+
+static_assert(! std::is_aggregate_v<v_union_struct_method_2_t>);
+#endif
+
+// Repeat the exercise
+union v_union_int_float_trivial_t{
+  int i = 0;
+  float f;
+};
+
+union v_union_int_float_method_1_t {
+  int i = 0;
+  float f;
+};
+
+#ifdef UNION_METHOD_2
+//TODO
+// union v_union_int_float_method_2_t {
+  int i = 0;
+  float f;
+};
+#endif
+
+// -------------------------------------------------------
+// OMUnions (not registered)
+// -------------------------------------------------------
+class OMUnions : public OMSubComponentAPI {
+public:
+  SST_ELI_REGISTER_SUBCOMPONENT(
+        OMUnions,            // Class name
+        "dbgsst15",          // Library name
+        "OMUnions",          // Subcomponent name
+        SST_ELI_ELEMENT_VERSION(1,0,0),  // A version number
+        "Simple subcomponent for object map evaluation", 
+        SST::ExtTest::OMSubComponentAPI) // Fully qualified API name
+ 
+  OMUnions(ComponentId_t id, Params& params);
+  ~OMUnions();
+  virtual void update(payload_t& p) final;
+
+public:
+  // serialization support
+  OMUnions() : OMSubComponentAPI() {}; // required for serialization
+  void serialize_order(SST::Core::Serialization::serializer& ser) override {
+    OMSubComponentAPI::serialize_order(ser);
+    SST_SER(v_union_struct_trivial);  // trivially serializable type will not be mapped
+    SST_SER(v_union_struct_method_1); // Define a serialize_impl
+    #ifdef UNION_METHOD_2
+    SST_SER(v_union_struct_method_2); // Add a constructor taking a std::string and an operator std::string() const
+    #endif
+    SST_SER(v_union_int_float_trivial);  // trivially serializable type will not be mapped
+    SST_SER(v_union_int_float_method_1); // Define a serialize_impl
+    #ifdef UNION_METHOD_2
+    SST_SER(v_union_int_float_method_2); // Add a constructor taking a std::string and an operator std::string() const
+    #endif
+  }
+  ImplementSerializable(SST::ExtTest::OMUnions)
+private:
+  SST::Output sstout_;
+
+  v_union_struct_trivial_t  v_union_struct_trivial;
+  v_union_struct_method_1_t v_union_struct_method_1;
+  #ifdef UNION_METHOD_2
+  v_union_struct_method_2_t v_union_struct_method_2;
+  #endif
+
+  v_union_int_float_trivial_t v_union_int_float_trivial;
+  v_union_int_float_method_1_t v_union_int_float_method_1;
+  #ifdef UNION_METHOD_2
+  v_union_int_float_method_2_t v_union_struct_method_2;
+  #endif
+
+}; //class OMUnions
+}//namespace SST::ExtTest
+
+// SST::Core::Serialization::serialize_impl specializations.
+// and unions are supposed to be simple, right?
+namespace SST::Core::Serialization {
+
+// Method 1. Define a serialize_impl<SST::ExtTest::v_union_struct_method_1_t> specialization.
+template <>
+class serialize_impl<SST::ExtTest::v_union_struct_method_1_t>
+{
+  void operator()(SST::ExtTest::v_union_struct_method_1_t& t, serializer& ser, ser_opt_t UNUSED(options)) {
+    if ( ser.mode() != serializer::MAP ) {
+      SST_SER(t);
+      return;
+    }
+    // Object map specialization
+    ser_opt_t opt = SerOption::is_set(options, SerOption::as_ptr_elem) ? SerOption::as_ptr : SerOption::none;
+    ser.mapper().map_hierarchy_start(ser.getMapName(), new ObjectMapContainer<SST::ExtTest::v_union_struct_method_1_t>(&t));
+    SST_SER_NAME(t.v, "v", opt);
+    //struct f containing the bit fields will require a more complex proxy wrapper of some sort
+    ser.mapper().map_hierarchy_end();
+  };
+  SST_FRIEND_SERIALIZE();
+};
+
+// Method 1. Define a serialize_impl<SST::ExtTest::v_union_int_float_method_1_t> specialization.
+template <>
+class serialize_impl<SST::ExtTest::v_union_int_float_method_1_t>
+{
+  void operator()(SST::ExtTest::v_union_int_float_method_1_t& t, serializer& ser, ser_opt_t UNUSED(options)) {
+    if ( ser.mode() != serializer::MAP ) {
+      SST_SER(t);
+      return;
+    }
+    // Object map specialization
+    ser_opt_t opt = SerOption::is_set(options, SerOption::as_ptr_elem) ? SerOption::as_ptr : SerOption::none;
+    ser.mapper().map_hierarchy_start(ser.getMapName(), new ObjectMapContainer<SST::ExtTest::v_union_int_float_method_1_t>(&t));
+    SST_SER_NAME(t.f, "f", opt);
+    //struct f containing the bit fields would require a more complex proxy wrapper of some sort
+    ser.mapper().map_hierarchy_end();
+  };
+  SST_FRIEND_SERIALIZE();
+};// class serialize_impl<SST::ExtTest::v_union_int_float_method_1_t>
+} //namespace SST::Core::Serialization
+
+#endif  // _SST_EXT_TESTS_OM_UNIONS
+
+// EOF

--- a/components/core-debug/omni.cc
+++ b/components/core-debug/omni.cc
@@ -1,5 +1,5 @@
 //
-// basic.cc
+// omni.cc
 //
 // Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 // All Rights Reserved
@@ -8,7 +8,7 @@
 // See LICENSE in the top level directory for licensing details
 //
 
-#include "basic.h"
+#include "omni.h"
 
 namespace SST::ExtTest{
 

--- a/components/core-debug/omni.h
+++ b/components/core-debug/omni.h
@@ -1,5 +1,6 @@
 //
-// basic.h
+// omni.h
+// Object Map Noir Inspector
 //
 // Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 // All Rights Reserved
@@ -14,21 +15,17 @@
 // complex behaviors by simply providing the subcomponent
 // at runtime.
 
-#ifndef _SST_EXT_TESTS_BASIC_
-#define _SST_EXT_TESTS_BASIC_
+#ifndef _SST_EXT_TESTS_OMNI_
+#define _SST_EXT_TESTS_OMNI_
 
 // clang-format off
 // -- Standard Headers
 #include "SST.h"
-#include <cassert>
-#include <cstddef>
-#include <cstdint>
-#include <map>
-#include <queue>
-#include "tcldbg.h"
 // clang-format on
 
 namespace SST::ExtTest {
+
+//TODO utilize events. placeholder for now
 
 // ---------------------------------------------
 // payload_t
@@ -70,13 +67,11 @@ public:
   virtual ~OMSubComponentAPI() {}
   
   virtual void update(payload_t& p) {
-    for (size_t i=0; i<8; i++) 
-      array_[i] = subcompapi_counter_ + i;
     subcompapi_counter_++;
+    p.data += 1;
   };
-protected:
-  uint64_t subcompapi_counter_ = 0; // ObjectMapFundamental
-  uint64_t array_[8] = {0};         // ObjectMapArray
+private:
+  uint64_t subcompapi_counter_ = 0;
 
 public:
   // minimum serialization for testing object map
@@ -84,55 +79,9 @@ public:
   void serialize_order(SST::Core::Serialization::serializer& ser) override {
     SubComponent::serialize_order(ser);
     SST_SER(subcompapi_counter_);
-    SST_SER(array_);
   }
   ImplementVirtualSerializable(SST::ExtTest::OMSubComponentAPI)
 }; //class OMSubComponentAPI
-
-// -------------------------------------------------------
-// OMSimpleSubComponent (not registered)
-// -------------------------------------------------------
-class OMSimpleSubComponent : public OMSubComponentAPI {
-public:
-  SST_ELI_REGISTER_SUBCOMPONENT(
-        OMSimpleSubComponent,            // Class name
-        "dbgsst15",                         // Library name
-        "OMSimpleSubComponent",          // Subcomponent name
-        SST_ELI_ELEMENT_VERSION(1,0,0),  // A version number
-        "Simple subcomponent for object map evaluation", 
-        SST::ExtTest::OMSubComponentAPI) // Fully qualified API name
- 
-  OMSimpleSubComponent(ComponentId_t id, Params& params) : OMSubComponentAPI(id,params) {
-    sstout_.init(getName() + ":@p:@t]: ", 0, 0, SST::Output::STDOUT );
-    v_queue_unsigned_.push(100);
-    v_queue_unsigned_.push(200);
-    v_queue_unsigned_.push(300);
-  }
-  ~OMSimpleSubComponent() {}
-  virtual void update(payload_t& p) final {
-    tcldbg::spinner("SPINNER");
-    OMSubComponentAPI::update(p);
-    p.data += 1;
-
-    assert(v_queue_unsigned_.size()==3);
-    unsigned front = v_queue_unsigned_.front() + 1;
-    v_queue_unsigned_.pop();
-    v_queue_unsigned_.push(front);
-    sstout_.verbose(CALL_INFO, 0, 0, "v_queue_unsigned_.front()=%d\n", v_queue_unsigned_.front());
-    // std::cout << getCurrentSimTime() << ": v_queue_unsigned_.front()=" << v_queue_unsigned_.front() << std::endl;
-  }
-public:
-    // serialization support
-    OMSimpleSubComponent() : OMSubComponentAPI() {}; // required for serialization
-    void serialize_order(SST::Core::Serialization::serializer& ser) override {
-      OMSubComponentAPI::serialize_order(ser);
-      SST_SER(v_queue_unsigned_);
-    }
-    ImplementSerializable(SST::ExtTest::OMSimpleSubComponent)
-private:
-    std::queue<uint32_t> v_queue_unsigned_;
-    SST::Output sstout_;
-}; //class OMSimpleSubComponent
 
 // ---------------------------------------------
 // OMSimpleComponent
@@ -141,7 +90,7 @@ class OMSimpleComponent : public SST::Component{
 
 public:
   SST_ELI_REGISTER_COMPONENT( OMSimpleComponent,   // component class
-                            "dbgsst15",       // component library
+             "dbgsst15",       // component library
                             "OMSimpleComponent",   // component name
                             SST_ELI_ELEMENT_VERSION( 1, 0, 0 ),
                             "Simple Object Map Evalulation Component",
@@ -205,8 +154,52 @@ public:
 
 }; //class OMSimpleComponent
 
+// -------------------------------------------------------
+// OmSubComponentAPI Specialization Example
+// OMQueue (not registered)
+// Testing: std::queue
+// -------------------------------------------------------
+class OMQueue : public OMSubComponentAPI {
+public:
+  SST_ELI_REGISTER_SUBCOMPONENT(
+        OMQueue,            // Class name
+        "dbgsst15",         // Library name
+        "OMQueue",          // Subcomponent name
+        SST_ELI_ELEMENT_VERSION(1,0,0),  // A version number
+        "Simple subcomponent for object map evaluation", 
+        SST::ExtTest::OMSubComponentAPI) // Fully qualified API name
+ 
+  OMQueue(ComponentId_t id, Params& params) : OMSubComponentAPI(id,params) {
+    sstout_.init(getName() + ":@p:@t]: ", 0, 0, SST::Output::STDOUT );
+    v_queue_unsigned_.push(100);
+    v_queue_unsigned_.push(200);
+    v_queue_unsigned_.push(300);
+  }
+  ~OMQueue() {}
+  virtual void update(payload_t& p) final {
+    OMSubComponentAPI::update(p);
+    assert(v_queue_unsigned_.size()==3);
+    unsigned front = v_queue_unsigned_.front() + 1;
+    v_queue_unsigned_.pop();
+    v_queue_unsigned_.push(front);
+    sstout_.verbose(CALL_INFO, 0, 0, "v_queue_unsigned_.front()=%d\n", v_queue_unsigned_.front());
+  }
+public:
+  // serialization support
+  OMQueue() : OMSubComponentAPI() {}; // required for serialization
+  void serialize_order(SST::Core::Serialization::serializer& ser) override {
+    OMSubComponentAPI::serialize_order(ser);
+    SST_SER(v_queue_unsigned_);
+  }
+  ImplementSerializable(SST::ExtTest::OMQueue)
+private:
+  SST::Output sstout_;
+  std::queue<uint32_t> v_queue_unsigned_;
+}; //class OMQueue
+
+
 } //namespace SST::ExtTest
 
-#endif  // _SST_EXT_TESTS_BASIC_
+#endif  // _SST_EXT_TESTS_OMNI_
 
 // EOF

--- a/components/include/SST.h
+++ b/components/include/SST.h
@@ -48,6 +48,7 @@
 #include <sst/core/rng/rng.h>
 #include <sst/core/rng/mersenne.h>
 #include <sst/core/serialization/serialize.h>
+#include <sst/core/serialization/serializer.h>
 #include <sst/core/subcomponent.h>
 #if 1 // Used for interactive console
 #include <sst/core/baseComponent.h>

--- a/tests/core-debug/omni.py
+++ b/tests/core-debug/omni.py
@@ -6,12 +6,12 @@
 # See LICENSE in the top level directory for licensing details
 #
 # omni.py
-# Object Map Network Implementor
+# Object Map Noir Inspector
 
 import argparse
 import sst
 
-parser = argparse.ArgumentParser(description="Object Map Network Implementor")
+parser = argparse.ArgumentParser(description="Object Map Noir Inspector")
 parser.add_argument("--verbose",              type=int,   help="verbosity", default=2)
 parser.add_argument("--function0",            type=str,   help="function0 subcomponent (e.g. dbgsst15.OMQueue)", required=True)
 

--- a/tests/core-debug/omni.py
+++ b/tests/core-debug/omni.py
@@ -5,14 +5,15 @@
 #
 # See LICENSE in the top level directory for licensing details
 #
-# basic.py
-#
+# omni.py
+# Object Map Network Implementor
 
 import argparse
 import sst
 
-parser = argparse.ArgumentParser(description="basic")
+parser = argparse.ArgumentParser(description="Object Map Network Implementor")
 parser.add_argument("--verbose",              type=int,   help="verbosity", default=2)
+parser.add_argument("--function0",            type=str,   help="function0 subcomponent (e.g. dbgsst15.OMQueue)", required=True)
 
 args = parser.parse_args()
 
@@ -25,22 +26,22 @@ class Simple():
       "verbose" : args.verbose,
       "primary" : 1
       })
-    self.c0f0 = self.c0.setSubComponent( "function0", "dbgsst15.OMSimpleSubComponent")
+    self.c0f0 = self.c0.setSubComponent( "function0", args.function0 )
 
 # 2 components sharing a link
 class Simple2():
   def __init__(self):
 
-    self.c0 =  sst.Component(f"c0",  "omap.OMSimpleComponent")
+    self.c0 =  sst.Component(f"c0",  "dbgsst15.OMSimpleComponent")
     self.c0.addParams({
       "verbose" : args.verbose,
       "primary" : 1
       })
-    self.c0f0 = self.c0.setSubComponent( "function0", "omap.OMSimpleSubComponent")
+    self.c0f0 = self.c0.setSubComponent( "function0", "args.function0")
 
-    self.c1 =  sst.Component(f"c1",  "omap.OMSimpleComponent")
+    self.c1 =  sst.Component(f"c1",  "dbgsst15.OMSimpleComponent")
     self.c1.addParams({"verbose" : args.verbose})
-    self.c1f0 = self.c1.setSubComponent( "function0", "omap.OMSimpleSubComponent")
+    self.c1f0 = self.c1.setSubComponent( "function0", "args.function0")
 
     self.link0 = sst.Link("f0")
     self.link0.connect( (self.c0, "port0", "10ns"), (self.c1, "port0", "10ns") ) 

--- a/tests/core-debug/type-queue.sh
+++ b/tests/core-debug/type-queue.sh
@@ -86,20 +86,18 @@ run 10400ns
 # CHECK 8 pwd\ncp0/v_queue_unsigned/container \(
 pwd
 
-# The values read have not change from their original
+# CHECK 9 ls\n0 = 1202 \(.+\n1 = 1302 \(.+\n2 = 1103 \(
 ls
-# 0 = 1100 (unsigned int)
-# 1 = 1200 (unsigned int)
-# 2 = 1300 (unsigned int)
-
-#TODO Depending on how we handle the above add trace testing.
+# 0 = 1202 (unsigned int)
+# 1 = 1302 (unsigned int)
+# 2 = 1103 (unsigned int)
 
 shutdown
 
 EOF
 
 # Update this whenever adding checks in the command comments above
-NUMCHECKS=9
+NUMCHECKS=10
 
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"

--- a/tests/core-debug/type-union.sh
+++ b/tests/core-debug/type-union.sh
@@ -27,7 +27,7 @@ SCRIPT_NAME=$(basename "$0")
 TNAME="${SCRIPT_NAME%.*}"
 echo "TESTNAME=$TNAME"
 CONFIG="omni.py"
-CONFIG_OPTS="--function0=dbgsst15.OMUnions --verbose=0"
+CONFIG_OPTS="--function0=dbgsst15.OMUnions"
 
 LOGFILE=$TNAME.log
 OUTFILE=$TNAME.console.out

--- a/tests/core-debug/type-union.sh
+++ b/tests/core-debug/type-union.sh
@@ -69,14 +69,14 @@ cd ..
 cd v_union_struct_method_1/ 
 
 #TODO Values are different between Mac and Ubuntu. Don't check values for now.
-# CHECK 4 ls\nv = [0-9]+ \(
+# CHECK 4 ls\nv = 3621246928 \(
 ls
 
 unwatch
 watch v changed
 run 1us
 
-# CHECK 5 ls\nv = [0-9]+ \(
+# CHECK 5 ls\nv = 3654932946 \(
 ls
 
 shutdown

--- a/tests/core-debug/type-union.sh
+++ b/tests/core-debug/type-union.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER DEV
-#EXT_TEST TEST_FILE_DESC "Exercise std::queue<unsigned> with one component"
+#EXT_TEST TEST_FILE_DESC "Exercise unions with one component"
 #EXT_TEST TIMEOUT 30
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
@@ -10,14 +10,24 @@ set -uo pipefail
 # Set default ensure failure if not set and component not installed
 SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
-# Settings
+# Convenience environment variables
+set +u
+if [[ -z "${CLEANUP}" ]]; then
 CLEANUP=1
+fi
+if [[ -z "${VERBOSE}" ]]; then
+  VERBOSE=0
+fi
+
+set -u
+
+# Common settings
 SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 SCRIPT_NAME=$(basename "$0")
 TNAME="${SCRIPT_NAME%.*}"
 echo "TESTNAME=$TNAME"
 CONFIG="omni.py"
-CONFIG_OPTS="--function0=dbgsst15.OMQueue --verbose=0"
+CONFIG_OPTS="--function0=dbgsst15.OMUnions --verbose=0"
 
 LOGFILE=$TNAME.log
 OUTFILE=$TNAME.console.out
@@ -37,51 +47,46 @@ confirm false
 
 cd c0
 cd function0/
-cd v_queue_unsigned_/
-cd container/
-# CHECK 0 pwd\nc0/function0/v_queue_unsigned_/container \(
+cd v_union_int_float_method_1/
+# CHECK 0 pwd\nc0/function0/v_union_int_float_method_1 \(
 pwd
 
-# CHECK 1 ls\n0 = 100 \(.+\n1 = 200 \(.+\n2 = 300 \(
+# CHECK 1 ls\nf = 0\.000000.+
 ls
-# 0 = 100 (unsigned int)
-# 1 = 200 (unsigned int)
-# 2 = 300 (unsigned int)
-run 10ns
-# 1000: v_queue_unsigned_.front()=200
-# 2000: v_queue_unsigned_.front()=300
-# 3000: v_queue_unsigned_.front()=101
-# 4000: v_queue_unsigned_.front()=201
-# 5000: v_queue_unsigned_.front()=301
-# 6000: v_queue_unsigned_.front()=102
-# 7000: v_queue_unsigned_.front()=202
-# 8000: v_queue_unsigned_.front()=302
-# 9000: v_queue_unsigned_.front()=103
-# Entering interactive mode at time 10000 
-# Ran clock for 10000 sim cycles
 
-# CHECK 2 ls\n0 = 103 \(.+\n1 = 203 \(.+\n2 = 303 \(
+run 1us
+
+# CHECK 2 ls\nf = 1998\.000000.+
 ls
-# 0 = 103 (unsigned int)
-# 1 = 203 (unsigned int)
-# 2 = 303 (unsigned int)
 
-# TODO sst-core #1517 requires rebuilding the object map on entry into interactive sessions.
-#      In order for this watchpoint to work we need to do the same every sample!
-#      We may have to restrict what can and cannot be watched and the user will have to add code.
-# watch 0 changed
-# run
-# ls
+watch f changed
+run 1us
+
+# CHECK 3 ls\nf = 2000\.000000.+
+ls
+
+cd ..
+cd v_union_struct_method_1/ 
+
+# CHECK 4 ls\nv = 576758322 \(
+ls
+
+unwatch
+watch v changed
+run 1us
+
+# CHECK 5 ls\nv = 845198516 \(
+ls
 
 shutdown
 
 EOF
 
-# Update this whenever adding checks in the command comments above
-NUMCHECKS=3
+# IMPORTANT: Update this whenever adding checks in the command comments above
+NUMCHECKS=6
 
 # Launch the program to start interactive mode at time 0
-LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- $CONFIG_OPTS"
+LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug --verbose=$VERBOSE $CONFIG -- $CONFIG_OPTS"
 echo $LAUNCH
 revVal=0
 $LAUNCH << EOF  | tee $LOGFILE

--- a/tests/core-debug/type-union.sh
+++ b/tests/core-debug/type-union.sh
@@ -68,14 +68,15 @@ ls
 cd ..
 cd v_union_struct_method_1/ 
 
-# CHECK 4 ls\nv = 576758322 \(
+#TODO Values are different between Mac and Ubuntu. Don't check values for now.
+# CHECK 4 ls\nv = [0-9]+ \(
 ls
 
 unwatch
 watch v changed
 run 1us
 
-# CHECK 5 ls\nv = 845198516 \(
+# CHECK 5 ls\nv = [0-9]+ \(
 ls
 
 shutdown


### PR DESCRIPTION
OMNI -> Object Map Noir Inspector ( open to suggestions... )

This has been tested on MacOS and Ubuntu using the latest Sandia devel branch: `2d7a4959`

This test component is designed to  zero in on specific types under the control (or not) of the interactive console. The current use case is to update the state of the subcomponent in the clock handler through a generic mechanism so we can easily write tests for watchpoints and the like ( see `type-queue-1.sh` and `type-union.sh` ).  I have placeholders for events over links so we can watch data in the even handlers as well.

Today this is pretty simple but it has found a few bugs. The std::queue sample sub-component detected the problem with stale data in the object map and the 'unions' subcomponent is being used as a case study in mapping a trivially serialized type. 

@donofrio  See `om-unions.h` which has `serialize_impl` specializations (method1) for two different types of unions.  Uncomment line 17 for method 2 ( the string conversion overrides ) which I've been unable to compile. 

Also take a look at these:
`sst/core/serialization/impl//serialize_utility.h : 156`  // discusses trivially serializable types and unions
 `sst/core/serialization/impl/serialize_trivial.h`      // Lee's code warning user a type is to automatically mapped
`sst/core/serialization/impl//serialize_trivial.cc : 




