### PR TITLE
maintenance, sst-version fix, and audit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # sst-ext-tests top-level CMake
 #
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 # See LICENSE in the top level directory for licensing details

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,11 +58,7 @@ execute_process(COMMAND sst --version
 )
 message(STATUS "${SST_VERSION_STRING}")
 
-# Allow override using -DSST_VERSION=n
-if (DEFINED SST_VERSION)
-  message(STATUS "SST_VERSION test selection override: ${SST_VERSION}")
-endif()
-
+# SST Flags
 execute_process(COMMAND sst-config --CXX
                 OUTPUT_VARIABLE CXX
                 OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -79,19 +75,22 @@ execute_process(COMMAND sst-config SST_ELEMENT_LIBRARY SST_ELEMENT_LIBRARY_LIBDI
                 OUTPUT_VARIABLE SST_ELEMENT_LIBRARY_LIBDIR
                 OUTPUT_STRIP_TRAILING_WHITESPACE
 )
+
+# Underscore prefix convention indicates private scope.
+# Use the resolved SST_VERSION in other other cmake files
 execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/sst-major-version.sh ${SST_VERSION}
-                OUTPUT_VARIABLE SST_MAJOR_VERSION
+                OUTPUT_VARIABLE _SST_MAJOR_VERSION
                 OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/sst-minor-version.sh ${SST_VERSION}
-                OUTPUT_VARIABLE SST_MINOR_VERSION
+                OUTPUT_VARIABLE _SST_MINOR_VERSION
                 OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-string_contains_number("${SST_MAJOR_VERSION}" contains_num)
+string_contains_number("${_SST_MAJOR_VERSION}" contains_num)
 if(NOT contains_num)
-  set(SST_MAJOR_VERSION "DEV")
-  set(SST_MINOR_VERSION "DEV")
+  set(_SST_MAJOR_VERSION "DEV")
+  set(_SST_MINOR_VERSION "DEV")
   execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/sst-git-hash.sh
                   OUTPUT_VARIABLE SST_GIT_HASH
                   OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -100,14 +99,19 @@ if(NOT contains_num)
 endif()
 
 #-- Create version variables (will rewrite command line provided SST_VERSION)
-message(STATUS "SST MAJOR VERSION=${SST_MAJOR_VERSION}")
-message(STATUS "SST MINOR VERSION=${SST_MINOR_VERSION}")
-if ("${SST_MAJOR_VERSION}" STREQUAL "DEV")
+message(STATUS "SST MAJOR VERSION=${_SST_MAJOR_VERSION}")
+message(STATUS "SST MINOR VERSION=${_SST_MINOR_VERSION}")
+
+# Allow override using -DSST_VERSION=n
+# Important: subdirectories should only use this resolved version
+if (DEFINED SST_VERSION)
+  message(STATUS "SST_VERSION test selection override: ${SST_VERSION}")
+elseif ("${_SST_MAJOR_VERSION}" STREQUAL "DEV")
   set(SST_VERSION "DEV")
 else()
- string(CONCAT SST_VERSION  ${SST_MAJOR_VERSION} "." ${SST_MINOR_VERSION})
+ string(CONCAT SST_VERSION  ${_SST_MAJOR_VERSION} "." ${_SST_MINOR_VERSION})
 endif()
-message(STATUS "SST FULL VERSION=${SST_VERSION}")
+message(STATUS "RESOLVED SST VERSION=${SST_VERSION}")
 
 
 #-- MPI Options
@@ -199,7 +203,7 @@ set(EXT_TEST_MPIARGS_COMMAND "${CMAKE_SOURCE_DIR}/scripts/test-mpiargs.sh")
 set(SST_TMP_VER_LIST "13.0" "13.1" "14.0" "14.1" "15.0" "15.1")
 set(SST_VER_LIST "DEV")
 
-if(NOT "${SST_MAJOR_VERSION}" STREQUAL "DEV")
+if(NOT "${_SST_MAJOR_VERSION}" STREQUAL "DEV")
   foreach(VERSION ${SST_TMP_VER_LIST})
     if(NOT ${VERSION} VERSION_LESS ${SST_VERSION})
       list(APPEND SST_VER_LIST ${VERSION})

--- a/audit/260213/13.0.0.ctest
+++ b/audit/260213/13.0.0.ctest
@@ -1,0 +1,70 @@
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+      Start  1: sst_base
+      Start  2: sstconfig_help
+      Start  3: sstconfig_list_CXXFLAGS
+      Start  4: sstconfig_list
+      Start  5: sst_heartbeat_0.1.30
+      Start  6: sst_help-13.0
+      Start  7: sst_help
+      Start  8: sstinfo_help
+      Start  9: sstinfo_list_elem
+      Start 10: sstinfo_list_env
+      Start 11: sstinfo_list_nodisplay
+      Start 12: sstinfo_list_quiet
+      Start 13: sstinfo_list
+      Start 14: sstinfo_list_xml_file
+      Start 15: sstinfo_list_xml
+      Start 16: sstinfo_sst
+      Start 17: sst_numthreads
+      Start 18: sst_output_config
+      Start 19: sst_output_dot
+      Start 20: sst_output_dot_verbosity
+ 1/31 Test  #2: sstconfig_help ...................   Passed    0.23 sec
+      Start 21: sst_output_json
+ 2/31 Test  #3: sstconfig_list_CXXFLAGS ..........   Passed    0.23 sec
+      Start 22: sst_output_prefix
+ 3/31 Test  #4: sstconfig_list ...................   Passed    0.25 sec
+      Start 23: sst_print_timing_info
+ 4/31 Test  #8: sstinfo_help .....................   Passed    0.33 sec
+      Start 24: sstregister_a
+ 5/31 Test #16: sstinfo_sst ......................   Passed    0.37 sec
+      Start 25: sst_register_list
+ 6/31 Test #11: sstinfo_list_nodisplay ...........   Passed    0.50 sec
+      Start 26: sst_sdlfile
+ 7/31 Test #12: sstinfo_list_quiet ...............   Passed    0.52 sec
+      Start 27: sst_version
+ 8/31 Test #13: sstinfo_list .....................   Passed    0.52 sec
+      Start 28: testinfo
+ 9/31 Test #25: sst_register_list ................   Passed    0.15 sec
+      Start 29: testinfo
+10/31 Test #10: sstinfo_list_env .................   Passed    0.54 sec
+      Start 30: testinfo
+11/31 Test #14: sstinfo_list_xml_file ............   Passed    0.54 sec
+      Start 31: testinfo
+12/31 Test #15: sstinfo_list_xml .................   Passed    0.56 sec
+13/31 Test #24: sstregister_a ....................   Passed    0.46 sec
+14/31 Test #28: testinfo .........................   Passed    0.30 sec
+15/31 Test #29: testinfo .........................   Passed    0.29 sec
+16/31 Test #30: testinfo .........................   Passed    0.29 sec
+17/31 Test #31: testinfo .........................   Passed    0.30 sec
+18/31 Test  #5: sst_heartbeat_0.1.30 .............   Passed    1.68 sec
+19/31 Test #27: sst_version ......................   Passed    1.21 sec
+20/31 Test  #6: sst_help-13.0 ....................   Passed    2.75 sec
+21/31 Test  #7: sst_help .........................   Passed    2.77 sec
+22/31 Test  #9: sstinfo_list_elem ................   Passed    3.33 sec
+23/31 Test  #1: sst_base .........................   Passed    5.86 sec
+24/31 Test #19: sst_output_dot ...................   Passed    5.88 sec
+25/31 Test #23: sst_print_timing_info ............   Passed    5.66 sec
+26/31 Test #26: sst_sdlfile ......................   Passed    5.40 sec
+27/31 Test #18: sst_output_config ................   Passed    5.90 sec
+28/31 Test #21: sst_output_json ..................   Passed    5.70 sec
+29/31 Test #22: sst_output_prefix ................   Passed    5.71 sec
+30/31 Test #17: sst_numthreads ...................   Passed    7.15 sec
+31/31 Test #20: sst_output_dot_verbosity .........   Passed   48.24 sec
+
+100% tests passed, 0 tests failed out of 31
+
+Label Time Summary:
+13.0    = 113.63 sec*proc (31 tests)
+
+Total Test time (real) =  48.30 sec

--- a/audit/260213/13.1.0.ctest
+++ b/audit/260213/13.1.0.ctest
@@ -1,0 +1,70 @@
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+      Start  1: sst_base
+      Start  2: sstconfig_help
+      Start  3: sstconfig_list_CXXFLAGS
+      Start  4: sstconfig_list
+      Start  5: sst_heartbeat_0.1.30
+      Start  6: sst_help-13.1
+      Start  7: sst_help
+      Start  8: sstinfo_help
+      Start  9: sstinfo_list_elem
+      Start 10: sstinfo_list_env
+      Start 11: sstinfo_list_nodisplay
+      Start 12: sstinfo_list_quiet
+      Start 13: sstinfo_list
+      Start 14: sstinfo_list_xml_file
+      Start 15: sstinfo_list_xml
+      Start 16: sstinfo_sst
+      Start 17: sst_numthreads
+      Start 18: sst_output_config
+      Start 19: sst_output_dot
+      Start 20: sst_output_dot_verbosity
+ 1/31 Test  #2: sstconfig_help ...................   Passed    0.24 sec
+      Start 21: sst_output_json
+ 2/31 Test  #4: sstconfig_list ...................   Passed    0.25 sec
+      Start 22: sst_output_prefix
+ 3/31 Test  #3: sstconfig_list_CXXFLAGS ..........   Passed    0.26 sec
+      Start 23: sst_print_timing_info
+ 4/31 Test  #8: sstinfo_help .....................   Passed    0.34 sec
+      Start 24: sstregister_a
+ 5/31 Test #16: sstinfo_sst ......................   Passed    0.37 sec
+      Start 25: sst_register_list
+ 6/31 Test #12: sstinfo_list_quiet ...............   Passed    0.52 sec
+      Start 26: sst_sdlfile
+ 7/31 Test #25: sst_register_list ................   Passed    0.15 sec
+      Start 27: sst_version
+ 8/31 Test #11: sstinfo_list_nodisplay ...........   Passed    0.55 sec
+      Start 28: testinfo
+ 9/31 Test #14: sstinfo_list_xml_file ............   Passed    0.59 sec
+      Start 29: testinfo
+10/31 Test #10: sstinfo_list_env .................   Passed    0.60 sec
+      Start 30: testinfo
+11/31 Test #13: sstinfo_list .....................   Passed    0.60 sec
+      Start 31: testinfo
+12/31 Test #15: sstinfo_list_xml .................   Passed    0.61 sec
+13/31 Test #24: sstregister_a ....................   Passed    0.44 sec
+14/31 Test #28: testinfo .........................   Passed    0.28 sec
+15/31 Test #30: testinfo .........................   Passed    0.27 sec
+16/31 Test #29: testinfo .........................   Passed    0.28 sec
+17/31 Test #31: testinfo .........................   Passed    0.29 sec
+18/31 Test  #5: sst_heartbeat_0.1.30 .............   Passed    1.75 sec
+19/31 Test #27: sst_version ......................   Passed    1.27 sec
+20/31 Test  #6: sst_help-13.1 ....................   Passed    2.72 sec
+21/31 Test  #7: sst_help .........................   Passed    2.75 sec
+22/31 Test  #9: sstinfo_list_elem ................   Passed    3.29 sec
+23/31 Test #19: sst_output_dot ...................   Passed    5.91 sec
+24/31 Test  #1: sst_base .........................   Passed    5.96 sec
+25/31 Test #23: sst_print_timing_info ............   Passed    5.71 sec
+26/31 Test #18: sst_output_config ................   Passed    5.95 sec
+27/31 Test #22: sst_output_prefix ................   Passed    5.72 sec
+28/31 Test #26: sst_sdlfile ......................   Passed    5.44 sec
+29/31 Test #21: sst_output_json ..................   Passed    5.76 sec
+30/31 Test #17: sst_numthreads ...................   Passed    7.29 sec
+31/31 Test #20: sst_output_dot_verbosity .........   Passed   48.43 sec
+
+100% tests passed, 0 tests failed out of 31
+
+Label Time Summary:
+13.1    = 114.62 sec*proc (31 tests)
+
+Total Test time (real) =  48.48 sec

--- a/audit/260213/14.0.0.ctest
+++ b/audit/260213/14.0.0.ctest
@@ -1,0 +1,72 @@
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+      Start  1: sst_base
+      Start  2: sstconfig_help
+      Start  3: sstconfig_list_CXXFLAGS
+      Start  4: sstconfig_list
+      Start  5: sst_heartbeat_0.1.30
+      Start  6: sst_help-14.0
+      Start  7: sst_help-MIN14.0
+      Start  8: sst_help
+      Start  9: sstinfo_help
+      Start 10: sstinfo_list_elem
+      Start 11: sstinfo_list_env
+      Start 12: sstinfo_list_nodisplay
+      Start 13: sstinfo_list_quiet
+      Start 14: sstinfo_list
+      Start 15: sstinfo_list_xml_file
+      Start 16: sstinfo_list_xml
+      Start 17: sstinfo_sst
+      Start 18: sst_numthreads
+      Start 19: sst_output_config
+      Start 20: sst_output_dot
+ 1/32 Test  #3: sstconfig_list_CXXFLAGS ..........   Passed    0.23 sec
+      Start 21: sst_output_dot_verbosity
+ 2/32 Test  #2: sstconfig_help ...................   Passed    0.24 sec
+      Start 22: sst_output_json
+ 3/32 Test  #4: sstconfig_list ...................   Passed    0.25 sec
+      Start 23: sst_output_prefix
+ 4/32 Test  #9: sstinfo_help .....................   Passed    0.34 sec
+      Start 24: sst_print_timing_info
+ 5/32 Test #17: sstinfo_sst ......................   Passed    0.36 sec
+      Start 25: sstregister_a
+ 6/32 Test #12: sstinfo_list_nodisplay ...........   Passed    0.58 sec
+      Start 26: sst_register_list
+ 7/32 Test #13: sstinfo_list_quiet ...............   Passed    0.58 sec
+      Start 27: sst_sdlfile
+ 8/32 Test #14: sstinfo_list .....................   Passed    0.60 sec
+      Start 28: sst_version
+ 9/32 Test #16: sstinfo_list_xml .................   Passed    0.61 sec
+      Start 29: testinfo
+10/32 Test #11: sstinfo_list_env .................   Passed    0.63 sec
+      Start 30: testinfo
+11/32 Test #15: sstinfo_list_xml_file ............   Passed    0.66 sec
+      Start 31: testinfo
+12/32 Test #26: sst_register_list ................   Passed    0.14 sec
+      Start 32: testinfo
+13/32 Test #25: sstregister_a ....................   Passed    0.44 sec
+14/32 Test #30: testinfo .........................   Passed    0.30 sec
+15/32 Test #29: testinfo .........................   Passed    0.31 sec
+16/32 Test #32: testinfo .........................   Passed    0.26 sec
+17/32 Test #31: testinfo .........................   Passed    0.31 sec
+18/32 Test  #5: sst_heartbeat_0.1.30 .............   Passed    1.88 sec
+19/32 Test #28: sst_version ......................   Passed    1.33 sec
+20/32 Test  #7: sst_help-MIN14.0 .................   Passed    2.89 sec
+21/32 Test  #6: sst_help-14.0 ....................   Passed    2.89 sec
+22/32 Test  #8: sst_help .........................   Passed    2.90 sec
+23/32 Test #10: sstinfo_list_elem ................   Passed    3.92 sec
+24/32 Test #19: sst_output_config ................   Passed    6.02 sec
+25/32 Test #20: sst_output_dot ...................   Passed    6.07 sec
+26/32 Test  #1: sst_base .........................   Passed    6.15 sec
+27/32 Test #23: sst_output_prefix ................   Passed    5.91 sec
+28/32 Test #22: sst_output_json ..................   Passed    5.94 sec
+29/32 Test #24: sst_print_timing_info ............   Passed    5.83 sec
+30/32 Test #27: sst_sdlfile ......................   Passed    5.59 sec
+31/32 Test #18: sst_numthreads ...................   Passed    7.33 sec
+32/32 Test #21: sst_output_dot_verbosity .........   Passed   48.57 sec
+
+100% tests passed, 0 tests failed out of 32
+
+Label Time Summary:
+14.0    = 120.02 sec*proc (32 tests)
+
+Total Test time (real) =  48.83 sec

--- a/audit/260213/14.1.0.ctest
+++ b/audit/260213/14.1.0.ctest
@@ -1,0 +1,84 @@
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+      Start  1: sst_base
+      Start  2: sstconfig_help
+      Start  3: sstconfig_list_CXXFLAGS
+      Start  4: sstconfig_list
+      Start  5: sst_heartbeat_0.1.30
+      Start  6: sst_heartbeat_1s
+      Start  7: sst_help-14.1
+      Start  8: sst_help-MIN14.0
+      Start  9: sst_help
+      Start 10: sstinfo_help
+      Start 11: sstinfo_list_elem
+      Start 12: sstinfo_list_env
+      Start 13: sstinfo_list_nodisplay
+      Start 14: sstinfo_list_quiet
+      Start 15: sstinfo_list
+      Start 16: sstinfo_list_xml_file
+      Start 17: sstinfo_list_xml
+      Start 18: sstinfo_sst
+      Start 19: sst_numthreads
+      Start 20: sst_output_config
+ 1/38 Test  #2: sstconfig_help ...................   Passed    0.24 sec
+      Start 21: sst_output_dot
+ 2/38 Test  #4: sstconfig_list ...................   Passed    0.25 sec
+      Start 22: sst_output_dot_verbosity
+ 3/38 Test  #3: sstconfig_list_CXXFLAGS ..........   Passed    0.26 sec
+      Start 23: sst_output_json
+ 4/38 Test #10: sstinfo_help .....................   Passed    0.34 sec
+      Start 24: sst_output_prefix
+ 5/38 Test #18: sstinfo_sst ......................   Passed    0.35 sec
+      Start 25: sst_print_timing_info
+ 6/38 Test #13: sstinfo_list_nodisplay ...........   Passed    0.53 sec
+      Start 26: sstregister_a
+ 7/38 Test #14: sstinfo_list_quiet ...............   Passed    0.53 sec
+      Start 27: sst_register_list
+ 8/38 Test #15: sstinfo_list .....................   Passed    0.57 sec
+      Start 28: sst_sdlfile
+ 9/38 Test #12: sstinfo_list_env .................   Passed    0.60 sec
+      Start 29: sst_version
+10/38 Test #17: sstinfo_list_xml .................   Passed    0.61 sec
+      Start 30: testinfo
+11/38 Test #16: sstinfo_list_xml_file ............   Passed    0.62 sec
+      Start 31: restart-heartbeat-14.1
+12/38 Test #27: sst_register_list ................   Passed    0.12 sec
+      Start 32: restart-interactive-14.1
+13/38 Test #30: testinfo .........................   Passed    0.31 sec
+      Start 33: restart-sigalrm-14.1
+14/38 Test #26: sstregister_a ....................   Passed    0.42 sec
+      Start 34: sigalrm_ckpt_comb
+15/38 Test #29: sst_version ......................   Passed    1.24 sec
+      Start 35: sigalrm
+16/38 Test  #8: sst_help-MIN14.0 .................   Passed    2.67 sec
+      Start 36: testinfo
+17/38 Test  #9: sst_help .........................   Passed    2.69 sec
+      Start 37: testinfo
+18/38 Test  #7: sst_help-14.1 ....................   Passed    2.89 sec
+      Start 38: testinfo
+19/38 Test #36: testinfo .........................   Passed    0.26 sec
+20/38 Test #37: testinfo .........................   Passed    0.24 sec
+21/38 Test #38: testinfo .........................   Passed    0.26 sec
+22/38 Test #11: sstinfo_list_elem ................   Passed    3.73 sec
+23/38 Test #20: sst_output_config ................   Passed    5.86 sec
+24/38 Test #23: sst_output_json ..................   Passed    5.82 sec
+25/38 Test #21: sst_output_dot ...................   Passed    5.87 sec
+26/38 Test  #1: sst_base .........................   Passed    6.14 sec
+27/38 Test #24: sst_output_prefix ................   Passed    5.79 sec
+28/38 Test #28: sst_sdlfile ......................   Passed    5.58 sec
+29/38 Test #25: sst_print_timing_info ............   Passed    5.79 sec
+30/38 Test  #5: sst_heartbeat_0.1.30 .............   Passed    6.17 sec
+31/38 Test #19: sst_numthreads ...................   Passed    7.28 sec
+32/38 Test #31: restart-heartbeat-14.1 ...........   Passed    6.87 sec
+33/38 Test #32: restart-interactive-14.1 .........   Passed    7.58 sec
+34/38 Test  #6: sst_heartbeat_1s .................   Passed   14.17 sec
+35/38 Test #33: restart-sigalrm-14.1 .............   Passed   18.26 sec
+36/38 Test #34: sigalrm_ckpt_comb ................   Passed   19.17 sec
+37/38 Test #35: sigalrm ..........................   Passed   19.78 sec
+38/38 Test #22: sst_output_dot_verbosity .........   Passed   47.96 sec
+
+100% tests passed, 0 tests failed out of 38
+
+Label Time Summary:
+14.1    = 207.83 sec*proc (38 tests)
+
+Total Test time (real) =  48.24 sec

--- a/audit/260213/15.0.0.ctest
+++ b/audit/260213/15.0.0.ctest
@@ -1,0 +1,102 @@
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+      Start  1: sst_base
+      Start  2: sst_checkpoint_name_format
+      Start  3: sstconfig_help
+      Start  4: sstconfig_list_CXXFLAGS
+      Start  5: sstconfig_list
+      Start  6: sst_heartbeat_0.1.30
+      Start  7: sst_heartbeat_1s
+      Start  8: sst_heartbeat_90s
+      Start  9: sst_help-15.0
+      Start 10: sst_help-MIN14.0
+      Start 11: sst_help
+      Start 12: sstinfo_help
+      Start 13: sstinfo_list_elem
+      Start 14: sstinfo_list_env
+      Start 15: sstinfo_list_nodisplay
+      Start 16: sstinfo_list_quiet
+      Start 17: sstinfo_list
+      Start 18: sstinfo_list_xml_file
+      Start 19: sstinfo_list_xml
+      Start 20: sstinfo_sst
+ 1/47 Test  #3: sstconfig_help ...................   Passed    0.23 sec
+      Start 21: sst_numthreads
+ 2/47 Test  #5: sstconfig_list ...................   Passed    0.24 sec
+      Start 22: sst_output_config
+ 3/47 Test  #4: sstconfig_list_CXXFLAGS ..........   Passed    0.25 sec
+      Start 23: sst_output_dir_config
+ 4/47 Test #20: sstinfo_sst ......................   Passed    0.34 sec
+      Start 24: sst_output_dir_cpt
+ 5/47 Test #12: sstinfo_help .....................   Passed    0.36 sec
+      Start 25: sst_output_dir_json
+ 6/47 Test #16: sstinfo_list_quiet ...............   Passed    0.57 sec
+      Start 26: sst_output_dir
+ 7/47 Test #15: sstinfo_list_nodisplay ...........   Passed    0.58 sec
+      Start 27: sst_output_dir_stats
+ 8/47 Test #17: sstinfo_list .....................   Passed    0.58 sec
+      Start 28: sst_output_dot
+ 9/47 Test #14: sstinfo_list_env .................   Passed    0.60 sec
+      Start 29: sst_output_dot_verbosity
+10/47 Test #18: sstinfo_list_xml_file ............   Passed    0.62 sec
+      Start 30: sst_output_json
+11/47 Test #19: sstinfo_list_xml .................   Passed    0.63 sec
+      Start 31: sst_output_prefix
+12/47 Test #11: sst_help .........................   Passed    2.99 sec
+      Start 32: sst_print_timing_info
+13/47 Test  #9: sst_help-15.0 ....................   Passed    3.04 sec
+      Start 33: sstregister_a
+14/47 Test #10: sst_help-MIN14.0 .................   Passed    3.05 sec
+      Start 34: sst_register_list
+15/47 Test #34: sst_register_list ................   Passed    0.14 sec
+      Start 35: sst_sdlfile
+16/47 Test #33: sstregister_a ....................   Passed    0.35 sec
+      Start 36: sst_version
+17/47 Test #13: sstinfo_list_elem ................   Passed    4.04 sec
+      Start 37: testinfo
+18/47 Test #37: testinfo .........................   Passed    0.29 sec
+      Start 38: restart-ckpt-with-sigalrm-15.0
+19/47 Test #36: sst_version ......................   Passed    1.12 sec
+      Start 39: restart-heartbeat
+20/47 Test  #1: sst_base .........................   Passed    6.27 sec
+      Start 40: restart-interactive
+21/47 Test  #8: sst_heartbeat_90s ................   Passed    6.42 sec
+      Start 41: restart-sigalrm-15.0
+22/47 Test #22: sst_output_config ................   Passed    6.22 sec
+      Start 42: sigalrm_ckpt_comb
+23/47 Test #30: sst_output_json ..................   Passed    5.87 sec
+      Start 43: sigalrm
+24/47 Test #31: sst_output_prefix ................   Passed    5.87 sec
+      Start 44: sigusr_interactive-15.0
+25/47 Test  #6: sst_heartbeat_0.1.30 .............   Passed    6.52 sec
+      Start 45: testinfo
+26/47 Test #28: sst_output_dot ...................   Passed    5.95 sec
+      Start 46: testinfo
+27/47 Test #45: testinfo .........................   Passed    0.29 sec
+      Start 47: testinfo
+28/47 Test #46: testinfo .........................   Passed    0.30 sec
+29/47 Test #47: testinfo .........................   Passed    0.28 sec
+30/47 Test #21: sst_numthreads ...................   Passed    7.56 sec
+31/47 Test #32: sst_print_timing_info ............   Passed    5.65 sec
+32/47 Test #35: sst_sdlfile ......................   Passed    5.53 sec
+33/47 Test  #2: sst_checkpoint_name_format .......   Passed   12.24 sec
+34/47 Test #39: restart-heartbeat ................   Passed    8.44 sec
+35/47 Test  #7: sst_heartbeat_1s .................   Passed   15.08 sec
+36/47 Test #40: restart-interactive ..............   Passed    8.82 sec
+37/47 Test #44: sigusr_interactive-15.0 ..........   Passed    8.63 sec
+38/47 Test #23: sst_output_dir_config ............   Passed   22.47 sec
+39/47 Test #27: sst_output_dir_stats .............   Passed   22.22 sec
+40/47 Test #25: sst_output_dir_json ..............   Passed   22.55 sec
+41/47 Test #26: sst_output_dir ...................   Passed   22.37 sec
+42/47 Test #24: sst_output_dir_cpt ...............   Passed   22.66 sec
+43/47 Test #38: restart-ckpt-with-sigalrm-15.0 ...   Passed   20.63 sec
+44/47 Test #41: restart-sigalrm-15.0 .............   Passed   19.02 sec
+45/47 Test #42: sigalrm_ckpt_comb ................   Passed   19.75 sec
+46/47 Test #43: sigalrm ..........................   Passed   20.94 sec
+47/47 Test #29: sst_output_dot_verbosity .........   Passed   48.79 sec
+
+100% tests passed, 0 tests failed out of 47
+
+Label Time Summary:
+15.0    = 377.37 sec*proc (47 tests)
+
+Total Test time (real) =  49.43 sec

--- a/audit/260213/15.1.0.ctest
+++ b/audit/260213/15.1.0.ctest
@@ -1,0 +1,140 @@
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+      Start  1: sst_base
+      Start  2: sst_checkpoint_name_format
+      Start  3: sstconfig_help
+      Start  4: sstconfig_list_CXXFLAGS
+      Start  5: sstconfig_list
+      Start  6: sst_heartbeat_0.1.30
+      Start  7: sst_heartbeat_1s
+      Start  8: sst_heartbeat_90s
+      Start  9: sst-help-15.1
+      Start 10: sst_help-MIN14.0
+      Start 11: sst_help
+      Start 12: sstinfo_help
+      Start 13: sstinfo_list_elem
+      Start 14: sstinfo_list_env
+      Start 15: sstinfo_list_nodisplay
+      Start 16: sstinfo_list_quiet
+      Start 17: sstinfo_list
+      Start 18: sstinfo_list_xml_file
+      Start 19: sstinfo_list_xml
+      Start 20: sstinfo_sst
+ 1/66 Test  #3: sstconfig_help ...................   Passed    0.21 sec
+      Start 21: sst_numthreads
+ 2/66 Test  #4: sstconfig_list_CXXFLAGS ..........   Passed    0.23 sec
+      Start 22: sst_output_config
+ 3/66 Test  #5: sstconfig_list ...................   Passed    0.24 sec
+      Start 23: sst_output_dir_config
+ 4/66 Test #12: sstinfo_help .....................   Passed    0.36 sec
+      Start 24: sst_output_dir_cpt
+ 5/66 Test #20: sstinfo_sst ......................   Passed    0.36 sec
+      Start 25: sst_output_dir_json
+ 6/66 Test #17: sstinfo_list .....................   Passed    0.61 sec
+      Start 26: sst_output_dir
+ 7/66 Test #16: sstinfo_list_quiet ...............   Passed    0.61 sec
+      Start 27: sst_output_dir_stats
+ 8/66 Test #15: sstinfo_list_nodisplay ...........   Passed    0.62 sec
+      Start 28: sst_output_dot
+ 9/66 Test #19: sstinfo_list_xml .................   Passed    0.63 sec
+      Start 29: sst_output_dot_verbosity
+10/66 Test #14: sstinfo_list_env .................   Passed    0.65 sec
+      Start 30: sst_output_json
+11/66 Test #18: sstinfo_list_xml_file ............   Passed    0.66 sec
+      Start 31: sst_output_prefix
+12/66 Test #10: sst_help-MIN14.0 .................   Passed    2.70 sec
+      Start 32: sst_print_timing_info
+13/66 Test #11: sst_help .........................   Passed    2.79 sec
+      Start 33: sstregister_a
+14/66 Test  #9: sst-help-15.1 ....................   Passed    2.86 sec
+      Start 34: sst_register_list
+15/66 Test #34: sst_register_list ................   Passed    0.14 sec
+      Start 35: sst_sdlfile
+16/66 Test #33: sstregister_a ....................   Passed    0.32 sec
+      Start 36: sst_version
+17/66 Test #13: sstinfo_list_elem ................   Passed    4.10 sec
+      Start 37: testinfo
+18/66 Test #36: sst_version ......................   Passed    1.17 sec
+      Start 38: restart-ckpt-with-heartbeat
+19/66 Test #37: testinfo .........................   Passed    0.27 sec
+      Start 39: restart-ckpt-with-interactive
+20/66 Test  #8: sst_heartbeat_90s ................   Passed    6.05 sec
+      Start 40: restart-heartbeat
+21/66 Test #22: sst_output_config ................   Passed    5.98 sec
+      Start 41: restart-interactive
+22/66 Test  #1: sst_base .........................   Passed    6.23 sec
+      Start 42: sigalrm_combined
+23/66 Test  #6: sst_heartbeat_0.1.30 .............   Passed    6.23 sec
+      Start 43: sigusr-interactive2
+24/66 Test #30: sst_output_json ..................   Passed    5.69 sec
+      Start 44: sigusr-interactive-ckpt
+25/66 Test #28: sst_output_dot ...................   Passed    5.80 sec
+      Start 45: sigusr-interactive
+26/66 Test #31: sst_output_prefix ................   Passed    5.76 sec
+      Start 46: testinfo
+27/66 Test #46: testinfo .........................   Passed    0.26 sec
+      Start 47: CaptCrunch_Interactive
+28/66 Test #21: sst_numthreads ...................   Passed    7.45 sec
+      Start 48: CaptCrunch_Simple1
+29/66 Test #47: CaptCrunch_Interactive ...........   Passed    1.36 sec
+      Start 49: testinfo
+30/66 Test #32: sst_print_timing_info ............   Passed    5.58 sec
+      Start 50: cmd-basic
+31/66 Test #49: testinfo .........................   Passed    0.27 sec
+      Start 51: cmd-ckptaction-err
+32/66 Test #35: sst_sdlfile ......................   Passed    5.62 sec
+      Start 52: cmd-cmp-types-false
+33/66 Test #51: cmd-ckptaction-err ...............   Passed    1.28 sec
+      Start 53: cmd-comments-short
+34/66 Test #50: cmd-basic ........................   Passed    1.42 sec
+      Start 54: cmd-comments-ws
+35/66 Test #53: cmd-comments-short ...............   Passed    1.30 sec
+      Start 55: cmd-cond
+36/66 Test #54: cmd-comments-ws ..................   Passed    1.36 sec
+      Start 56: cmd-default-ic
+37/66 Test #52: cmd-cmp-types-false ..............   Passed    2.71 sec
+      Start 57: cmd-history
+38/66 Test  #2: sst_checkpoint_name_format .......   Passed   11.80 sec
+      Start 58: cmd-logging
+39/66 Test #55: cmd-cond .........................   Passed    1.34 sec
+      Start 59: cmd-replay2
+40/66 Test #39: restart-ckpt-with-interactive ....   Passed    7.98 sec
+      Start 60: cmd-replay3
+41/66 Test #56: cmd-default-ic ...................   Passed    1.29 sec
+      Start 61: cmd-replay
+42/66 Test #57: cmd-history ......................   Passed    1.47 sec
+      Start 62: cmd-replay-sync
+43/66 Test #38: restart-ckpt-with-heartbeat ......   Passed    8.75 sec
+      Start 63: cmd-sanity
+44/66 Test #58: cmd-logging ......................   Passed    1.52 sec
+      Start 64: cmd-set
+45/66 Test #62: cmd-replay-sync ..................   Passed    1.26 sec
+      Start 65: cmd-setstr
+46/66 Test #63: cmd-sanity .......................   Passed    1.23 sec
+      Start 66: testinfo
+47/66 Test #66: testinfo .........................   Passed    0.24 sec
+48/66 Test #40: restart-heartbeat ................   Passed    8.64 sec
+49/66 Test #64: cmd-set ..........................   Passed    1.61 sec
+50/66 Test  #7: sst_heartbeat_1s .................   Passed   14.92 sec
+51/66 Test #41: restart-interactive ..............   Passed    8.80 sec
+52/66 Test #44: sigusr-interactive-ckpt ..........   Passed    8.87 sec
+53/66 Test #65: cmd-setstr .......................   Passed    1.27 sec
+54/66 Test #45: sigusr-interactive ...............   Passed    9.06 sec
+55/66 Test #43: sigusr-interactive2 ..............   Passed    9.28 sec
+56/66 Test #59: cmd-replay2 ......................   Passed    3.75 sec
+57/66 Test #60: cmd-replay3 ......................   Passed    3.78 sec
+58/66 Test #61: cmd-replay .......................   Passed    3.89 sec
+59/66 Test #26: sst_output_dir ...................   Passed   21.83 sec
+60/66 Test #23: sst_output_dir_config ............   Passed   22.23 sec
+61/66 Test #25: sst_output_dir_json ..............   Passed   22.11 sec
+62/66 Test #24: sst_output_dir_cpt ...............   Passed   22.16 sec
+63/66 Test #27: sst_output_dir_stats .............   Passed   22.04 sec
+64/66 Test #48: CaptCrunch_Simple1 ...............   Passed   18.52 sec
+65/66 Test #29: sst_output_dot_verbosity .........   Passed   47.47 sec
+66/66 Test #42: sigalrm_combined .................   Passed   54.57 sec
+
+100% tests passed, 0 tests failed out of 66
+
+Label Time Summary:
+15.1    = 431.55 sec*proc (66 tests)
+
+Total Test time (real) =  60.82 sec

--- a/audit/260213/info.audit
+++ b/audit/260213/info.audit
@@ -1,0 +1,25 @@
+Fri Feb 13 11:30:48 CST 2026
+gizmo.dev.tactcomplabs.com
+Linux gizmo.dev.tactcomplabs.com 4.18.0-477.10.1.el8_8.x86_64 #1 SMP Tue May 16 11:38:37 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
+On branch maintain
+Your branch is up to date with 'origin/maintain'.
+
+Changes not staged for commit:
+  (use "git add/rm <file>..." to update what will be committed)
+  (use "git restore <file>..." to discard changes in working directory)
+	modified:   ../251222/13.0.0.ctest
+	modified:   ../251222/13.1.0.ctest
+	modified:   ../251222/14.0.0.ctest
+	modified:   ../251222/14.1.0.ctest
+	modified:   ../251222/15.0.0.ctest
+	modified:   ../251222/15.1.0.ctest
+	modified:   ../251222/info.audit
+	deleted:    ../251222/log
+	modified:   ../251222/tests.info
+
+Untracked files:
+  (use "git add <file>..." to include in what will be committed)
+	./
+
+no changes added to commit (use "git add" and/or "git commit -a")
+1d2c773 fixed SST_VERSION override bug

--- a/audit/260213/testlist.audit
+++ b/audit/260213/testlist.audit
@@ -1,0 +1,364 @@
+/scratch/kgriesser/work/sst-ext-tests/build
+
+### Checking test selection for sst version 13.0 ###
+
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+  Test  #1: sst_base
+  Test  #2: sstconfig_help
+  Test  #3: sstconfig_list_CXXFLAGS
+  Test  #4: sstconfig_list
+  Test  #5: sst_heartbeat_0.1.30
+  Test  #6: sst_help-13.0
+  Test  #7: sst_help
+  Test  #8: sstinfo_help
+  Test  #9: sstinfo_list_elem
+  Test #10: sstinfo_list_env
+  Test #11: sstinfo_list_nodisplay
+  Test #12: sstinfo_list_quiet
+  Test #13: sstinfo_list
+  Test #14: sstinfo_list_xml_file
+  Test #15: sstinfo_list_xml
+  Test #16: sstinfo_sst
+  Test #17: sst_numthreads
+  Test #18: sst_output_config
+  Test #19: sst_output_dot
+  Test #20: sst_output_dot_verbosity
+  Test #21: sst_output_json
+  Test #22: sst_output_prefix
+  Test #23: sst_print_timing_info
+  Test #24: sstregister_a
+  Test #25: sst_register_list
+  Test #26: sst_sdlfile
+  Test #27: sst_version
+  Test #28: testinfo
+  Test #29: testinfo
+  Test #30: testinfo
+  Test #31: testinfo
+
+Total Tests: 31
+
+### Checking test selection for sst version 13.1 ###
+
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+  Test  #1: sst_base
+  Test  #2: sstconfig_help
+  Test  #3: sstconfig_list_CXXFLAGS
+  Test  #4: sstconfig_list
+  Test  #5: sst_heartbeat_0.1.30
+  Test  #6: sst_help-13.1
+  Test  #7: sst_help
+  Test  #8: sstinfo_help
+  Test  #9: sstinfo_list_elem
+  Test #10: sstinfo_list_env
+  Test #11: sstinfo_list_nodisplay
+  Test #12: sstinfo_list_quiet
+  Test #13: sstinfo_list
+  Test #14: sstinfo_list_xml_file
+  Test #15: sstinfo_list_xml
+  Test #16: sstinfo_sst
+  Test #17: sst_numthreads
+  Test #18: sst_output_config
+  Test #19: sst_output_dot
+  Test #20: sst_output_dot_verbosity
+  Test #21: sst_output_json
+  Test #22: sst_output_prefix
+  Test #23: sst_print_timing_info
+  Test #24: sstregister_a
+  Test #25: sst_register_list
+  Test #26: sst_sdlfile
+  Test #27: sst_version
+  Test #28: testinfo
+  Test #29: testinfo
+  Test #30: testinfo
+  Test #31: testinfo
+
+Total Tests: 31
+
+### Checking test selection for sst version 14.0 ###
+
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+  Test  #1: sst_base
+  Test  #2: sstconfig_help
+  Test  #3: sstconfig_list_CXXFLAGS
+  Test  #4: sstconfig_list
+  Test  #5: sst_heartbeat_0.1.30
+  Test  #6: sst_help-14.0
+  Test  #7: sst_help-MIN14.0
+  Test  #8: sst_help
+  Test  #9: sstinfo_help
+  Test #10: sstinfo_list_elem
+  Test #11: sstinfo_list_env
+  Test #12: sstinfo_list_nodisplay
+  Test #13: sstinfo_list_quiet
+  Test #14: sstinfo_list
+  Test #15: sstinfo_list_xml_file
+  Test #16: sstinfo_list_xml
+  Test #17: sstinfo_sst
+  Test #18: sst_numthreads
+  Test #19: sst_output_config
+  Test #20: sst_output_dot
+  Test #21: sst_output_dot_verbosity
+  Test #22: sst_output_json
+  Test #23: sst_output_prefix
+  Test #24: sst_print_timing_info
+  Test #25: sstregister_a
+  Test #26: sst_register_list
+  Test #27: sst_sdlfile
+  Test #28: sst_version
+  Test #29: testinfo
+  Test #30: testinfo
+  Test #31: testinfo
+  Test #32: testinfo
+
+Total Tests: 32
+
+### Checking test selection for sst version 14.1 ###
+
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+  Test  #1: sst_base
+  Test  #2: sstconfig_help
+  Test  #3: sstconfig_list_CXXFLAGS
+  Test  #4: sstconfig_list
+  Test  #5: sst_heartbeat_0.1.30
+  Test  #6: sst_heartbeat_1s
+  Test  #7: sst_help-14.1
+  Test  #8: sst_help-MIN14.0
+  Test  #9: sst_help
+  Test #10: sstinfo_help
+  Test #11: sstinfo_list_elem
+  Test #12: sstinfo_list_env
+  Test #13: sstinfo_list_nodisplay
+  Test #14: sstinfo_list_quiet
+  Test #15: sstinfo_list
+  Test #16: sstinfo_list_xml_file
+  Test #17: sstinfo_list_xml
+  Test #18: sstinfo_sst
+  Test #19: sst_numthreads
+  Test #20: sst_output_config
+  Test #21: sst_output_dot
+  Test #22: sst_output_dot_verbosity
+  Test #23: sst_output_json
+  Test #24: sst_output_prefix
+  Test #25: sst_print_timing_info
+  Test #26: sstregister_a
+  Test #27: sst_register_list
+  Test #28: sst_sdlfile
+  Test #29: sst_version
+  Test #30: testinfo
+  Test #31: restart-heartbeat-14.1
+  Test #32: restart-interactive-14.1
+  Test #33: restart-sigalrm-14.1
+  Test #34: sigalrm_ckpt_comb
+  Test #35: sigalrm
+  Test #36: testinfo
+  Test #37: testinfo
+  Test #38: testinfo
+
+Total Tests: 38
+
+### Checking test selection for sst version 15.0 ###
+
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+  Test  #1: sst_base
+  Test  #2: sst_checkpoint_name_format
+  Test  #3: sstconfig_help
+  Test  #4: sstconfig_list_CXXFLAGS
+  Test  #5: sstconfig_list
+  Test  #6: sst_heartbeat_0.1.30
+  Test  #7: sst_heartbeat_1s
+  Test  #8: sst_heartbeat_90s
+  Test  #9: sst_help-15.0
+  Test #10: sst_help-MIN14.0
+  Test #11: sst_help
+  Test #12: sstinfo_help
+  Test #13: sstinfo_list_elem
+  Test #14: sstinfo_list_env
+  Test #15: sstinfo_list_nodisplay
+  Test #16: sstinfo_list_quiet
+  Test #17: sstinfo_list
+  Test #18: sstinfo_list_xml_file
+  Test #19: sstinfo_list_xml
+  Test #20: sstinfo_sst
+  Test #21: sst_numthreads
+  Test #22: sst_output_config
+  Test #23: sst_output_dir_config
+  Test #24: sst_output_dir_cpt
+  Test #25: sst_output_dir_json
+  Test #26: sst_output_dir
+  Test #27: sst_output_dir_stats
+  Test #28: sst_output_dot
+  Test #29: sst_output_dot_verbosity
+  Test #30: sst_output_json
+  Test #31: sst_output_prefix
+  Test #32: sst_print_timing_info
+  Test #33: sstregister_a
+  Test #34: sst_register_list
+  Test #35: sst_sdlfile
+  Test #36: sst_version
+  Test #37: testinfo
+  Test #38: restart-ckpt-with-sigalrm-15.0
+  Test #39: restart-heartbeat
+  Test #40: restart-interactive
+  Test #41: restart-sigalrm-15.0
+  Test #42: sigalrm_ckpt_comb
+  Test #43: sigalrm
+  Test #44: sigusr_interactive-15.0
+  Test #45: testinfo
+  Test #46: testinfo
+  Test #47: testinfo
+
+Total Tests: 47
+
+### Checking test selection for sst version 15.1 ###
+
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+  Test  #1: sst_base
+  Test  #2: sst_checkpoint_name_format
+  Test  #3: sstconfig_help
+  Test  #4: sstconfig_list_CXXFLAGS
+  Test  #5: sstconfig_list
+  Test  #6: sst_heartbeat_0.1.30
+  Test  #7: sst_heartbeat_1s
+  Test  #8: sst_heartbeat_90s
+  Test  #9: sst-help-15.1
+  Test #10: sst_help-MIN14.0
+  Test #11: sst_help
+  Test #12: sstinfo_help
+  Test #13: sstinfo_list_elem
+  Test #14: sstinfo_list_env
+  Test #15: sstinfo_list_nodisplay
+  Test #16: sstinfo_list_quiet
+  Test #17: sstinfo_list
+  Test #18: sstinfo_list_xml_file
+  Test #19: sstinfo_list_xml
+  Test #20: sstinfo_sst
+  Test #21: sst_numthreads
+  Test #22: sst_output_config
+  Test #23: sst_output_dir_config
+  Test #24: sst_output_dir_cpt
+  Test #25: sst_output_dir_json
+  Test #26: sst_output_dir
+  Test #27: sst_output_dir_stats
+  Test #28: sst_output_dot
+  Test #29: sst_output_dot_verbosity
+  Test #30: sst_output_json
+  Test #31: sst_output_prefix
+  Test #32: sst_print_timing_info
+  Test #33: sstregister_a
+  Test #34: sst_register_list
+  Test #35: sst_sdlfile
+  Test #36: sst_version
+  Test #37: testinfo
+  Test #38: restart-ckpt-with-heartbeat
+  Test #39: restart-ckpt-with-interactive
+  Test #40: restart-heartbeat
+  Test #41: restart-interactive
+  Test #42: sigalrm_combined
+  Test #43: sigusr-interactive2
+  Test #44: sigusr-interactive-ckpt
+  Test #45: sigusr-interactive
+  Test #46: testinfo
+  Test #47: CaptCrunch_Interactive
+  Test #48: CaptCrunch_Simple1
+  Test #49: testinfo
+  Test #50: cmd-basic
+  Test #51: cmd-ckptaction-err
+  Test #52: cmd-cmp-types-false
+  Test #53: cmd-comments-short
+  Test #54: cmd-comments-ws
+  Test #55: cmd-cond
+  Test #56: cmd-default-ic
+  Test #57: cmd-history
+  Test #58: cmd-logging
+  Test #59: cmd-replay2
+  Test #60: cmd-replay3
+  Test #61: cmd-replay
+  Test #62: cmd-replay-sync
+  Test #63: cmd-sanity
+  Test #64: cmd-set
+  Test #65: cmd-setstr
+  Test #66: testinfo
+
+Total Tests: 66
+
+### Checking test selection for sst version DEV ###
+
+Test project /scratch/kgriesser/work/sst-ext-tests/build
+  Test  #1: sst_base
+  Test  #2: sst_checkpoint_name_format
+  Test  #3: sstconfig_help
+  Test  #4: sstconfig_list_CXXFLAGS
+  Test  #5: sstconfig_list
+  Test  #6: sst_heartbeat_0.1.30
+  Test  #7: sst_heartbeat_1s
+  Test  #8: sst_heartbeat_90s
+  Test  #9: sst_help-MIN14.0
+  Test #10: sst_help
+  Test #11: sstinfo_help
+  Test #12: sstinfo_list_elem
+  Test #13: sstinfo_list_env
+  Test #14: sstinfo_list_nodisplay
+  Test #15: sstinfo_list_quiet
+  Test #16: sstinfo_list
+  Test #17: sstinfo_list_xml_file
+  Test #18: sstinfo_list_xml
+  Test #19: sstinfo_sst
+  Test #20: sst_numthreads
+  Test #21: sst_output_config
+  Test #22: sst_output_dir_config
+  Test #23: sst_output_dir_cpt
+  Test #24: sst_output_dir_json
+  Test #25: sst_output_dir
+  Test #26: sst_output_dir_stats
+  Test #27: sst_output_dot
+  Test #28: sst_output_dot_verbosity
+  Test #29: sst_output_json
+  Test #30: sst_output_prefix
+  Test #31: sst_print_timing_info
+  Test #32: sstregister_a
+  Test #33: sst_register_list
+  Test #34: sst_sdlfile
+  Test #35: sst_version
+  Test #36: testinfo
+  Test #37: restart-ckpt-with-heartbeat
+  Test #38: restart-ckpt-with-interactive
+  Test #39: restart-heartbeat
+  Test #40: restart-interactive
+  Test #41: sigalrm_combined
+  Test #42: sigusr-interactive2
+  Test #43: sigusr-interactive-ckpt
+  Test #44: sigusr-interactive
+  Test #45: testinfo
+  Test #46: CaptCrunch_Interactive
+  Test #47: CaptCrunch_Simple1
+  Test #48: testinfo
+  Test #49: cmd-basic
+  Test #50: cmd-ckptaction-err
+  Test #51: cmd-cmp-types-false
+  Test #52: cmd-comments-short
+  Test #53: cmd-comments-ws
+  Test #54: cmd-cond
+  Test #55: cmd-default-ic
+  Test #56: cmd-history
+  Test #57: cmd-logging
+  Test #58: cmd-replay2
+  Test #59: cmd-replay3
+  Test #60: cmd-replay
+  Test #61: cmd-replay-sync
+  Test #62: cmd-sanity
+  Test #63: cmd-set
+  Test #64: cmd-setstr
+  Test #65: testinfo
+  Test #66: type-aggregate
+  Test #67: type-arrays
+  Test #68: type-f0array-f1queue
+  Test #69: type-nested-containers
+  Test #70: type-pair
+  Test #71: type-priority-queue
+  Test #72: type-queue-1
+  Test #73: type-queue
+  Test #74: type-stack
+  Test #75: type-tuple
+  Test #76: type-union
+
+Total Tests: 76

--- a/audit/260213/tests.info
+++ b/audit/260213/tests.info
@@ -1,0 +1,160 @@
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| Test                                          | MinVer | MaxVer | Desc                                                                                                           |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| sst-help-15.1                                 | 15.1   | 15.1   | Displays the help menu of SST 15.1                                                                             |
+| sst_base                                      | 13.0   | None   | Basic execution test suitable for all versions of SST                                                          |
+| sst_checkpoint_name_format                    | 15.0   | None   | Tests custom naming of checkpoint directories and files                                                        |
+| sst_heartbeat_0.1.30                          | 13.0   | None   | Tests a 90 second heartbeat using %H:%M:%S syntax                                                              |
+| sst_heartbeat_90s                             | 15.0   | None   | Tests a 90 second heartbeat using seconds-only syntax                                                          |
+| sst_help-13.0                                 | 13.0   | 13.0   | Displays help menu for SST 13.0                                                                                |
+| sst_help-13.1                                 | 13.1   | 13.1   | Displays the help menu of SST 13.1                                                                             |
+| sst_help-14.0                                 | 14.0   | 14.0   | Displays the help menu of the SST 14.0                                                                         |
+| sst_help-14.1                                 | 14.1   | 14.1   | Displays the help menu of SST 14.1                                                                             |
+| sst_help-15.0                                 | 15.0   | 15.0   | Displays the help menu of SST 15.0                                                                             |
+| sst_help-MIN14.0                              | 14.0   | None   | Displays the help menu for SST versions of minimum of SST 14.0                                                 |
+| sst_help                                      | 13.0   | None   | Displays the help menu for all versions of SST                                                                 |
+| sst_numthreads                                | 13.0   | None   | Tests the num_threads option for executing a basic SDL file                                                    |
+| sst_output_config                             | 13.0   | None   | Tests outputting the config file back to a python script                                                       |
+| sst_output_dir                                | 15.0   | None   | Tests basic directory creation using --output-directory                                                        |
+| sst_output_dir_config                         | 15.0   | None   | Tests relocation of config files                                                                               |
+| sst_output_dir_cpt                            | 15.0   | None   | Tests relocation of checkpoint files                                                                           |
+| sst_output_dir_json                           | 15.0   | None   | Tests relocation of JSON config files                                                                          |
+| sst_output_dir_stats                          | 15.0   | None   | Tests statistics output file creation using --output-directory                                                 |
+| sst_output_dot                                | 13.0   | None   | Tests outputting the config graph as a dot file                                                                |
+| sst_output_dot_verbosity                      | 13.0   | None   | Tests outputting config graph graph data to a dot file with verbosity                                          |
+| sst_output_json                               | 13.0   | None   | Tests outptting the config graph to JSON                                                                       |
+| sst_output_prefix                             | 13.0   | None   | Tests outputting files with a prefix                                                                           |
+| sst_print_timing_info                         | 13.0   | None   | Tests printing the runtime timing info                                                                         |
+| sst_register_list                             | 13.0   | None   | Tests listing the registered sst component libraries                                                           |
+| sst_sdlfile                                   | 13.0   | None   | Tests the SDL file runtime option                                                                              |
+| sst_version                                   | 13.0   | None   | Tests printing the SST version info                                                                            |
+| sstconfig_help                                | 13.0   | None   | Tests printing the sst-config help menu                                                                        |
+| sstconfig_list                                | 13.0   | None   | Tests the baseline sst-config                                                                                  |
+| sstconfig_list_CXXFLAGS                       | 13.0   | None   | Tests printing the CXXFLAGS sst-config option                                                                  |
+| sstinfo_help                                  | 13.0   | None   | Tests the sst-info help menu                                                                                   |
+| sstinfo_list                                  | 13.0   | None   | Tests the output of the basic sst-info command                                                                 |
+| sstinfo_list_elem                             | 13.0   | None   | Tests printing sst-info for all the appropriate ELEMENT LIBRARY values                                         |
+| sstinfo_list_env                              | 13.0   | None   | Tests the sst-info print-env command option                                                                    |
+| sstinfo_list_nodisplay                        | 13.0   | None   | Tests the sst-info no info option                                                                              |
+| sstinfo_list_quiet                            | 13.0   | None   | Tests the sst-info quiet option                                                                                |
+| sstinfo_list_xml                              | 13.0   | None   | Tests the sst-info xml output                                                                                  |
+| sstinfo_list_xml_file                         | 13.0   | None   | Tests the sst-info XML output with a specified file                                                            |
+| sstinfo_sst                                   | 13.0   | None   | Tests the output of the basic sst-info sst command                                                             |
+| sstregister_a                                 | 13.0   | None   | Tests the known failure of the sst-register -a option                                                          |
+| testinfo                                      | None   | None   | Provide information on local tests                                                                             |
+| sst_heartbeat_1s                              | 14.1   | None   | Tests a 1 second heartbeat                                                                                     |
+| test_Checkpoint-DEV                           | None   | None   | Tests checkpointing                                                                                            |
+| test_Component-DEV                            | None   | None   | Tests component loading with checkpointing                                                                     |
+| test_Component_createStats-DEV                | None   | None   | Tests statistics with checkpointing                                                                            |
+| test_Component_enableAllStats-DEV             | None   | None   | Tests enabling all stats with checkpointing                                                                    |
+| test_Component_setStats-DEV                   | None   | None   | Tests setting stats with checkpointing                                                                         |
+| test_Component_time_overflow-DEV              | None   | None   | Tests time overflow with checkpointing                                                                         |
+| test_Links-DEV                                | None   | None   | Tests link handlers with checkpointing                                                                         |
+| test_MemPool_overflow-DEV                     | None   | None   | Tests mempooling overflowo with checkpointing                                                                  |
+| test_MemPool_undeleted_items-DEV              | None   | None   | Tests mempooling undeleted items with checkpointing                                                            |
+| test_MessageMesh-DEV                          | None   | None   | Tests message mesh routing with checkpointing                                                                  |
+| test_Module-DEV                               | None   | None   | Tests the module loader with checkpointing                                                                     |
+| test_Output-DEV                               | None   | None   | Tests the outputter with checkpointing                                                                         |
+| test_ParallelLoad-DEV                         | None   | None   | Tests parallel loading with checkpointing                                                                      |
+| test_ParamComponent-DEV                       | None   | None   | Tests component parameter loading with checkpointing                                                           |
+| test_PerfComponent-DEV                        | None   | None   | Tests perf component with checkpointing                                                                        |
+| test_PythonUnitAlgebra-DEV                    | None   | None   | Tests Python unit algebra with checkpointing                                                                   |
+| test_RNGComponent_marsaglia-DEV               | None   | None   | Tests the RNG marsaglia with checkpointing                                                                     |
+| test_RNGComponent_mersenne-DEV                | None   | None   | Tests the RNG mersenne with checkpointing                                                                      |
+| test_RNGComponent_xorshift-DEV                | None   | None   | Tests RNG xorshift with checkpointing                                                                          |
+| test_Serialization_ATOMIC-DEV                 | None   | None   | Tests the basic serialization with ATOMIC types and checkpointing                                              |
+| test_Serialization_COMPONENTINFO-DEV          | None   | None   | Tests the basic serialization with COMPONENT INFO types and checkpointing                                      |
+| test_Serialization_HANDLER-DEV                | None   | None   | Tests the basic serialization with HANDLER types and checkpointing                                             |
+| test_Serialization_MAPTOVECTOR-DEV            | None   | None   | Tests the basic serialization with MAP TO VECTOR types and checkpointing                                       |
+| test_Serialization_ORDERED_CONTAINERS-DEV     | None   | None   | Tests the basic serialization with ORDERED CONTAINERS types and checkpointing                                  |
+| test_Serialization_POD-DEV                    | None   | None   | Tests the basic serialization with POD types and checkpointing                                                 |
+| test_Serialization_PODPTR-DEV                 | None   | None   | Tests the basic serialization with PODPTR types and checkpointing                                              |
+| test_Serialization_POINTERTRACKING-DEV        | None   | None   | Tests the basic serialization with POINTER TRACKING types and checkpointing                                    |
+| test_Serialization_UNORDERED_CONTAINERS-DEV   | None   | None   | Tests the basic serialization with UNORDERED CONTAINERS types and checkpointing                                |
+| test_SharedObject-DEV                         | None   | None   | Tests shared object loading with checkpointing                                                                 |
+| test_StatisticsComponent-DEV                  | None   | None   | Tests statistics with integers and checkpointing                                                               |
+| test_StatisticsComponent_basic-DEV            | None   | None   | None                                                                                                           |
+| test_SubComponent-DEV                         | None   | None   | Tests subcomponent loading with checkpointing                                                                  |
+| test_SubComponent_2-DEV                       | None   | None   | None                                                                                                           |
+| cmd-setstr                                    | 15.1   | None   | Check set string with spaces                                                                                   |
+| type-pair                                     | DEV    | None   | short std::pair watch test                                                                                     |
+| cmd-t2-confirm                                | NEW    | None   | Verify comfirm set across threads                                                                              |
+| cmd-logging                                   | 15.1   | None   | Log debug commands to an external file                                                                         |
+| cmd-multithread-NEW                           | NEW    | None   | Test basic thread commands: thread, info                                                                       |
+| cmd-multithread-actions-NEW                   | NEW    | None   | Test trace actions in thread1                                                                                  |
+| cmd-multithread-serial-NEW                    | NEW    | None   | Test basic thread commands in serial exec: thread, info                                                        |
+| cmd-multithread-shutdown-NEW                  | NEW    | None   | Test trace actions in thread1                                                                                  |
+| cmd-t2-define                                 | NEW    | None   | Check user-defined commands in multiple threads.                                                               |
+| cmd-actions                                   | NEW    | None   | Check for interactive, printTrace, printStatus, and set actions                                                |
+| cmd-replay                                    | 15.1   | None   | Replay file from inside debug console                                                                          |
+| cmd-t4-logging                                | NEW    | None   | Log debug commands to an external file from multiple threads                                                   |
+| type-aggregate                                | DEV    | None   | Exercise aggregate types                                                                                       |
+| type-union                                    | DEV    | None   | Exercise unions with one component                                                                             |
+| cmd-ckptaction                                | NEW    | None   | Check that trace checkpoint action triggers checkpoints                                                        |
+| cmd-multithread-8thds-NEW                     | NEW    | None   | Test basic thread commands: thread, info                                                                       |
+| cmd-basic                                     | 15.1   | None   | Basic interactive command check: cd, ls, pwd, run, continue                                                    |
+| cmd-t4-switch                                 | NEW    | None   | Exercise switch amond 4 threads                                                                                |
+| cmd-replay-sync                               | 15.1   | None   | Conditional watch trigger replayed from file                                                                   |
+| cmd-t2-replay                                 | NEW    | None   | Test simple replay invoked from thread 1                                                                       |
+| testinfo                                      | None   | None   | Provide information on local tests                                                                             |
+| type-tuple                                    | DEV    | None   | Exercise std::pair and std::tuple                                                                              |
+| cmd-history                                   | 15.1   | None   | Log history to file and check it                                                                               |
+| type-priority-queue                           | DEV    | None   | Exercise std::priority_queue<unsigned>                                                                         |
+| cmd-cmp-types-false                           | 15.1   | None   | Test comparisons for different types: all false                                                                |
+| type-queue-1                                  | DEV    | None   | Exercise std::queue<unsigned> with one component                                                               |
+| cmd-sanity                                    | 15.1   | None   | Enter interactive mode, change an internal variable and confirm it has been change                             |
+| type-nested-containers                        | DEV    | None   | show handling (or not) of rediculously long type strings                                                       |
+| cmd-comments-short                            | 15.1   | None   | Check that comments have no effect in replay file                                                              |
+| cmd-set                                       | 15.1   | None   | Check for set and print commands                                                                               |
+| cmd-watch                                     | NEW    | None   | Check watch commands with different trigger types                                                              |
+| cmd-default-ic                                | 15.1   | None   | Tests use of default IC with interactive-start                                                                 |
+| type-stack                                    | DEV    | None   | Exercise std::stack<unsigned>                                                                                  |
+| cmd-define                                    | NEW    | None   | Exercise std::bitset and std::vector<bool>                                                                     |
+| cmd-cmp-types-true                            | NEW    | None   | Test comparisons for different types: all true                                                                 |
+| cmd-help                                      | NEW    | None   | Walk through help commands                                                                                     |
+| cmd-trace                                     | NEW    | None   | Check for trace commands: trace, printWatchpoint, addTraceVar, printTrace, resetTrace, unwatch, quit           |
+| cmd-comments-ws                               | 15.1   | None   | Check that comments have no effect in replay file                                                              |
+| cmd-unwatch                                   | NEW    | None   | Check interactive console unwatch command                                                                      |
+| type-queue                                    | DEV    | None   | Exercise std::queue<unsigned>                                                                                  |
+| type-bitset                                   | NEW    | None   | Exercise std::bitset and std::vector<bool>                                                                     |
+| cmd-replay3                                   | 15.1   | None   | Debug replay from file and check we get a prompt                                                               |
+| cmd-t4-ckptaction                             | NEW    | None   | Check that trace checkpoint action triggers checkpoints with 4 threads                                         |
+| cmd-cond                                      | 15.1   | None   | Basic check for simple conditional watch trigger                                                               |
+| cmd-handler                                   | NEW    | None   | Check setHandler commands with trace                                                                           |
+| cmd-replay2                                   | 15.1   | None   | Replay session using SST command line option                                                                   |
+| type-arrays                                   | DEV    | None   | Exercise arrays with one component                                                                             |
+| cmd-ckptaction-err                            | 15.1   | None   | Check checkpoint action triggers error when checkpoint not enabled                                             |
+| type-f0array-f1queue                          | DEV    | None   | Exercise arrays and tuples in 1 component with 2 slots                                                         |
+| mpi-sdl-ALL                                   | None   | None   | Sample test input file                                                                                         |
+| mpi-sdl-DEV                                   | None   | None   | Sample test input file                                                                                         |
+| restart-ckpt-with-sigalrm-15.0                | 15.0   | 15.0   | Tests checkpoint with sigalrm to see if the sigalrm is carried over to restart (i.e. load-checkpoint)          |
+| restart-heartbeat-14.1                        | 14.1   | 14.1   | Tests using sigalrm with restart (i.e. load checkpoint)                                                        |
+| restart-interactive-14.1                      | 14.1   | 14.1   | Tests using interactive console with restart (i.e. load checkpoint)                                            |
+| restart-sigalrm-14.1                          | 14.1   | 14.1   | Tests using sigalrm with restart (i.e. load checkpoint)                                                        |
+| testinfo                                      | None   | None   | Provide information on local tests                                                                             |
+| restart-ckpt-with-heartbeat                   | 15.1   | None   | Tests restart for a checkpoint that had heartbeat to see if the heartbeat is carried over.                     |
+| sigusr-interactive2                           | 15.1   | None   | Tests sigusr1/2 with default interactive console & real time action                                            |
+| restart-ckpt-with-interactive-prefix-path-NEW | NEW    | None   | Tests expected fail for passing path to checkpoint-prefix.                                                     |
+| restart-ckpt-with-interactive                 | 15.1   | None   | Tests restart for a checkpoint that had interactive console to see if the interactive console is carried over. |
+| restart-sigalrm-15.0                          | 15.0   | 15.0   | Tests using sigalrm with restart (i.e. load checkpoint)                                                        |
+| sigalrm                                       | 14.1   | 15.0   | Tests sigalrm for single real time actions                                                                     |
+| sigalrm_ckpt_comb-NEW                         | NEW    | None   | Tests sigalrm for checkpoint combined with other real time actions                                             |
+| sigalrm_ckpt_comb                             | 14.1   | 15.0   | Tests sigalrm for checkpoint combined with other real time actions                                             |
+| restart-sigalrm-NEW                           | NEW    | None   | Tests using sigalrm with restart (i.e. load checkpoint)                                                        |
+| sigalrm-NEW                                   | NEW    | None   | Tests sigalrm for single real time actions                                                                     |
+| restart-heartbeat                             | 15.0   | None   | Tests using sigalrm with restart (i.e. load checkpoint)                                                        |
+| restart-interactive                           | 15.0   | None   | Tests using interactive console with restart (i.e. load checkpoint)                                            |
+| sigalrm_combined                              | 15.1   | None   | Tests sigalrm for combinations of two real time actions (checkpoint not included)                              |
+| restart-ckpt-with-sigalrm                     | NEW    | None   | Tests checkpoint with sigalrm to see if the sigalrm is carried over to restart (i.e. load-checkpoint)          |
+| sigusr-interactive-ckpt                       | 15.1   | None   | Tests sigusr1/2 with default interactive console w/checkpoint                                                  |
+| sigusr-interactive                            | 15.1   | None   | Tests sigusr1/2 with interactive console real time action                                                      |
+| sigusr-prefix-path-NEW                        | NEW    | None   | Tests sigusr1/2 expected fail when passing path to checkpoint-directory                                        |
+| sigusr_interactive-15.0                       | 15.0   | 15.0   | Tests sigusr1/2 with interactive console real time action                                                      |
+| restart-ckpt-with-sigalrm-NEW                 | NEW    | None   | Tests checkpoint with sigalrm to see if the sigalrm is carried over to restart (i.e. load-checkpoint)          |
+| sigusr-NEW                                    | NEW    | None   | Tests sigusr1/2 for single real time actions                                                                   |
+| testinfo                                      | None   | None   | Provide information on local tests                                                                             |
+| CaptCrunch_Interactive                        | 15.1   | None   | Tests CaptCrunch simple data integrity                                                                         |
+| CaptCrunch_Simple1                            | 15.1   | None   | Tests CaptCrunch simple data integrity                                                                         |
+| sst_restart_platform                          | NEW    | None   | Tests to ensure that existing checkpoints can be restarted on the correct architecture                         |
+| sst_restart_platform_knownfail                | NEW    | None   | Tests to ensure that existing checkpoints fail to restart on the wrong architecture                            |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/bin/sst-ext-tests
+++ b/bin/sst-ext-tests
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # sst-ext-tests/components CMake
 #
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 # See LICENSE in the top level directory for licensing details

--- a/components/CaptCrunch/CMakeLists.txt
+++ b/components/CaptCrunch/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # sst-ext-tests/tests/components/CaptCrunch CMake
 #
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 # See LICENSE in the top level directory for licensing details

--- a/components/CaptCrunch/CaptCrunch.cc
+++ b/components/CaptCrunch/CaptCrunch.cc
@@ -1,7 +1,7 @@
 //
 // _CaptCrunch_cc_
 //
-// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //

--- a/components/CaptCrunch/CaptCrunch.h
+++ b/components/CaptCrunch/CaptCrunch.h
@@ -1,7 +1,7 @@
 //
 // _CaptCrunch_h_
 //
-// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //

--- a/components/core-debug/CMakeLists.txt
+++ b/components/core-debug/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # sst-ext-tests/tests/components/core-debug CMake
 #
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 # See LICENSE in the top level directory for licensing details

--- a/components/core-debug/dbgsst15.cc
+++ b/components/core-debug/dbgsst15.cc
@@ -1,7 +1,7 @@
 //
 // _dbgsst15_cc_
 //
-// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //

--- a/components/core-debug/dbgsst15.h
+++ b/components/core-debug/dbgsst15.h
@@ -1,7 +1,7 @@
 //
 // _dbgsst15_h_
 //
-// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //

--- a/components/core-debug/om-arrays.cc
+++ b/components/core-debug/om-arrays.cc
@@ -1,7 +1,7 @@
 //
 // om-arrays.cc
 //
-// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //

--- a/components/core-debug/om-arrays.h
+++ b/components/core-debug/om-arrays.h
@@ -1,7 +1,7 @@
 //
 // om-arrays.h
 //
-// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //

--- a/components/core-debug/om-nested-containers.cc
+++ b/components/core-debug/om-nested-containers.cc
@@ -1,7 +1,7 @@
 //
 // om-nested-containers.cc
 //
-// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //

--- a/components/core-debug/om-nested-containers.h
+++ b/components/core-debug/om-nested-containers.h
@@ -1,7 +1,7 @@
 //
 // om-nested-containers.h
 //
-// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //

--- a/components/core-debug/om-queue.cc
+++ b/components/core-debug/om-queue.cc
@@ -1,7 +1,7 @@
 //
 // om-queue.cc
 //
-// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //

--- a/components/core-debug/om-queue.h
+++ b/components/core-debug/om-queue.h
@@ -1,7 +1,7 @@
 //
 // om-queue.h
 //
-// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //

--- a/components/core-debug/om-unions.cc
+++ b/components/core-debug/om-unions.cc
@@ -1,7 +1,7 @@
 //
 // om-unions.cc
 //
-// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //

--- a/components/core-debug/om-unions.h
+++ b/components/core-debug/om-unions.h
@@ -1,7 +1,7 @@
 //
 // om-unions.h
 //
-// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //

--- a/components/core-debug/omni.cc
+++ b/components/core-debug/omni.cc
@@ -1,7 +1,7 @@
 //
 // omni.cc
 //
-// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //

--- a/components/core-debug/omni.h
+++ b/components/core-debug/omni.h
@@ -2,7 +2,7 @@
 // omni.h
 // Object Map Noir Inspector
 //
-// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //

--- a/components/core-debug/tcldbg.h
+++ b/components/core-debug/tcldbg.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 // See LICENSE in the top level directory for licensing details

--- a/components/include/SST.h
+++ b/components/include/SST.h
@@ -1,7 +1,7 @@
 //
 // _SST_h_
 //
-// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //

--- a/components/include/list-traits.h
+++ b/components/include/list-traits.h
@@ -1,7 +1,7 @@
 //
 // _LIST_TRAITS_H
 //
-// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //

--- a/jenkins/exec-ext-test.sh
+++ b/jenkins/exec-ext-test.sh
@@ -2,7 +2,7 @@
 #
 # ~/jenkins/exec-test.sh
 #
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/jenkins/exec-sstcore-mpi-build.sh
+++ b/jenkins/exec-sstcore-mpi-build.sh
@@ -2,7 +2,7 @@
 #
 # ~/jenkins/exec-sstcore-mpi-build.sh
 #
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/jenkins/exec-sstcore-mpi-run.sh
+++ b/jenkins/exec-sstcore-mpi-run.sh
@@ -2,7 +2,7 @@
 #
 # ~/jenkins/exec-sstcore-mpi-run.sh
 #
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/jenkins/exec-sstcore-mpi.sh
+++ b/jenkins/exec-sstcore-mpi.sh
@@ -2,7 +2,7 @@
 #
 # ~/jenkins/exec-sstcore-mpi.sh
 #
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/jenkins/run.sh
+++ b/jenkins/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 # See LICENSE in the top level directory for licensing details

--- a/jenkins/serverside.sh
+++ b/jenkins/serverside.sh
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 # See LICENSE in the top level directory for licensing details

--- a/scripts/alt.mk
+++ b/scripts/alt.mk
@@ -3,7 +3,7 @@
 # Alternative test run flow to check that we're not over-filtering tests.
 #
 
-# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/scripts/gen-testlist.sh
+++ b/scripts/gen-testlist.sh
@@ -4,7 +4,7 @@
 # Used by local CMakeLists.txt to generate a test list given
 # a specific sst version number. Currently non-recursive.
 #
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 # See LICENSE in the top level directory for licensing details

--- a/scripts/test-dep.sh
+++ b/scripts/test-dep.sh
@@ -6,7 +6,7 @@
 # of the component dependency list
 #
 #
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 # See LICENSE in the top level directory for licensing details

--- a/scripts/test-mpiargs.sh
+++ b/scripts/test-mpiargs.sh
@@ -4,7 +4,7 @@
 # Given a fully qualified path to a test file (.sh or .py), examines
 # the file header for EXT_TEST MPIARGS "VALUE"
 #
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 # See LICENSE in the top level directory for licensing details

--- a/scripts/test-timeout.sh
+++ b/scripts/test-timeout.sh
@@ -4,7 +4,7 @@
 # Given a fully qualified path to a test file (.sh or .py), examines
 # the file header for EXT_TEST TIMEOUT VALUE
 #
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 # See LICENSE in the top level directory for licensing details

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # sst-ext-tests/tests CMake
 #
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 # See LICENSE in the top level directory for licensing details

--- a/tests/CaptCrunch/CMakeLists.txt
+++ b/tests/CaptCrunch/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # sst-ext-tests/tests/CaptCrunch CMake
 #
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/tests/CaptCrunch/debug.py
+++ b/tests/CaptCrunch/debug.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/tests/cli/CMakeLists.txt
+++ b/tests/cli/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # sst-ext-tests/tests/cli CMake
 #
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/tests/core-chkpt/CMakeLists.txt
+++ b/tests/core-chkpt/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # sst-ext-tests/tests/core-chkpt CMake
 #
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/tests/core-debug/CMakeLists.txt
+++ b/tests/core-debug/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # sst-ext-tests/tests/core-debug CMake
 #
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/tests/core-debug/dbgsst15.py
+++ b/tests/core-debug/dbgsst15.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/tests/core-debug/omni.py
+++ b/tests/core-debug/omni.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/tests/mpi/CMakeLists.txt
+++ b/tests/mpi/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # sst-ext-tests/tests/mpi CMake
 #
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/tests/rt_action/CMakeLists.txt
+++ b/tests/rt_action/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # sst-ext-tests/tests/rt_action CMake
 #
-# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/tests/rt_action/rt_action.py
+++ b/tests/rt_action/rt_action.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #


### PR DESCRIPTION
This PR is to track benign changes for copyright and test audit file updates.
Also fixed a problem with generating the correct SST_VERSION using -DSST_VERSION="version-string"
