### PR TITLE
manually specifying python 3.11 on SLES15 targets

### DIFF
--- a/jenkins/sstcore-sles15-clang20-mpich3.4.sh
+++ b/jenkins/sstcore-sles15-clang20-mpich3.4.sh
@@ -31,6 +31,8 @@ echo "VALGRIND=$VALGRIND"
 echo $SST_INSTALL
 echo $PATH
 
+export PYFLAGS="--with-python=/usr/bin/python3.11-config"
+
 rm -Rf $SST_INSTALL/*
 if [ "$CLANGFORMAT" = true ]; then
   ./scripts/clang-format-test.sh --format-exe /pkgs/Linux/Rocky93/LLVM/LLVM-20.1.0-Linux-X64/bin/clang-format || exit 10
@@ -48,7 +50,7 @@ if [ "$SANITIZER" = true ]; then
     # detect_leaks is not supported on Mac
     # export ASAN_OPTIONS=detect_leaks=0
 fi
-./configure --prefix=$SST_INSTALL $DBGFLAGS || exit 11
+./configure --prefix=$SST_INSTALL $DBGFLAGS $PYFLAGS || exit 11
 if [ "$HEADERCHECK" = true ] ; then
   ./scripts/test-includes.pl || exit 20
 fi

--- a/jenkins/sstcore-sles15-clang20-mpich4.1.2.sh
+++ b/jenkins/sstcore-sles15-clang20-mpich4.1.2.sh
@@ -31,6 +31,8 @@ echo "VALGRIND=$VALGRIND"
 echo $SST_INSTALL
 echo $PATH
 
+export PYFLAGS="--with-python=/usr/bin/python3.11-config"
+
 rm -Rf $SST_INSTALL/*
 if [ "$CLANGFORMAT" = true ]; then
   ./scripts/clang-format-test.sh --format-exe /pkgs/Linux/Rocky93/LLVM/LLVM-20.1.0-Linux-X64/bin/clang-format || exit 10
@@ -48,7 +50,7 @@ if [ "$SANITIZER" = true ]; then
     # detect_leaks is not supported on Mac
     # export ASAN_OPTIONS=detect_leaks=0
 fi
-./configure --prefix=$SST_INSTALL $DBGFLAGS || exit 11
+./configure --prefix=$SST_INSTALL $DBGFLAGS $PYFLAGS || exit 11
 if [ "$HEADERCHECK" = true ] ; then
   ./scripts/test-includes.pl || exit 20
 fi

--- a/jenkins/sstcore-sles15-clang20-openmpi4.1.7.sh
+++ b/jenkins/sstcore-sles15-clang20-openmpi4.1.7.sh
@@ -31,6 +31,8 @@ echo "VALGRIND=$VALGRIND"
 echo $SST_INSTALL
 echo $PATH
 
+export PYFLAGS="--with-python=/usr/bin/python3.11-config"
+
 rm -Rf $SST_INSTALL/*
 if [ "$CLANGFORMAT" = true ]; then
   ./scripts/clang-format-test.sh --format-exe /pkgs/Linux/Rocky93/LLVM/LLVM-20.1.0-Linux-X64/bin/clang-format || exit 10
@@ -48,7 +50,7 @@ if [ "$SANITIZER" = true ]; then
     # detect_leaks is not supported on Mac
     # export ASAN_OPTIONS=detect_leaks=0
 fi
-./configure --prefix=$SST_INSTALL $DBGFLAGS || exit 11
+./configure --prefix=$SST_INSTALL $DBGFLAGS $PYFLAGS || exit 11
 if [ "$HEADERCHECK" = true ] ; then
 	./scripts/test-includes.pl || exit 20
 fi

--- a/jenkins/sstcore-sles15-gcc15-mpich3.4.sh
+++ b/jenkins/sstcore-sles15-gcc15-mpich3.4.sh
@@ -31,6 +31,8 @@ echo "VALGRIND=$VALGRIND"
 echo $SST_INSTALL
 echo $PATH
 
+export PYFLAGS="--with-python=/usr/bin/python3.11-config"
+
 rm -Rf $SST_INSTALL/*
 if [ "$CLANGFORMAT" = true ]; then
   ./scripts/clang-format-test.sh --format-exe /pkgs/Linux/Rocky93/LLVM/LLVM-20.1.0-Linux-X64/bin/clang-format || exit 10
@@ -48,7 +50,7 @@ if [ "$SANITIZER" = true ]; then
     # detect_leaks is not supported on Mac
     # export ASAN_OPTIONS=detect_leaks=0
 fi
-./configure --prefix=$SST_INSTALL $DBGFLAGS || exit 11
+./configure --prefix=$SST_INSTALL $DBGFLAGS $PYFLAGS || exit 11
 if [ "$HEADERCHECK" = true ] ; then
   ./scripts/test-includes.pl || exit 20
 fi

--- a/jenkins/sstcore-sles15-gcc15-mpich4.1.2.sh
+++ b/jenkins/sstcore-sles15-gcc15-mpich4.1.2.sh
@@ -31,6 +31,8 @@ echo "VALGRIND=$VALGRIND"
 echo $SST_INSTALL
 echo $PATH
 
+export PYFLAGS="--with-python=/usr/bin/python3.11-config"
+
 rm -Rf $SST_INSTALL/*
 if [ "$CLANGFORMAT" = true ]; then
   ./scripts/clang-format-test.sh --format-exe /pkgs/Linux/Rocky93/LLVM/LLVM-20.1.0-Linux-X64/bin/clang-format || exit 10
@@ -48,7 +50,7 @@ if [ "$SANITIZER" = true ]; then
     # detect_leaks is not supported on Mac
     # export ASAN_OPTIONS=detect_leaks=0
 fi
-./configure --prefix=$SST_INSTALL $DBGFLAGS || exit 11
+./configure --prefix=$SST_INSTALL $DBGFLAGS $PYFLAGS || exit 11
 if [ "$HEADERCHECK" = true ] ; then
 	./scripts/test-includes.pl || exit 20
 fi

--- a/jenkins/sstcore-sles15-gcc15-openmpi4.1.7.sh
+++ b/jenkins/sstcore-sles15-gcc15-openmpi4.1.7.sh
@@ -31,6 +31,8 @@ echo "VALGRIND=$VALGRIND"
 echo $SST_INSTALL
 echo $PATH
 
+export PYFLAGS="--with-python=/usr/bin/python3.11-config"
+
 rm -Rf $SST_INSTALL/*
 if [ "$CLANGFORMAT" = true ]; then
   ./scripts/clang-format-test.sh --format-exe /pkgs/Linux/Rocky93/LLVM/LLVM-20.1.0-Linux-X64/bin/clang-format || exit 10
@@ -48,7 +50,7 @@ if [ "$SANITIZER" = true ]; then
     # detect_leaks is not supported on Mac
     # export ASAN_OPTIONS=detect_leaks=0
 fi
-./configure --prefix=$SST_INSTALL $DBGFLAGS || exit 11
+./configure --prefix=$SST_INSTALL $DBGFLAGS $PYFLAGS || exit 11
 if [ "$HEADERCHECK" = true ] ; then
 	./scripts/test-includes.pl || exit 20
 fi


### PR DESCRIPTION
Adds: 

`export PYFLAGS="--with-python=/usr/bin/python3.11-config"`

and 
`$PYFLAGS` to configure step for sst-core