### PR TITLE
Add support for pagination 

### DIFF
--- a/tests/CaptCrunch/CaptCrunch_Interactive.sh
+++ b/tests/CaptCrunch/CaptCrunch_Interactive.sh
@@ -26,9 +26,11 @@ wait
 
 sst --interactive-start=0 --add-lib-path=$SST_COMPONENT_BASE/CaptCrunch/ $TEST_NAME.py <<EOF
 ls
+c
 confirm false
 cd c0
 ls
+c
 quit
 EOF
 


### PR DESCRIPTION
This  PR is dependent on  https://github.com/tactcomplabs/sst-core/pull/47  and should not be approved until that has been pushed into the sst-core repo. 

The `CaptCrunch_Interactive` test needs this slight tweak to work properly. The output of the `ls` command is longer than 50 lines (the current default) so the test must issue the `c` command to continue the output scrolling, otherwise, the test will time out