### PR TITLE
object map test enhancements providing type traits information and checking

### DIFF
--- a/components/core-debug/CMakeLists.txt
+++ b/components/core-debug/CMakeLists.txt
@@ -12,6 +12,8 @@ set(DbgSST15Srcs
   omni.h
   om-arrays.cc
   om-arrays.h
+  om-queue.cc
+  om-queue.h
   om-unions.cc
   om-unions.h
   dbgsst15.cc

--- a/components/core-debug/dbgsst15.h
+++ b/components/core-debug/dbgsst15.h
@@ -8,8 +8,8 @@
 // See LICENSE in the top level directory for licensing details
 //
 
-#ifndef _SSTDEBUG_DBGSST15_H_
-#define _SSTDEBUG_DBGSST15_H_
+#ifndef _SST_EXT_TESTS_DBGSST15_H_
+#define _SST_EXT_TESTS_DBGSST15_H_
 
 // -- Standard Headers
 #include <bitset>
@@ -447,6 +447,6 @@ public:
 #endif // PROBE
 } // namespace SSTDEBUG::DbgSST15
 
-#endif // _SSTDEBUG_DBGSST15_H_
+#endif // _SST_EXT_TESTS_DBGSST15_H_
 
 // EOF

--- a/components/core-debug/om-arrays.cc
+++ b/components/core-debug/om-arrays.cc
@@ -23,12 +23,25 @@ OMArrays::OMArrays(ComponentId_t id, Params& params) : OMSubComponentAPI(id,para
 OMArrays::~OMArrays() {}
 
 void OMArrays::update(payload_t& p) {
-  OMSubComponentAPI::update(p);
-
-    memcpy(v_pong_t, v_ping_t, BUFFER_SIZE * sizeof(uint16_t));
-    for (size_t i=0; i<BUFFER_SIZE; i++)
-      v_ping_t[i] +=1;
+  subcompapi_counter_++;
+  assert(subcompapi_counter_ < UINT16_MAX);
+  memcpy(v_pong_t, v_ping_t, BUFFER_SIZE * sizeof(uint16_t));
+  for (size_t i=0; i<BUFFER_SIZE; i++)
+    v_ping_t[i] += 1;
 }
+
+void OMArrays::check()
+{
+  sstout_.verbose(CALL_INFO, 0, 0, "Checking internal state\n");
+  for (uint16_t i=0; i<BUFFER_SIZE; i++) {
+    uint16_t e = (uint16_t)subcompapi_counter_ + i;
+    if (v_pong_t[i] != e) 
+      sstout_.fatal(CALL_INFO, -1, "v_pong[%" PRIu16 "]: Expected %" PRIu16 " but found %" PRIu16 "\n", i, e, v_pong_t[i]);
+    if (v_ping_t[i] != e + 1) 
+      sstout_.fatal(CALL_INFO, -1, "v_ping[%" PRIu16 "]: Expected %" PRIu16 " but found %" PRIu16 "\n", i, e, v_ping_t[i]);
+  }
+}
+
 
 }//namespace SST::ExtTest
 

--- a/components/core-debug/om-arrays.h
+++ b/components/core-debug/om-arrays.h
@@ -10,8 +10,8 @@
 
 // Intent:  Verify debug console operations on simple arrays.
 // 
-#ifndef _SST_EXT_TESTS_OM_ARRAYS
-#define _SST_EXT_TESTS_OM_ARRAYS
+#ifndef _SST_EXT_TESTS_OM_ARRAYS_H_
+#define _SST_EXT_TESTS_OM_ARRAYS_H_
 
 #include "omni.h"
 
@@ -56,6 +56,6 @@ private:
 
 }//namespace SST::ExtTest
 
-#endif  // _SST_EXT_TESTS_OM_ARRAYS
+#endif  // _SST_EXT_TESTS_OM_ARRAYS_H_
 
 // EOF

--- a/components/core-debug/om-arrays.h
+++ b/components/core-debug/om-arrays.h
@@ -13,11 +13,12 @@
 #ifndef _SST_EXT_TESTS_OM_ARRAYS_H_
 #define _SST_EXT_TESTS_OM_ARRAYS_H_
 
+#include <queue>
+
 #include "omni.h"
 
-#include <cassert>
-#include <cstdint>
-#include <queue>
+
+
 
 namespace SST::ExtTest {
 
@@ -36,6 +37,10 @@ public:
  
   OMArrays(ComponentId_t id, Params& params);
   ~OMArrays();
+
+  void init(unsigned int phase) final {
+    sstout_.verbose(CALL_INFO, 0, 0, "%s", list_type_traits(v_ping_t).c_str());
+  };
   virtual void update(payload_t& p) final;
 
 public:

--- a/components/core-debug/om-arrays.h
+++ b/components/core-debug/om-arrays.h
@@ -41,7 +41,9 @@ public:
   void init(unsigned int phase) final {
     sstout_.verbose(CALL_INFO, 0, 0, "%s", list_type_traits(v_ping_t).c_str());
   };
+  
   virtual void update(payload_t& p) final;
+  virtual void check() final;
 
 public:
   static const size_t BUFFER_SIZE = 1000;

--- a/components/core-debug/om-queue.cc
+++ b/components/core-debug/om-queue.cc
@@ -20,12 +20,22 @@ OMQueue::OMQueue(ComponentId_t id, Params& params) : OMSubComponentAPI(id,params
 }
 
 void OMQueue::update(payload_t& p) {
-  OMSubComponentAPI::update(p);
+  subcompapi_counter_++;
+  assert(subcompapi_counter_<UINT32_MAX);
   assert(v_queue_unsigned_.size()==3);
   unsigned front = v_queue_unsigned_.front() + 1;
   v_queue_unsigned_.pop();
   v_queue_unsigned_.push(front);
   sstout_.verbose(CALL_INFO, 1, 0, "v_queue_unsigned_.front()=%d\n", v_queue_unsigned_.front());
+}
+
+void OMQueue::check()
+{
+  sstout_.verbose(CALL_INFO, 0, 0, "Checking internal state\n");
+  uint32_t e = 100 + (uint32_t) subcompapi_counter_/3;
+  uint32_t f = v_queue_unsigned_.front();
+  if ( f != e )
+    sstout_.fatal(CALL_INFO, -1, "v_queue_unsigned_.front(): Expected %" PRIu32 " but found %" PRIu32 "\n", e, f);
 }
 
 } //namespace SST::ExtTest

--- a/components/core-debug/om-queue.cc
+++ b/components/core-debug/om-queue.cc
@@ -12,7 +12,6 @@
 
 namespace SST::ExtTest {
 
-
 OMQueue::OMQueue(ComponentId_t id, Params& params) : OMSubComponentAPI(id,params) {
   sstout_.init(getName() + ":@p:@t]: ", 0, 0, SST::Output::STDOUT );
   v_queue_unsigned_.push(100);

--- a/components/core-debug/om-queue.cc
+++ b/components/core-debug/om-queue.cc
@@ -25,7 +25,7 @@ void OMQueue::update(payload_t& p) {
   unsigned front = v_queue_unsigned_.front() + 1;
   v_queue_unsigned_.pop();
   v_queue_unsigned_.push(front);
-  sstout_.verbose(CALL_INFO, 0, 0, "v_queue_unsigned_.front()=%d\n", v_queue_unsigned_.front());
+  sstout_.verbose(CALL_INFO, 1, 0, "v_queue_unsigned_.front()=%d\n", v_queue_unsigned_.front());
 }
 
 } //namespace SST::ExtTest

--- a/components/core-debug/om-queue.cc
+++ b/components/core-debug/om-queue.cc
@@ -1,0 +1,34 @@
+//
+// om-queue.cc
+//
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "om-queue.h"
+
+namespace SST::ExtTest {
+
+
+OMQueue::OMQueue(ComponentId_t id, Params& params) : OMSubComponentAPI(id,params) {
+  sstout_.init(getName() + ":@p:@t]: ", 0, 0, SST::Output::STDOUT );
+  v_queue_unsigned_.push(100);
+  v_queue_unsigned_.push(200);
+  v_queue_unsigned_.push(300);
+}
+
+void OMQueue::update(payload_t& p) {
+  OMSubComponentAPI::update(p);
+  assert(v_queue_unsigned_.size()==3);
+  unsigned front = v_queue_unsigned_.front() + 1;
+  v_queue_unsigned_.pop();
+  v_queue_unsigned_.push(front);
+  sstout_.verbose(CALL_INFO, 0, 0, "v_queue_unsigned_.front()=%d\n", v_queue_unsigned_.front());
+}
+
+} //namespace SST::ExtTest
+
+// EOF

--- a/components/core-debug/om-queue.h
+++ b/components/core-debug/om-queue.h
@@ -1,0 +1,54 @@
+//
+// om-queue.h
+//
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef _SST_EXT_TESTS_OM_QUEUE_H_
+#define _SST_EXT_TESTS_OM_QUEUE_H_
+
+#include "omni.h"
+
+namespace SST::ExtTest {
+
+// -------------------------------------------------------
+// OmSubComponentAPI subcomponent
+// OMQueue (not registered)
+// Testing: std::queue
+// -------------------------------------------------------
+class OMQueue : public OMSubComponentAPI {
+public:
+  SST_ELI_REGISTER_SUBCOMPONENT(
+        OMQueue,            // Class name
+        "dbgsst15",         // Library name
+        "OMQueue",          // Subcomponent name
+        SST_ELI_ELEMENT_VERSION(1,0,0),  // A version number
+        "std::queue test sub-component", 
+        SST::ExtTest::OMSubComponentAPI) // Fully qualified API name
+ 
+  OMQueue(ComponentId_t id, Params& params);
+  ~OMQueue() {}
+  virtual void update(payload_t& p) final;
+public:
+  // serialization support
+  OMQueue() : OMSubComponentAPI() {}; // required for serialization
+  void serialize_order(SST::Core::Serialization::serializer& ser) override {
+    OMSubComponentAPI::serialize_order(ser);
+    SST_SER(v_queue_unsigned_);
+  }
+  ImplementSerializable(SST::ExtTest::OMQueue)
+private:
+  SST::Output sstout_;
+  std::queue<uint32_t> v_queue_unsigned_;
+}; //class OMQueue
+
+
+} //namespace SST::ExtTest
+
+#endif  // _SST_EXT_TESTS_OM_QUEUE_H_
+
+// EOF

--- a/components/core-debug/om-queue.h
+++ b/components/core-debug/om-queue.h
@@ -35,7 +35,7 @@ public:
   ~OMQueue() {}
 
   void init(unsigned int phase) final {
-    sstout_.verbose(CALL_INFO, 0, 0, "%s", list_type_traits<std::queue<uint32_t>>().c_str());
+    sstout_.verbose(CALL_INFO, 0, 0, "%s", list_type_traits(v_queue_unsigned_).c_str());
   };
 
   // OMSubComponentAPI

--- a/components/core-debug/om-queue.h
+++ b/components/core-debug/om-queue.h
@@ -12,6 +12,7 @@
 #define _SST_EXT_TESTS_OM_QUEUE_H_
 
 #include "omni.h"
+#include "list-traits.h"
 
 namespace SST::ExtTest {
 
@@ -32,6 +33,12 @@ public:
  
   OMQueue(ComponentId_t id, Params& params);
   ~OMQueue() {}
+
+  void init(unsigned int phase) final {
+    sstout_.verbose(CALL_INFO, 0, 0, "%s", list_type_traits<std::queue<uint32_t>>().c_str());
+  };
+
+  // OMSubComponentAPI
   virtual void update(payload_t& p) final;
 public:
   // serialization support

--- a/components/core-debug/om-queue.h
+++ b/components/core-debug/om-queue.h
@@ -40,6 +40,8 @@ public:
 
   // OMSubComponentAPI
   virtual void update(payload_t& p) final;
+  virtual void check() final;
+
 public:
   // serialization support
   OMQueue() : OMSubComponentAPI() {}; // required for serialization

--- a/components/core-debug/om-unions.cc
+++ b/components/core-debug/om-unions.cc
@@ -15,22 +15,22 @@ namespace SST::ExtTest {
 OMUnions::OMUnions(ComponentId_t id, Params& params) : OMSubComponentAPI(id,params) {
   sstout_.init("[" + getName() + ":@p:@t]: ", 0, 0, SST::Output::STDOUT );
   v_union_struct_trivial.v  = 0x11111111;
-  v_union_struct_method_1.v = 0x22222222;
+  v_union_struct_method_1.v = 0;
   #ifdef UNION_METHOD_2
   v_union_struct_method_2.v = 0x33333333;
   #endif
   v_union_int_float_trivial.f  = 0.0;
-  v_union_struct_method_1.v = 0.0;
+  v_union_int_float_method_1.f = 0.0;
   #ifdef UNION_METHOD_2
-  v_union_struct_method_2.v = 0.0;
+  v_union_int_float_method_2.v = 0.0;
   #endif
 }
 
 OMUnions::~OMUnions() {}
 
 void OMUnions::update(payload_t& p) {
-  OMSubComponentAPI::update(p);
-
+  subcompapi_counter_++;
+  assert(subcompapi_counter_ < UINT32_MAX);
   v_union_struct_trivial.v  += 0x01010101;   
   v_union_struct_method_1.v += 0x02020202;   
   #ifdef UNION_METHOD_2
@@ -42,6 +42,44 @@ void OMUnions::update(payload_t& p) {
   #ifdef UNION_METHOD_2
   v_union_int_float_method_2.f += 3.0f;
   #endif
+}
+
+void OMUnions::check()
+{
+
+  sstout_.verbose(CALL_INFO, 0, 0, "Checking internal state\n");
+  uint32_t v0 = 0x11111111;
+  uint32_t v1 = 0;
+  float f0 = 0.0f;
+  float f1 = 0.0f;
+
+  for (size_t i=0; i<subcompapi_counter_; i++) {
+    v0 += 0x01010101;
+    v1 += 0x02020202;
+    f0 += 1.0f;
+    f1 += 2.0f;
+  }
+
+  uint32_t e = v0;
+  uint32_t f = v_union_struct_trivial.v;
+  if ( e != f )
+    sstout_.fatal(CALL_INFO, -1, "v_union_struct_trivial.v: Expected %" PRIx32 " but found %" PRIx32 "\n", e, f);
+
+  e = v1;
+  f = v_union_struct_method_1.v;
+  if ( e != f )
+    sstout_.fatal(CALL_INFO, -1, "v_union_struct_method_1.v: Expected %" PRIx32 " but found %" PRIx32 "\n", e, f);
+
+  e = (uint32_t) f0;
+  f = (uint32_t) v_union_int_float_trivial.f;
+  if ( e != f )
+    sstout_.fatal(CALL_INFO, -1, "v_union_int_float_trivial.f: Expected %" PRIx32 " but found %" PRIx32 "\n", e, f);
+
+  e = (uint32_t) f1;
+  f = (uint32_t) v_union_int_float_method_1.f;
+  if ( e != f )
+    sstout_.fatal(CALL_INFO, -1, "v_union_int_float_method_1.f: Expected %" PRIx32 " but found %" PRIx32 "\n", e, f);
+
 }
 
 }//namespace SST::ExtTest

--- a/components/core-debug/om-unions.h
+++ b/components/core-debug/om-unions.h
@@ -147,6 +147,7 @@ public:
   };
   
   virtual void update(payload_t& p) final;
+  virtual void check() final;
 
 public:
   // serialization support

--- a/components/core-debug/om-unions.h
+++ b/components/core-debug/om-unions.h
@@ -22,8 +22,8 @@
 //          SST online documentation for a `serialize_impl`
 //          specialization.
 // 
-#ifndef _SST_EXT_TESTS_OM_UNIONS
-#define _SST_EXT_TESTS_OM_UNIONS
+#ifndef _SST_EXT_TESTS_OM_UNIONS_
+#define _SST_EXT_TESTS_OM_UNIONS_
 
 #include "omni.h"
 
@@ -221,6 +221,6 @@ class serialize_impl<SST::ExtTest::v_union_int_float_method_1_t>
 };// class serialize_impl<SST::ExtTest::v_union_int_float_method_1_t>
 } //namespace SST::Core::Serialization
 
-#endif  // _SST_EXT_TESTS_OM_UNIONS
+#endif  // _SST_EXT_TESTS_OM_UNIONS_
 
 // EOF

--- a/components/core-debug/om-unions.h
+++ b/components/core-debug/om-unions.h
@@ -25,11 +25,8 @@
 #ifndef _SST_EXT_TESTS_OM_UNIONS_
 #define _SST_EXT_TESTS_OM_UNIONS_
 
-#include "omni.h"
 
-#include <cassert>
-#include <cstdint>
-#include <queue>
+#include "omni.h"
 
 //TODO Verify method2 works. Currently does not compile
 // #define UNION_METHOD_2
@@ -141,6 +138,14 @@ public:
  
   OMUnions(ComponentId_t id, Params& params);
   ~OMUnions();
+
+  void init(unsigned int phase) final {
+    sstout_.verbose(CALL_INFO, 0, 0, "%s", list_type_traits(v_union_struct_trivial).c_str());
+    sstout_.verbose(CALL_INFO, 0, 0, "%s", list_type_traits(v_union_struct_method_1).c_str());
+    sstout_.verbose(CALL_INFO, 0, 0, "%s", list_type_traits(v_union_int_float_trivial).c_str());
+    sstout_.verbose(CALL_INFO, 0, 0, "%s", list_type_traits(v_union_int_float_method_1).c_str());
+  };
+  
   virtual void update(payload_t& p) final;
 
 public:

--- a/components/core-debug/omni.cc
+++ b/components/core-debug/omni.cc
@@ -96,6 +96,12 @@ bool OMSimpleComponent::clockTick(SST::Cycle_t currentCycle)
     #endif
 }
 
+void OMSimpleComponent::init(unsigned int phase)
+{
+    if (p_omsimplecomp_function0_)
+        p_omsimplecomp_function0_->init(phase);
+}
+
 } // namespace SST::ExtTest
 
 // EOF

--- a/components/core-debug/omni.cc
+++ b/components/core-debug/omni.cc
@@ -96,12 +96,6 @@ bool OMSimpleComponent::clockTick(SST::Cycle_t currentCycle)
     #endif
 }
 
-void OMSimpleComponent::init(unsigned int phase)
-{
-    if (p_omsimplecomp_function0_)
-        p_omsimplecomp_function0_->init(phase);
-}
-
 } // namespace SST::ExtTest
 
 // EOF

--- a/components/core-debug/omni.h
+++ b/components/core-debug/omni.h
@@ -110,7 +110,7 @@ public:
   ~OMSimpleComponent() {}
 
   // Component Lifecycle
-  void init( unsigned int phase ) override {};     // post-construction, polled events
+  void init( unsigned int phase ) override;        // post-construction, polled events
   void setup() override {};                        // pre-simulation, called once per component
   void complete( unsigned int phase ) override {}; // post-simulation, polled events
   void finish() override {};                       // pre-destruction, called once per component

--- a/components/core-debug/omni.h
+++ b/components/core-debug/omni.h
@@ -15,8 +15,8 @@
 // complex behaviors by simply providing the subcomponent
 // at runtime.
 
-#ifndef _SST_EXT_TESTS_OMNI_
-#define _SST_EXT_TESTS_OMNI_
+#ifndef _SST_EXT_TESTS_OMNI_H_
+#define _SST_EXT_TESTS_OMNI_H_
 
 // -- Standard Headers
 #include "SST.h"
@@ -88,11 +88,11 @@ class OMSimpleComponent : public SST::Component{
 
 public:
   SST_ELI_REGISTER_COMPONENT( OMSimpleComponent,   // component class
-             "dbgsst15",       // component library
-                            "OMSimpleComponent",   // component name
-                            SST_ELI_ELEMENT_VERSION( 1, 0, 0 ),
-                            "Simple Object Map Evalulation Component",
-                            COMPONENT_CATEGORY_UNCATEGORIZED )
+    "dbgsst15",       // component library
+    "OMSimpleComponent",   // component name
+    SST_ELI_ELEMENT_VERSION( 1, 0, 0 ),
+    "Simple Object Map Evalulation Component",
+    COMPONENT_CATEGORY_UNCATEGORIZED )
   SST_ELI_DOCUMENT_PARAMS(
     {"verbose", "Sets the verbosity level of output",   "1" },
     {"primary", "Sets component as primary controller", "0" },
@@ -152,52 +152,8 @@ public:
 
 }; //class OMSimpleComponent
 
-// -------------------------------------------------------
-// OmSubComponentAPI Specialization Example
-// OMQueue (not registered)
-// Testing: std::queue
-// -------------------------------------------------------
-class OMQueue : public OMSubComponentAPI {
-public:
-  SST_ELI_REGISTER_SUBCOMPONENT(
-        OMQueue,            // Class name
-        "dbgsst15",         // Library name
-        "OMQueue",          // Subcomponent name
-        SST_ELI_ELEMENT_VERSION(1,0,0),  // A version number
-        "std::queue test sub-component", 
-        SST::ExtTest::OMSubComponentAPI) // Fully qualified API name
- 
-  OMQueue(ComponentId_t id, Params& params) : OMSubComponentAPI(id,params) {
-    sstout_.init(getName() + ":@p:@t]: ", 0, 0, SST::Output::STDOUT );
-    v_queue_unsigned_.push(100);
-    v_queue_unsigned_.push(200);
-    v_queue_unsigned_.push(300);
-  }
-  ~OMQueue() {}
-  virtual void update(payload_t& p) final {
-    OMSubComponentAPI::update(p);
-    assert(v_queue_unsigned_.size()==3);
-    unsigned front = v_queue_unsigned_.front() + 1;
-    v_queue_unsigned_.pop();
-    v_queue_unsigned_.push(front);
-    sstout_.verbose(CALL_INFO, 0, 0, "v_queue_unsigned_.front()=%d\n", v_queue_unsigned_.front());
-  }
-public:
-  // serialization support
-  OMQueue() : OMSubComponentAPI() {}; // required for serialization
-  void serialize_order(SST::Core::Serialization::serializer& ser) override {
-    OMSubComponentAPI::serialize_order(ser);
-    SST_SER(v_queue_unsigned_);
-  }
-  ImplementSerializable(SST::ExtTest::OMQueue)
-private:
-  SST::Output sstout_;
-  std::queue<uint32_t> v_queue_unsigned_;
-}; //class OMQueue
-
-
 } //namespace SST::ExtTest
 
-#endif  // _SST_EXT_TESTS_OMNI_
+#endif  // _SST_EXT_TESTS_OMNI_H_
 
 // EOF

--- a/components/core-debug/omni.h
+++ b/components/core-debug/omni.h
@@ -20,6 +20,7 @@
 
 // -- Standard Headers
 #include "SST.h"
+#include "list-traits.h"
 
 namespace SST::ExtTest {
 

--- a/components/core-debug/omni.h
+++ b/components/core-debug/omni.h
@@ -65,11 +65,11 @@ public:
   OMSubComponentAPI(ComponentId_t id, Params& params) : SubComponent(id) {};
   virtual ~OMSubComponentAPI() {}
   
-  virtual void update(payload_t& p) {
-    subcompapi_counter_++;
-    p.data += 1;
-  };
-private:
+  // API
+  virtual void update(payload_t& p) = 0;
+  virtual void check() = 0;
+
+protected:
   uint64_t subcompapi_counter_ = 0;
 
 public:
@@ -111,9 +111,16 @@ public:
   ~OMSimpleComponent() {}
 
   // Component Lifecycle
-  void init( unsigned int phase ) override;        // post-construction, polled events
+  void init( unsigned int phase ) override         // post-construction, polled events
+  { 
+    p_omsimplecomp_function0_->init(phase);
+  }
   void setup() override {};                        // pre-simulation, called once per component
-  void complete( unsigned int phase ) override {}; // post-simulation, polled events
+  void complete( unsigned int phase ) override     // post-simulation, polled events
+  {
+    p_omsimplecomp_function0_->check();
+  }
+
   void finish() override {};                       // pre-destruction, called once per component
   void emergencyShutdown() override {};            // SIGINT, SIGTERM
   void printStatus(Output& out) override {};       // SIGUSR2

--- a/components/core-debug/probe.h
+++ b/components/core-debug/probe.h
@@ -9,8 +9,8 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#ifndef SST_DEBUG_PROBE_H
-#define SST_DEBUG_PROBE_H
+#ifndef SST_EXT_TESTS_DEBUG_PROBE_H_
+#define SST_EXT_TESTS_DEBUG_PROBE_H_
 
 // -- Standard Headers
 #include <assert.h>
@@ -426,4 +426,4 @@ private:
 }; // class ProbeSocket
 
 } // namespace SSTDEBUG::Probe
-#endif /* SST_DEBUG_PROBE_H */
+#endif /* SST_EXT_TESTS_DEBUG_PROBE_H_ */

--- a/components/core-debug/tcldbg.h
+++ b/components/core-debug/tcldbg.h
@@ -5,8 +5,8 @@
 // See LICENSE in the top level directory for licensing details
 //
 
-#ifndef _TCLDBG_H
-#define _TCLDBG_H
+#ifndef _SST_EXT_TESTS_TCLDBG_H_
+#define _SST_EXT_TESTS_TCLDBG_H_
 
 #include <iostream>
 #include <ostream>
@@ -38,4 +38,4 @@ spinner(const char* id, bool cond = true)
 
 } // namespace tcldbg
 
-#endif //_TCLDBG_H
+#endif //_SST_EXT_TESTS_TCLDBG_H_

--- a/components/include/list-traits.h
+++ b/components/include/list-traits.h
@@ -10,15 +10,114 @@
 
 //
 // Informational list of type traits useful for test audits
-//
+// ref: https://en.cppreference.com/w/cpp/header/type_traits.html
 
 #include <iostream>
 #include <type_traits>
 #include <string>
+#include <sstream>
 #include <iomanip>
 
-#define PRINT_TRAIT(trait, type) \
-    std::cout << std::setw(30) << #trait << ": " \
-              << (trait<type>::value ? "true" : "false") << '\n'
+#define PRINT_TRAIT(o, trait, type) \
+    o << std::setw(32) << #trait << ": " \
+              << (trait<type>::value ? "true" : "false") << '\n';
 
-              
+// Template function to list traits for a given type
+template <typename T>
+std::string list_type_traits() {
+    std::stringstream s;
+    s << "Type traits for: " << typeid(T).name() << "\n";
+    s << "----------------------------------------\n";
+
+    // Primary type categories
+    PRINT_TRAIT(s, std::is_void, T);
+    PRINT_TRAIT(s, std::is_null_pointer, T);
+    PRINT_TRAIT(s, std::is_integral, T);
+    PRINT_TRAIT(s, std::is_floating_point, T);
+    PRINT_TRAIT(s, std::is_array, T);
+    PRINT_TRAIT(s, std::is_enum, T);
+    PRINT_TRAIT(s, std::is_union, T);
+    PRINT_TRAIT(s, std::is_class, T);
+    PRINT_TRAIT(s, std::is_function, T)
+    PRINT_TRAIT(s, std::is_pointer, T);
+    PRINT_TRAIT(s, std::is_lvalue_reference, T);
+    PRINT_TRAIT(s, std::is_rvalue_reference, T);
+    PRINT_TRAIT(s, std::is_member_object_pointer, T);
+    PRINT_TRAIT(s, std::is_member_function_pointer, T)
+
+    // Composite type categories
+    PRINT_TRAIT(s, std::is_fundamental, T);
+    PRINT_TRAIT(s, std::is_arithmetic, T);
+    PRINT_TRAIT(s, std::is_scalar, T);
+    PRINT_TRAIT(s, std::is_object, T);
+    PRINT_TRAIT(s, std::is_compound, T);
+    PRINT_TRAIT(s, std::is_reference, T);
+    PRINT_TRAIT(s, std::is_member_pointer, T);
+
+    // Type properties
+    PRINT_TRAIT(s, std::is_const, T);
+    PRINT_TRAIT(s, std::is_volatile, T);
+    PRINT_TRAIT(s, std::is_trivial, T);         // deprecated in C++26
+    PRINT_TRAIT(s, std::is_trivially_copyable, T);
+    PRINT_TRAIT(s, std::is_standard_layout, T);
+    PRINT_TRAIT(s, std::is_pod, T);             // deprecated in C++20
+    // PRINT_TRAIT(s, std::is_literal_type, T); // deprecated in C++17
+    PRINT_TRAIT(s, std::has_unique_object_representations, T); // C++17
+    PRINT_TRAIT(s, std::is_empty, T);
+    PRINT_TRAIT(s, std::is_polymorphic, T);
+    PRINT_TRAIT(s, std::is_abstract, T);
+    PRINT_TRAIT(s, std::is_final, T);           // C++14
+    PRINT_TRAIT(s, std::is_aggregate, T);       // C++17
+    // PRINT_TRAIT(s, std::is_implicit_lifetime, T); // c++23
+    PRINT_TRAIT(s, std::is_signed, T);
+    PRINT_TRAIT(s, std::is_unsigned, T);
+    // PRINT_TRAIT(s, std::is_bounded_array, T);    // c++20
+    // PRINT_TRAIT(s, std::is_unbounded_array, T);  // c++20
+    // PRINT_TRAIT(s, std::is_scoped_enum, T);      // c++23   
+
+    // Supported operations
+    PRINT_TRAIT(s, std::is_constructible, T);
+    PRINT_TRAIT(s, std::is_trivially_constructible, T);
+    PRINT_TRAIT(s, std::is_nothrow_constructible, T);
+
+    PRINT_TRAIT(s, std::is_default_constructible, T);
+    PRINT_TRAIT(s, std::is_trivially_default_constructible, T);
+    PRINT_TRAIT(s, std::is_nothrow_default_constructible, T);
+
+    PRINT_TRAIT(s, std::is_copy_constructible, T);
+    PRINT_TRAIT(s, std::is_trivially_copy_constructible, T);
+    PRINT_TRAIT(s, std::is_nothrow_copy_constructible, T);
+
+    PRINT_TRAIT(s, std::is_move_constructible, T);
+    PRINT_TRAIT(s, std::is_trivially_move_constructible, T);
+    PRINT_TRAIT(s, std::is_nothrow_move_constructible, T);
+
+    // PRINT_TRAIT(s, std::is_assignable, T);           // Requires 2 parameters
+    // PRINT_TRAIT(s, std::is_trivially_assignable, T);
+    // PRINT_TRAIT(s, std::is_nothrow_assignable, T);
+
+    PRINT_TRAIT(s, std::is_copy_assignable, T);
+    PRINT_TRAIT(s, std::is_trivially_copy_assignable, T);
+    PRINT_TRAIT(s, std::is_nothrow_copy_assignable, T);
+
+    PRINT_TRAIT(s, std::is_move_assignable, T);
+    PRINT_TRAIT(s, std::is_trivially_move_assignable, T);
+    PRINT_TRAIT(s, std::is_nothrow_move_assignable, T);
+
+    PRINT_TRAIT(s, std::is_destructible, T);
+    PRINT_TRAIT(s, std::is_trivially_destructible, T);
+    PRINT_TRAIT(s, std::is_nothrow_destructible, T);
+
+    PRINT_TRAIT(s, std::has_virtual_destructor, T);
+
+    // PRINT_TRAIT(s, std::is_swappable_with, T);       // c++17 Requires 2 parameters
+    // PRINT_TRAIT(s, std::is_swappable, T);
+    // PRINT_TRAIT(s, std::is_nothrow_swappable_with, T);
+    // PRINT_TRAIT(s, std::is_nothrow_swappable, T);
+
+    // PRINT_TRAIT(s, std::reference_converts_from_temporary, T);   // c++23
+    // PRINT_TRAIT(s, std::reference_constructs_from_temporary, T); // c++23
+
+    s << "----------------------------------------\n";
+    return s.str();
+}        

--- a/components/include/list-traits.h
+++ b/components/include/list-traits.h
@@ -1,0 +1,24 @@
+//
+// _LIST_TRAITS_H
+//
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+//
+// Informational list of type traits useful for test audits
+//
+
+#include <iostream>
+#include <type_traits>
+#include <string>
+#include <iomanip>
+
+#define PRINT_TRAIT(trait, type) \
+    std::cout << std::setw(30) << #trait << ": " \
+              << (trait<type>::value ? "true" : "false") << '\n'
+
+              

--- a/components/include/list-traits.h
+++ b/components/include/list-traits.h
@@ -12,6 +12,9 @@
 // Informational list of type traits useful for test audits
 // ref: https://en.cppreference.com/w/cpp/header/type_traits.html
 
+#ifndef _SST_EXT_TESTS_LIST_TRAITS_H_
+#define _SST_EXT_TESTS_LIST_TRAITS_H_
+
 #include <cxxabi.h>
 #include <iomanip>
 #include <iostream>
@@ -20,7 +23,7 @@
 #include <type_traits>
 
 #define PRINT_TRAIT(o, trait, type) \
-    o << std::setw(35) << #trait << ": " \
+    o << std::setw(40) << #trait << ": " \
               << (trait<type>::value ? "true" : "false") << '\n';
 
 template <typename T>
@@ -38,7 +41,7 @@ std::string demangled_type_string(const T& obj) {
 template <typename T>
 std::string list_type_traits(const T& obj) {
     std::stringstream s;
-    s << "type traits for:" << demangled_type_string(obj) << std::endl;
+    s << "type traits for: " << demangled_type_string(obj) << std::endl;
     s << "----------------------------------------\n";
 
     // Primary type categories
@@ -132,4 +135,6 @@ std::string list_type_traits(const T& obj) {
 
     s << "----------------------------------------\n";
     return s.str();
-}        
+}
+
+#endif //_SST_EXT_TESTS_LIST_TRAITS_H_

--- a/components/include/list-traits.h
+++ b/components/include/list-traits.h
@@ -12,21 +12,33 @@
 // Informational list of type traits useful for test audits
 // ref: https://en.cppreference.com/w/cpp/header/type_traits.html
 
+#include <cxxabi.h>
+#include <iomanip>
 #include <iostream>
-#include <type_traits>
 #include <string>
 #include <sstream>
-#include <iomanip>
+#include <type_traits>
 
 #define PRINT_TRAIT(o, trait, type) \
     o << std::setw(32) << #trait << ": " \
               << (trait<type>::value ? "true" : "false") << '\n';
 
+template <typename T>
+std::string demangled_type_string() {
+  int status;
+  char* s = abi::__cxa_demangle(typeid(T).name(), nullptr, nullptr, &status);
+  if (status == 0 ) {
+    std::string ret(s);
+    std::free(s);
+    return ret;
+  }
+  return "";
+};
 // Template function to list traits for a given type
 template <typename T>
 std::string list_type_traits() {
     std::stringstream s;
-    s << "Type traits for: " << typeid(T).name() << "\n";
+    s << "type traits for:" << demangled_type_string<T>() << std::endl;
     s << "----------------------------------------\n";
 
     // Primary type categories

--- a/components/include/list-traits.h
+++ b/components/include/list-traits.h
@@ -20,13 +20,13 @@
 #include <type_traits>
 
 #define PRINT_TRAIT(o, trait, type) \
-    o << std::setw(32) << #trait << ": " \
+    o << std::setw(35) << #trait << ": " \
               << (trait<type>::value ? "true" : "false") << '\n';
 
 template <typename T>
-std::string demangled_type_string() {
+std::string demangled_type_string(const T& obj) {
   int status;
-  char* s = abi::__cxa_demangle(typeid(T).name(), nullptr, nullptr, &status);
+  char* s = abi::__cxa_demangle(typeid(obj).name(), nullptr, nullptr, &status);
   if (status == 0 ) {
     std::string ret(s);
     std::free(s);
@@ -36,9 +36,9 @@ std::string demangled_type_string() {
 };
 // Template function to list traits for a given type
 template <typename T>
-std::string list_type_traits() {
+std::string list_type_traits(const T& obj) {
     std::stringstream s;
-    s << "type traits for:" << demangled_type_string<T>() << std::endl;
+    s << "type traits for:" << demangled_type_string(obj) << std::endl;
     s << "----------------------------------------\n";
 
     // Primary type categories

--- a/tests/core-debug/CMakeLists.txt
+++ b/tests/core-debug/CMakeLists.txt
@@ -10,6 +10,7 @@
 
 set(TEST_FILE_EXT "sh")
 set(passRegex "PASS")
+set(failRegex "ERROR")
 
 if (SST_VALGRIND)
   set(timeout "600")
@@ -67,6 +68,7 @@ foreach(testSrc ${TEST_SRCS_TARGET_VER})
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND ./${testSrc})
     set_property(TEST ${testName} PROPERTY LABELS "${SST_VERSION}")
+    set_property(TEST ${testName} PROPERTY FAIL_REGULAR_EXPRESSION "${failRegex}")
     set_property(TEST ${testName} PROPERTY PASS_REGULAR_EXPRESSION "${passRegex}")
     set_property(TEST ${testName} PROPERTY ENVIRONMENT "SST_COMPONENT_BASE=$ENV{SST_COMPONENT_BASE}")
     if(NOT ${EXT_TEST_TIMEOUT} EQUAL 0)

--- a/tests/core-debug/type-stack.sh
+++ b/tests/core-debug/type-stack.sh
@@ -59,76 +59,76 @@ p 1
 # CHECK 6 p 2\n2 = 30
 p 2
 
-# watch 0 changed
-# watch 1 changed
-# watch 2 changed
-# run
+watch 0 changed
+watch 1 changed
+watch 2 changed
+run
 
-# # -check- 7 pwd\ncp0/v_stack_unsigned/container
-# pwd
+# CHECK 7 pwd\ncp0/v_stack_unsigned/container
+pwd
 
-# # -check- 8 ls\n0 = 10 .+\n1 = 20 .+\n2 = 31 .+
-# ls
+# CHECK 8 ls\n0 = 10 .+\n1 = 20 .+\n2 = 31 .+
+ls
 
-# run
-# # -check- 9 ls\n0 = 10 .+\n1 = 20 .+\n2 = 32 .+
-# ls
+run
+# CHECK 9 ls\n0 = 10 .+\n1 = 20 .+\n2 = 32 .+
+ls
 
-# run
-# # -check- 10 ls\n0 = 10 .+\n1 = 20 .+\n2 = 33 .+
-# ls
+run
+# CHECK 10 ls\n0 = 10 .+\n1 = 20 .+\n2 = 33 .+
+ls
 
-# run
-# # -check- 11 ls\n0 = 10 .+\n1 = 20 .+\n2 = 34 .+
-# ls
+run
+# CHECK 11 ls\n0 = 10 .+\n1 = 20 .+\n2 = 34 .+
+ls
 
-# set 2 200
-# # -check- 12 ls\n0 = 10 .+\n1 = 20 .+\n2 = 200 .+
-# ls
+set 2 200
+# CHECK 12 ls\n0 = 10 .+\n1 = 20 .+\n2 = 200 .+
+ls
 
-# # The watchpoint appears trigger on `set` above.
-# run
-# run
-# # -check- 13 ls\n0 = 10 .+\n1 = 20 .+\n2 = 201 .+
-# ls
+# The watchpoint appears trigger on `set` above.
+run
+run
+# CHECK 13 ls\n0 = 10 .+\n1 = 20 .+\n2 = 201 .+
+ls
 
 # stack does not have an emplace member function but we can still write values in the debugger
 set 0 100
 set 1 150
-# CHECK 14 ls\n0 = 100 .+\n1 = 150 .+\n2 = 30 .+
+# CHECK 14 ls\n0 = 100 .+\n1 = 150 .+\n2 = 201 .+
 ls
 
 run
 run
-# CHECK 15 ls\n0 = 100 .+\n1 = 150 .+\n2 = 31 .+
+# CHECK 15 ls\n0 = 100 .+\n1 = 150 .+\n2 = 202 .+
 ls
 
-# # now do a trace
-# unwatch
+# now do a trace
+unwatch
 
-# # -check- 16 trace 2 changed  : 4 2 : 0 1 2 : interactive\nAdded watchpoint #0
-# trace 2 changed  : 4 2 : 0 1 2 : interactive
+# CHECK 16 trace 2 changed  : 4 2 : 0 1 2 : interactive\nAdded watchpoint #0
+trace 2 changed  : 4 2 : 0 1 2 : interactive
 
-# sethandler 0 ac
-# run
+sethandler 0 ac
+run
 
-# TODO  add check when iconsole branch merged.
-# # The trace should be:
-# # TriggerCount=1
-# # LastTriggerRecord:@cycle7700000: SamplesLost=0: cp0/v_stack_unsigned/container/0=100 cp0/v_stack_unsigned/container/1=150 cp0/v_stack_unsigned/container/2=203 
-# # buf[2] AC @7699000 (-) cp0/v_stack_unsigned/container/0=100 cp0/v_stack_unsigned/container/1=150 cp0/v_stack_unsigned/container/2=202 
-# # buf[3] AC @7700000 (!) cp0/v_stack_unsigned/container/0=100 cp0/v_stack_unsigned/container/1=150 cp0/v_stack_unsigned/container/2=203 
-# # buf[0] AC @7701000 (+) cp0/v_stack_unsigned/container/0=100 cp0/v_stack_unsigned/container/1=150 cp0/v_stack_unsigned/container/2=203 
+# CHECK 17 printTrace 0\nTriggerRecord:@cycle7700000: samples lost = 0:.+\nbuf\[2] AC .+ \(-) cp0.+/2=202[ ]*\nbuf\[3] AC .+ \(\!) cp0.+/2=203[ ]*\nbuf\[0] AC .+ \(\+) cp0.+/2=203[ ]*\nbuf\[1] AC .+ \(\+) cp0.+/2=203
+printTrace 0
 
-# # _check_ 17 printTrace 0\nTriggerCount=1\n.+TriggerRecord:@cycle.+: SamplesLost=0: cp0/v_stack_unsigned/container/0=100 cp0/v_stack_unsigned/container/1=150 cp0/v_stack_unsigned/container/2=203 \nbuf\[2\] AC @.+ \(-\) cp0/v_stack_unsigned/container/0=100 cp0/v_stack_unsigned/container/1=150 cp0/v_stack_unsigned/container/2=202 \nbuf\[3\] AC @7700000 \(!\) cp0/v_stack_unsigned/container/0=100 cp0/v_stack_unsigned/container/1=150 cp0/v_stack_unsigned/container/2=203 \nbuf\[0\] AC @.+ \(\+\) cp0/v_stack_unsigned/container/0=100 cp0/v_stack_unsigned/container/1=150 cp0/v_stack_unsigned/container/2=203
-# printTrace 0
+# Expected
+# TriggerRecord:@cycle7700000: samples lost = 0: cp0/v_stack_unsigned/container/0=100 cp0/v_stack_unsigned/container/1=150 cp0/v_stack_unsigned/container/2=203 
+# buf[2] AC @7699000 (-) cp0/v_stack_unsigned/container/0=100 cp0/v_stack_unsigned/container/1=150 cp0/v_stack_unsigned/container/2=202 
+# buf[3] AC @7700000 (!) cp0/v_stack_unsigned/container/0=100 cp0/v_stack_unsigned/container/1=150 cp0/v_stack_unsigned/container/2=203 
+# buf[0] AC @7701000 (+) cp0/v_stack_unsigned/container/0=100 cp0/v_stack_unsigned/container/1=150 cp0/v_stack_unsigned/container/2=203 
+# buf[1] AC @7702000 (+) cp0/v_stack_unsigned/container/0=100 cp0/v_stack_unsigned/container/1=150 cp0/v_stack_unsigned/container/2=203 
+
 
 shutdown
 
 EOF
 
 # Update this whenever adding checks in the command comments above
-NUMCHECKS=8
+NUMCHECKS=18
 
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"

--- a/tests/core-debug/type-stack.sh
+++ b/tests/core-debug/type-stack.sh
@@ -86,7 +86,6 @@ set 2 200
 # CHECK 12 ls\n0 = 10 .+\n1 = 20 .+\n2 = 200 .+
 ls
 
-# The watchpoint appears trigger on `set` above.
 run
 run
 # CHECK 13 ls\n0 = 10 .+\n1 = 20 .+\n2 = 201 .+
@@ -112,10 +111,12 @@ trace 2 changed  : 4 2 : 0 1 2 : interactive
 sethandler 0 ac
 run
 
-# CHECK 17 printTrace 0\nTriggerRecord:@cycle7700000: samples lost = 0:.+\nbuf\[2] AC .+ \(-) cp0.+/2=202[ ]*\nbuf\[3] AC .+ \(\!) cp0.+/2=203[ ]*\nbuf\[0] AC .+ \(\+) cp0.+/2=203[ ]*\nbuf\[1] AC .+ \(\+) cp0.+/2=203
+# TODO add this check when iconsole is merged. The current checker can't handle optional lines.
+# --check-- 17 printTrace 0\nTriggerRecord:@cycle7700000: samples lost = 0:.+\nbuf\[2] AC .+ \(-) cp0.+/2=202[ ]*\nbuf\[3] AC .+ \(\!) cp0.+/2=203[ ]*\nbuf\[0] AC .+ \(\+) cp0.+/2=203[ ]*\nbuf\[1] AC .+ \(\+) cp0.+/2=203
 printTrace 0
 
-# Expected
+# Expected when iconsole branch merged
+# TriggerCount=1 <-- HERE this is being added
 # TriggerRecord:@cycle7700000: samples lost = 0: cp0/v_stack_unsigned/container/0=100 cp0/v_stack_unsigned/container/1=150 cp0/v_stack_unsigned/container/2=203 
 # buf[2] AC @7699000 (-) cp0/v_stack_unsigned/container/0=100 cp0/v_stack_unsigned/container/1=150 cp0/v_stack_unsigned/container/2=202 
 # buf[3] AC @7700000 (!) cp0/v_stack_unsigned/container/0=100 cp0/v_stack_unsigned/container/1=150 cp0/v_stack_unsigned/container/2=203 
@@ -128,7 +129,7 @@ shutdown
 EOF
 
 # Update this whenever adding checks in the command comments above
-NUMCHECKS=18
+NUMCHECKS=17
 
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"

--- a/tests/rt_action/CMakeLists.txt
+++ b/tests/rt_action/CMakeLists.txt
@@ -10,6 +10,7 @@
 
 set(TEST_FILE_EXT "sh")
 set(passRegex "PASS")
+set(failRegex "ERROR")
 
 if (SST_VALGRIND)
   set(timeout "600")
@@ -67,6 +68,7 @@ foreach(testSrc ${TEST_SRCS_TARGET_VER})
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND ./${testSrc})
     set_property(TEST ${testName} PROPERTY LABELS "${SST_VERSION}")
+    set_property(TEST ${testName} PROPERTY FAIL_REGULAR_EXPRESSION "${failRegex}")
     set_property(TEST ${testName} PROPERTY PASS_REGULAR_EXPRESSION "${passRegex}")
     set_property(TEST ${testName} PROPERTY ENVIRONMENT "SST_COMPONENT_BASE=$ENV{SST_COMPONENT_BASE}")
     if(NOT ${EXT_TEST_TIMEOUT} EQUAL 0)


### PR DESCRIPTION
This PR is another step towards my goal of having targeted tests to exercise and debug specific types in the interactive console. There are some cosmetic changes and CMakeFile changes as well.

First, the most generally useful feature is the new include file, `list-traits.h`.  This simple prints the bool values of all the type-traits (up to C++17) so we can quickly see what may be unique about some object without having to talk about it in the abstract.  Give the amount of specialization code in the object map, I thought this would provide a productivity boost and also serve as a way to audit what has and hasn't been tested.

Second, the 'OMNI' subcomponent now has pure virtual functions for `update()` and `check()`. This enforces the test convention to update the internal state and provide an independent check that predicts that values as a function of the number of times `update()` is called. This may seem trite but it's a simple and consistent way to do checking and debug of checkpoint restart as well as possible object map corruption.

Finally, added and updated a bunch of tests....

