### PR TITLE
added duplicate variable name in subcomponent matching the subcompone…

### DIFF
--- a/components/core-debug/omni.cc
+++ b/components/core-debug/omni.cc
@@ -55,6 +55,7 @@ void OMSimpleComponent::serialize_order(SST::Core::Serialization::serializer &se
     // Does this actually work with checkpointing?
     #if 1
     SST_SER(p_omsimplecomp_function0_);
+    SST_SER(function0);
     #endif
 
 }

--- a/components/core-debug/omni.h
+++ b/components/core-debug/omni.h
@@ -131,6 +131,7 @@ public:
 private:
   // Subcomponent pointers
   OMSubComponentAPI* p_omsimplecomp_function0_ = nullptr;
+  std::vector<uint8_t> function0 = { 10,20,30,40,50,60,70,80 };   // demonstrate name collision with slot name "function0"
 
   // SST Handlers
   SST::Output sstout_;


### PR DESCRIPTION
This provides an example of how a duplicate variable name can occur in a single level of hierarchy in an object map. In the case, the component has a slot name 'function0'. In the subcomponent, I can create a variable with the same name (of any type including the subcomponentAPI type).  When the component and subcomponent are both serialized we end up with to variables of the same name ( and can even be the same type! ).

To demonstrate this:
```
$ sst --interactive-start=0 omni.py -- --function0=dbgsst15.OMArrays
> cd c0
> ls
```
resulting in
```
component_state_ = 3 (SST::BaseComponent::ComponentState)
function0/ (SST::ExtTest::OMArrays)
function0/ (std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>)
my_info_/ ()
p_omsimplecomp_function0_/ (SST::ExtTest::OMArrays)
```

You can clearly see `function0` is listed twice.

The following sst-core PR provides the ability to navigate into either of these (following user prompting).
https://github.com/tactcomplabs/sst-core/pull/39

We will have to discuss solutions for this. My initial thought is to consider that the 'slot' name belongs with the component and the duplicate variable name belongs with the subcomponent. It feels like a layer of hierarchy should be inserted.