### PR TITLE
adding parallel json tests

### DIFF
--- a/tests/json_parallel/CMakeLists.txt
+++ b/tests/json_parallel/CMakeLists.txt
@@ -1,0 +1,161 @@
+#
+# sst-ext-tests/tests/json_parallel CMake
+#
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+#EXT_TEST TEST_FILE_EXT sh
+#
+
+# !!! TODO !!! This file not updated for new conventions over test selection
+
+set(TEST_FILE_EXT "sh")
+set(passRegex "Simulation is complete")
+set(timeout "60")
+
+#-- SST Enabled Minimum Test Versions
+file(GLOB TEST_SRCS_TARGET_VER RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *-MIN${SST_VERSION}.${TEST_FILE_EXT})
+foreach(testSrc ${TEST_SRCS_TARGET_VER})
+  # Extract the file name
+  get_filename_component(testName ${testSrc} NAME_WLE)
+
+  execute_process(COMMAND ${EXT_TEST_DEP_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${testSrc}
+                OUTPUT_VARIABLE EXT_TEST_CHECK
+                RESULT_VARIABLE EXT_TEST_RTN
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+		ERROR_QUIET
+  )
+  execute_process(COMMAND ${EXT_TEST_TIMEOUT_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${testSrc}
+                OUTPUT_VARIABLE EXT_TEST_TIMEOUT
+                RESULT_VARIABLE EXT_TEST_RTN
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
+  )
+
+  if(NOT EXT_TEST_RTN EQUAL "0")
+      message(FATAL_ERROR "${EXT_TEST_TIMEOUT_COMMAND} failed")
+  endif()
+
+  execute_process(COMMAND ${EXT_TEST_MPIARGS_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${testSrc}
+                OUTPUT_VARIABLE EXT_TEST_MPIARGS
+                RESULT_VARIABLE EXT_TEST_RTN
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
+  )
+  string(REPLACE " " ";" MPI_ARG_LIST "${EXT_TEST_MPIARGS}")
+
+  message(STATUS "Dep Check ${testSrc} = ${EXT_TEST_CHECK}")
+
+  if (SST_VALGRIND)
+    message(STATUS "Disabling Valgrind for MPI test=${testSrc}")
+  endif()
+
+  # Add the tests for execution
+  if( "${EXT_TEST_CHECK}" STREQUAL "RUN" )
+    add_test(NAME ${testName}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      COMMAND ./${testSrc} ${MPIEXEC_EXECUTABLE} ${MPI_ARG_LIST})
+    set_property(TEST ${testName} PROPERTY LABELS "${SST_VERSION}")
+    set_property(TEST ${testName} PROPERTY PASS_REGULAR_EXPRESSION "${passRegex}")
+    if(NOT ${EXT_TEST_TIMEOUT} EQUAL 0)
+      set_property(TEST ${testName} PROPERTY TIMEOUT ${EXT_TEST_TIMEOUT})
+      message(STATUS "Runtime ${testSrc} = ${EXT_TEST_TIMEOUT}")
+    else()
+      set_property(TEST ${testName} PROPERTY TIMEOUT ${timeout})
+    endif()
+  endif()
+endforeach(testSrc)
+
+#-- SST Enabled Test Versions
+foreach(testVer ${SST_VER_LIST})
+  message(STATUS "###  tests for SST VERSION ${testVer} ###")
+  file(GLOB TEST_SRCS_VER RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *-${testVer}.${TEST_FILE_EXT})
+  foreach(testSrc ${TEST_SRCS_VER})
+    # Extract the file name
+    get_filename_component(testName ${testSrc} NAME_WLE)
+
+    execute_process(COMMAND ${EXT_TEST_DEP_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${testSrc}
+                  OUTPUT_VARIABLE EXT_TEST_CHECK
+                  RESULT_VARIABLE EXT_TEST_RTN
+                  OUTPUT_STRIP_TRAILING_WHITESPACE
+		  ERROR_QUIET
+    )
+    execute_process(COMMAND ${EXT_TEST_TIMEOUT_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${testSrc}
+                  OUTPUT_VARIABLE EXT_TEST_TIMEOUT
+                  RESULT_VARIABLE EXT_TEST_RTN
+                  OUTPUT_STRIP_TRAILING_WHITESPACE
+                  ERROR_QUIET
+    )
+    execute_process(COMMAND ${EXT_TEST_MPIARGS_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${testSrc}
+                  OUTPUT_VARIABLE EXT_TEST_MPIARGS
+                  RESULT_VARIABLE EXT_TEST_RTN
+                  OUTPUT_STRIP_TRAILING_WHITESPACE
+                  ERROR_QUIET
+    )
+    string(REPLACE " " ";" MPI_ARG_LIST "${EXT_TEST_MPIARGS}")
+
+    message(STATUS "Dep Check ${testSrc} = ${EXT_TEST_CHECK}")
+
+    # Add the tests for execution
+    if( "${EXT_TEST_CHECK}" STREQUAL "RUN" )
+      add_test(NAME ${testName}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND ./${testSrc} ${MPIEXEC_EXECUTABLE} ${MPI_ARG_LIST})
+      set_property(TEST ${testName} PROPERTY LABELS "${testVer}")
+      set_property(TEST ${testName} PROPERTY PASS_REGULAR_EXPRESSION "${passRegex}")
+      if(NOT ${EXT_TEST_TIMEOUT} EQUAL 0)
+        set_property(TEST ${testName} PROPERTY TIMEOUT ${EXT_TEST_TIMEOUT})
+        message(STATUS "Runtime ${testSrc} = ${EXT_TEST_TIMEOUT}")
+      else()
+        set_property(TEST ${testName} PROPERTY TIMEOUT ${timeout})
+      endif()
+    endif()
+  endforeach(testSrc)
+endforeach(testVer)
+
+#-- SST All Version Tests
+file(GLOB TEST_SRCS_ALL RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *-ALL.${TEST_FILE_EXT})
+foreach(testSrc ${TEST_SRCS_ALL})
+  # Extract the file name
+  get_filename_component(testName ${testSrc} NAME_WE)
+
+  execute_process(COMMAND ${EXT_TEST_DEP_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${testSrc}
+                OUTPUT_VARIABLE EXT_TEST_CHECK
+                RESULT_VARIABLE EXT_TEST_RTN
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+		ERROR_QUIET
+  )
+  execute_process(COMMAND ${EXT_TEST_TIMEOUT_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${testSrc}
+                OUTPUT_VARIABLE EXT_TEST_TIMEOUT
+                RESULT_VARIABLE EXT_TEST_RTN
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
+  )
+  execute_process(COMMAND ${EXT_TEST_MPIARGS_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${testSrc}
+                OUTPUT_VARIABLE EXT_TEST_MPIARGS
+                RESULT_VARIABLE EXT_TEST_RTN
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
+  )
+  string(REPLACE " " ";" MPI_ARG_LIST "${EXT_TEST_MPIARGS}")
+
+  message(STATUS "Dep Check ${testSrc} = ${EXT_TEST_CHECK}")
+
+  # Add the tests for execution
+  if( "${EXT_TEST_CHECK}" STREQUAL "RUN" )
+    add_test(NAME ${testName}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      COMMAND ./${testSrc} ${MPIEXEC_EXECUTABLE} ${MPI_ARG_LIST})
+    set_property(TEST ${testName} PROPERTY LABELS "ALL")
+    set_property(TEST ${testName} PROPERTY PASS_REGULAR_EXPRESSION "${passRegex}")
+    if(NOT ${EXT_TEST_TIMEOUT} EQUAL 0)
+      set_property(TEST ${testName} PROPERTY TIMEOUT ${EXT_TEST_TIMEOUT})
+      message(STATUS "Runtime ${testSrc} = ${EXT_TEST_TIMEOUT}")
+    else()
+      set_property(TEST ${testName} PROPERTY TIMEOUT ${timeout})
+    endif()
+  endif()
+endforeach(testSrc)
+
+# EOF

--- a/tests/json_parallel/test-core-par-DEV.sh
+++ b/tests/json_parallel/test-core-par-DEV.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER DEV
+#EXT_TEST TEST_FILE_MAXVER DEV
+#EXT_TEST TEST_FILE_DESC "sst-test-core parallel json tests"
+#EXT_TEST TIMEOUT 120
+#EXT_TEST DEP "coreTestElement.SubComponentLoader coreTestElement.message_mesh.enclosing_component"
+
+MPIEXEC="$1"
+shift
+MPIARGS="$@"
+
+# Parallel / serial load
+sst -n 4 test_MessageMesh_6_6_1r4t.json
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR [test_MessageMesh_6_6_1r4t.json] : $retVal"
+  exit $retVal
+fi
+
+$MPIEXEC $MPIARGS -np 2 sst -n 3 test_MessageMesh_6_6_2r3t.json
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR [test_MessageMesh_6_6_2r3t.json] : $retVal"
+  exit $retVal
+fi
+
+$MPIEXEC $MPIARGS -np 3 sst test_MessageMesh_6_6_3r1t.json
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR [test_MessageMesh_6_6_3r1t.json] : $retVal"
+  exit $retVal
+fi
+
+sst -n 4 --parallel-load="MULTI" test_MessageMesh_6_6_1r4t_paraload.json
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR [test_MessageMesh_6_6_1r4t_paraload.json] : $retVal"
+  exit $retVal
+fi
+
+$MPIEXEC $MPIARGS -np 2 sst -n 3 --parallel-load="MULTI" test_MessageMesh_6_6_2r3t_paraload.json
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR [test_MessageMesh_6_6_2r3t_paraload.json] : $retVal"
+  exit $retVal
+fi
+
+$MPIEXEC $MPIARGS -np 3 sst --parallel-load="MULTI" test_MessageMesh_6_6_3r1t_paraload.json
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR [test_MessageMesh_6_6_3r1t_paraload.json] : $retVal"
+  exit $retVal
+fi
+
+# EOF

--- a/tests/json_parallel/test_MessageMesh_6_6_1r4t.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_1r4t.json
@@ -1,0 +1,2942 @@
+{
+"program_options":{
+  "verbose": "0",
+  "stop-at": "10us",
+  "print-timing-info": "0",
+  "timing-info-json": "",
+  "heartbeat-sim-period": "",
+  "heartbeat-wall-period": "0",
+  "timebase": "1ps",
+  "partitioner": "sst.linear",
+  "timeVortex": "sst.timevortex.priority_queue",
+  "interthread-links": "false",
+  "output-prefix-core": "@x SST Core: ",
+  "checkpoint-sim-period": "",
+  "checkpoint-wall-period": "0"
+},
+"statistics_options":{
+  "statisticLoadLevel": 2,
+  "statisticOutput": "sst.statOutputCSV"
+},
+"components": [
+{
+  "name": "component0",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "0",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component1",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "1",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component2",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "2",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component3",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "3",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component4",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "4",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component5",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "5",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component6",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "6",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component7",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "7",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component8",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "8",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component9",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "9",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component10",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "10",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component11",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "11",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component12",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "12",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component13",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "13",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component14",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "14",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component15",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "15",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component16",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "16",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component17",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "17",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component18",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "18",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component19",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "19",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component20",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "20",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component21",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "21",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component22",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "22",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component23",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "23",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component24",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "24",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component25",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "25",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component26",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "26",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component27",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "27",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component28",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "28",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component29",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "29",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component30",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "30",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component31",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "31",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component32",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "32",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component33",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "33",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component34",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "34",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component35",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "35",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+}
+],
+"statistics_group": null,
+"links": [
+{
+  "name": "link_x0y0_x1y0",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component1:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y0_x0y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component5:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y0_x0y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component6:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y5_x0y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component30:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y0_x2y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component1:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component2:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y0_x1y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component1:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component7:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y5_x1y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component1:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component31:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y0_x3y0",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component2:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component3:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y0_x2y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component2:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component8:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y5_x2y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component2:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component32:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y0_x4y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component3:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component4:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y0_x3y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component3:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component9:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y5_x3y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component3:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component33:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y0_x5y0",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component4:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component5:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y0_x4y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component4:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component10:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y5_x4y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component4:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component34:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y0_x5y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component5:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component11:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y5_x5y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component5:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y1_x1y1",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component6:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component7:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y1_x0y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component6:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component11:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y1_x0y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component6:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component12:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y1_x2y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component7:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component8:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y1_x1y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component7:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component13:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y1_x3y1",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component8:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component9:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y1_x2y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component8:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component14:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y1_x4y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component9:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component10:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y1_x3y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component9:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component15:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y1_x5y1",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component10:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component11:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y1_x4y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component10:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component16:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y1_x5y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component11:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component17:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y2_x1y2",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component12:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component13:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y2_x0y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component12:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component17:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y2_x0y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component12:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component18:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y2_x2y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component13:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component14:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y2_x1y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component13:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component19:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y2_x3y2",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component14:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component15:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y2_x2y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component14:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component20:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y2_x4y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component15:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component16:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y2_x3y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component15:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component21:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y2_x5y2",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component16:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component17:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y2_x4y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component16:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component22:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y2_x5y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component17:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component23:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y3_x1y3",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component18:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component19:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y3_x0y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component18:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component23:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y3_x0y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component18:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component24:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y3_x2y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component19:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component20:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y3_x1y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component19:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component25:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y3_x3y3",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component20:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component21:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y3_x2y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component20:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component26:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y3_x4y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component21:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component22:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y3_x3y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component21:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component27:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y3_x5y3",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component22:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component23:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y3_x4y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component22:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component28:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y3_x5y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component23:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component29:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y4_x1y4",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component24:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component25:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y4_x0y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component24:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component29:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y4_x0y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component24:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component30:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y4_x2y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component25:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component26:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y4_x1y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component25:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component31:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y4_x3y4",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component26:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component27:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y4_x2y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component26:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component32:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y4_x4y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component27:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component28:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y4_x3y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component27:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component33:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y4_x5y4",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component28:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component29:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y4_x4y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component28:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component34:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y4_x5y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component29:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y5_x1y5",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component30:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component31:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y5_x0y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component30:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y5_x2y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component31:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component32:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y5_x3y5",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component32:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component33:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y5_x4y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component33:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component34:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y5_x5y5",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component34:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+}
+]
+}

--- a/tests/json_parallel/test_MessageMesh_6_6_1r4t_paraload.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_1r4t_paraload.json
@@ -1,0 +1,3086 @@
+{
+"program_options":{
+  "verbose": "0",
+  "stop-at": "10us",
+  "print-timing-info": "0",
+  "timing-info-json": "",
+  "heartbeat-sim-period": "",
+  "heartbeat-wall-period": "0",
+  "timebase": "1ps",
+  "partitioner": "sst.linear",
+  "timeVortex": "sst.timevortex.priority_queue",
+  "interthread-links": "false",
+  "output-prefix-core": "@x SST Core: ",
+  "checkpoint-sim-period": "",
+  "checkpoint-wall-period": "0"
+},
+"statistics_options":{
+  "statisticLoadLevel": 2,
+  "statisticOutput": "sst.statOutputCSV"
+},
+"components": [
+{
+  "name": "component0",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "0",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component1",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "1",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component2",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "2",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component3",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "3",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component4",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "4",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component5",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "5",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component6",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "6",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component7",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "7",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component8",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "8",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component9",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "9",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component10",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "10",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 1
+  }
+},
+{
+  "name": "component11",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "11",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 1
+  }
+},
+{
+  "name": "component12",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "12",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 1
+  }
+},
+{
+  "name": "component13",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "13",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 1
+  }
+},
+{
+  "name": "component14",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "14",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 1
+  }
+},
+{
+  "name": "component15",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "15",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 1
+  }
+},
+{
+  "name": "component16",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "16",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 1
+  }
+},
+{
+  "name": "component17",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "17",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 1
+  }
+},
+{
+  "name": "component18",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "18",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 1
+  }
+},
+{
+  "name": "component19",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "19",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 1
+  }
+},
+{
+  "name": "component20",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "20",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 2
+  }
+},
+{
+  "name": "component21",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "21",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 2
+  }
+},
+{
+  "name": "component22",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "22",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 2
+  }
+},
+{
+  "name": "component23",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "23",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 2
+  }
+},
+{
+  "name": "component24",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "24",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 2
+  }
+},
+{
+  "name": "component25",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "25",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 2
+  }
+},
+{
+  "name": "component26",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "26",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 2
+  }
+},
+{
+  "name": "component27",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "27",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 2
+  }
+},
+{
+  "name": "component28",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "28",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 3
+  }
+},
+{
+  "name": "component29",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "29",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 3
+  }
+},
+{
+  "name": "component30",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "30",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 3
+  }
+},
+{
+  "name": "component31",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "31",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 3
+  }
+},
+{
+  "name": "component32",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "32",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 3
+  }
+},
+{
+  "name": "component33",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "33",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 3
+  }
+},
+{
+  "name": "component34",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "34",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 3
+  }
+},
+{
+  "name": "component35",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "35",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 3
+  }
+}
+],
+"statistics_group": null,
+"links": [
+{
+  "name": "link_x0y0_x1y0",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component1:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y0_x0y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component5:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y0_x0y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component6:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y5_x0y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component30:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y0_x2y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component1:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component2:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y0_x1y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component1:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component7:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y5_x1y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component1:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component31:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y0_x3y0",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component2:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component3:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y0_x2y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component2:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component8:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y5_x2y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component2:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component32:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y0_x4y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component3:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component4:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y0_x3y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component3:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component9:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y5_x3y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component3:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component33:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y0_x5y0",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component4:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component5:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y0_x4y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component4:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component10:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y5_x4y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component4:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component34:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y0_x5y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component5:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component11:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y5_x5y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component5:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y1_x1y1",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component6:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component7:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y1_x0y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component6:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component11:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y1_x0y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component6:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component12:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y1_x2y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component7:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component8:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y1_x1y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component7:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component13:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y1_x3y1",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component8:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component9:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y1_x2y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component8:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component14:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y1_x4y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component9:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component10:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y1_x3y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component9:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component15:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y1_x5y1",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component10:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component11:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y1_x4y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component10:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component16:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y1_x5y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component11:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component17:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y2_x1y2",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component12:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component13:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y2_x0y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component12:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component17:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y2_x0y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component12:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component18:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y2_x2y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component13:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component14:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y2_x1y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component13:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component19:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y2_x3y2",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component14:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component15:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y2_x2y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component14:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component20:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y2_x4y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component15:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component16:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y2_x3y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component15:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component21:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y2_x5y2",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component16:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component17:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y2_x4y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component16:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component22:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y2_x5y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component17:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component23:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y3_x1y3",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component18:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component19:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y3_x0y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component18:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component23:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y3_x0y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component18:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component24:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y3_x2y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component19:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component20:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y3_x1y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component19:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component25:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y3_x3y3",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component20:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component21:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y3_x2y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component20:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component26:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y3_x4y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component21:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component22:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y3_x3y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component21:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component27:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y3_x5y3",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component22:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component23:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y3_x4y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component22:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component28:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y3_x5y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component23:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component29:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y4_x1y4",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component24:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component25:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y4_x0y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component24:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component29:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y4_x0y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component24:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component30:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y4_x2y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component25:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component26:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y4_x1y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component25:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component31:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y4_x3y4",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component26:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component27:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y4_x2y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component26:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component32:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y4_x4y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component27:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component28:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y4_x3y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component27:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component33:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y4_x5y4",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component28:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component29:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y4_x4y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component28:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component34:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y4_x5y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component29:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y5_x1y5",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component30:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component31:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y5_x0y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component30:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y5_x2y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component31:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component32:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y5_x3y5",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component32:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component33:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y5_x4y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component33:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component34:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y5_x5y5",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component34:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+}
+]
+}

--- a/tests/json_parallel/test_MessageMesh_6_6_2r3t.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_2r3t.json
@@ -1,0 +1,2942 @@
+{
+"program_options":{
+  "verbose": "0",
+  "stop-at": "10us",
+  "print-timing-info": "0",
+  "timing-info-json": "",
+  "heartbeat-sim-period": "",
+  "heartbeat-wall-period": "0",
+  "timebase": "1ps",
+  "partitioner": "sst.linear",
+  "timeVortex": "sst.timevortex.priority_queue",
+  "interthread-links": "false",
+  "output-prefix-core": "@x SST Core: ",
+  "checkpoint-sim-period": "",
+  "checkpoint-wall-period": "0"
+},
+"statistics_options":{
+  "statisticLoadLevel": 2,
+  "statisticOutput": "sst.statOutputCSV"
+},
+"components": [
+{
+  "name": "component0",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "0",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component1",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "1",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component2",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "2",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component3",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "3",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component4",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "4",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component5",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "5",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component6",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "6",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component7",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "7",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component8",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "8",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component9",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "9",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component10",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "10",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component11",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "11",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component12",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "12",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component13",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "13",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component14",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "14",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component15",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "15",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component16",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "16",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component17",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "17",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component18",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "18",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component19",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "19",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component20",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "20",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component21",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "21",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component22",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "22",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component23",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "23",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component24",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "24",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component25",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "25",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component26",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "26",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component27",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "27",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component28",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "28",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component29",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "29",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component30",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "30",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component31",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "31",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component32",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "32",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component33",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "33",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component34",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "34",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component35",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "35",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+}
+],
+"statistics_group": null,
+"links": [
+{
+  "name": "link_x0y0_x1y0",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component1:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y0_x0y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component5:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y0_x0y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component6:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y5_x0y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component30:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y0_x2y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component1:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component2:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y0_x1y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component1:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component7:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y5_x1y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component1:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component31:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y0_x3y0",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component2:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component3:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y0_x2y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component2:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component8:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y5_x2y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component2:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component32:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y0_x4y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component3:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component4:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y0_x3y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component3:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component9:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y5_x3y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component3:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component33:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y0_x5y0",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component4:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component5:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y0_x4y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component4:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component10:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y5_x4y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component4:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component34:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y0_x5y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component5:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component11:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y5_x5y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component5:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y1_x1y1",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component6:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component7:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y1_x0y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component6:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component11:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y1_x0y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component6:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component12:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y1_x2y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component7:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component8:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y1_x1y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component7:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component13:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y1_x3y1",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component8:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component9:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y1_x2y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component8:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component14:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y1_x4y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component9:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component10:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y1_x3y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component9:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component15:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y1_x5y1",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component10:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component11:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y1_x4y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component10:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component16:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y1_x5y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component11:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component17:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y2_x1y2",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component12:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component13:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y2_x0y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component12:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component17:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y2_x0y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component12:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component18:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y2_x2y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component13:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component14:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y2_x1y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component13:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component19:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y2_x3y2",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component14:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component15:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y2_x2y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component14:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component20:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y2_x4y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component15:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component16:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y2_x3y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component15:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component21:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y2_x5y2",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component16:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component17:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y2_x4y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component16:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component22:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y2_x5y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component17:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component23:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y3_x1y3",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component18:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component19:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y3_x0y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component18:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component23:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y3_x0y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component18:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component24:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y3_x2y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component19:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component20:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y3_x1y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component19:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component25:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y3_x3y3",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component20:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component21:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y3_x2y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component20:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component26:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y3_x4y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component21:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component22:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y3_x3y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component21:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component27:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y3_x5y3",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component22:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component23:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y3_x4y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component22:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component28:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y3_x5y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component23:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component29:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y4_x1y4",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component24:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component25:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y4_x0y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component24:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component29:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y4_x0y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component24:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component30:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y4_x2y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component25:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component26:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y4_x1y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component25:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component31:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y4_x3y4",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component26:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component27:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y4_x2y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component26:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component32:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y4_x4y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component27:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component28:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y4_x3y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component27:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component33:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y4_x5y4",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component28:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component29:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y4_x4y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component28:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component34:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y4_x5y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component29:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y5_x1y5",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component30:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component31:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y5_x0y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component30:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y5_x2y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component31:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component32:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y5_x3y5",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component32:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component33:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y5_x4y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component33:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component34:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y5_x5y5",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component34:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+}
+]
+}

--- a/tests/json_parallel/test_MessageMesh_6_6_2r3t_paraload0.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_2r3t_paraload0.json
@@ -1,0 +1,1634 @@
+{
+"program_options":{
+  "verbose": "0",
+  "stop-at": "10us",
+  "print-timing-info": "0",
+  "timing-info-json": "",
+  "heartbeat-sim-period": "",
+  "heartbeat-wall-period": "0",
+  "timebase": "1ps",
+  "partitioner": "sst.linear",
+  "timeVortex": "sst.timevortex.priority_queue",
+  "interthread-links": "false",
+  "output-prefix-core": "@x SST Core: ",
+  "checkpoint-sim-period": "",
+  "checkpoint-wall-period": "0"
+},
+"statistics_options":{
+  "statisticLoadLevel": 2,
+  "statisticOutput": "sst.statOutputCSV"
+},
+"components": [
+{
+  "name": "component0",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "0",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component1",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "1",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component2",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "2",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component3",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "3",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component4",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "4",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component5",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "5",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component6",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "6",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 1
+  }
+},
+{
+  "name": "component7",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "7",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 1
+  }
+},
+{
+  "name": "component8",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "8",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 1
+  }
+},
+{
+  "name": "component9",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "9",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 1
+  }
+},
+{
+  "name": "component10",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "10",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 1
+  }
+},
+{
+  "name": "component11",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "11",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 1
+  }
+},
+{
+  "name": "component12",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "12",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 2
+  }
+},
+{
+  "name": "component13",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "13",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 2
+  }
+},
+{
+  "name": "component14",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "14",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 2
+  }
+},
+{
+  "name": "component15",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "15",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 2
+  }
+},
+{
+  "name": "component16",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "16",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 2
+  }
+},
+{
+  "name": "component17",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "17",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 2
+  }
+}
+],
+"statistics_group": null,
+"links": [
+{
+  "name": "link_x0y0_x1y0",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component1:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y0_x0y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component5:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y0_x0y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component6:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y5_x0y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component0:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 2
+  }
+},
+{
+  "name": "link_x1y0_x2y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component1:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component2:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y0_x1y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component1:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component7:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y5_x1y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component1:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 2
+  }
+},
+{
+  "name": "link_x2y0_x3y0",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component2:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component3:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y0_x2y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component2:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component8:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y5_x2y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component2:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 2
+  }
+},
+{
+  "name": "link_x3y0_x4y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component3:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component4:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y0_x3y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component3:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component9:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y5_x3y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component3:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 2
+  }
+},
+{
+  "name": "link_x4y0_x5y0",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component4:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component5:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y0_x4y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component4:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component10:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y5_x4y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component4:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 2
+  }
+},
+{
+  "name": "link_x5y0_x5y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component5:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component11:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y5_x5y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component5:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 2
+  }
+},
+{
+  "name": "link_x0y1_x1y1",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component6:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component7:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y1_x0y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component6:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component11:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y1_x0y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component6:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component12:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y1_x2y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component7:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component8:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y1_x1y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component7:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component13:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y1_x3y1",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component8:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component9:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y1_x2y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component8:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component14:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y1_x4y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component9:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component10:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y1_x3y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component9:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component15:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y1_x5y1",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component10:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component11:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y1_x4y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component10:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component16:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y1_x5y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component11:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component17:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y2_x1y2",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component12:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component13:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y2_x0y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component12:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component17:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y2_x0y3",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component12:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x1y2_x2y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component13:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component14:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y2_x1y3",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component13:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x2y2_x3y2",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component14:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component15:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y2_x2y3",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component14:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x3y2_x4y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component15:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component16:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y2_x3y3",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component15:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x4y2_x5y2",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component16:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component17:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y2_x4y3",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component16:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x5y2_x5y3",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component17:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 0
+  }
+}
+]
+}

--- a/tests/json_parallel/test_MessageMesh_6_6_2r3t_paraload1.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_2r3t_paraload1.json
@@ -1,0 +1,1634 @@
+{
+"program_options":{
+  "verbose": "0",
+  "stop-at": "10us",
+  "print-timing-info": "0",
+  "timing-info-json": "",
+  "heartbeat-sim-period": "",
+  "heartbeat-wall-period": "0",
+  "timebase": "1ps",
+  "partitioner": "sst.linear",
+  "timeVortex": "sst.timevortex.priority_queue",
+  "interthread-links": "false",
+  "output-prefix-core": "@x SST Core: ",
+  "checkpoint-sim-period": "",
+  "checkpoint-wall-period": "0"
+},
+"statistics_options":{
+  "statisticLoadLevel": 2,
+  "statisticOutput": "sst.statOutputCSV"
+},
+"components": [
+{
+  "name": "component18",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "18",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "component19",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "19",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "component20",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "20",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "component21",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "21",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "component22",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "22",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "component23",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "23",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "component24",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "24",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 1
+  }
+},
+{
+  "name": "component25",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "25",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 1
+  }
+},
+{
+  "name": "component26",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "26",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 1
+  }
+},
+{
+  "name": "component27",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "27",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 1
+  }
+},
+{
+  "name": "component28",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "28",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 1
+  }
+},
+{
+  "name": "component29",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "29",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 1
+  }
+},
+{
+  "name": "component30",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "30",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 2
+  }
+},
+{
+  "name": "component31",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "31",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 2
+  }
+},
+{
+  "name": "component32",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "32",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 2
+  }
+},
+{
+  "name": "component33",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "33",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 2
+  }
+},
+{
+  "name": "component34",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "34",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 2
+  }
+},
+{
+  "name": "component35",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "35",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 2
+  }
+}
+],
+"statistics_group": null,
+"links": [
+{
+  "name": "link_x0y5_x0y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component30:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x1y5_x1y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component31:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x2y5_x2y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component32:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x3y5_x3y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component33:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x4y5_x4y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component34:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x5y5_x5y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component35:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x0y2_x0y3",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component18:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 2
+  }
+},
+{
+  "name": "link_x1y2_x1y3",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component19:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 2
+  }
+},
+{
+  "name": "link_x2y2_x2y3",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component20:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 2
+  }
+},
+{
+  "name": "link_x3y2_x3y3",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component21:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 2
+  }
+},
+{
+  "name": "link_x4y2_x4y3",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component22:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 2
+  }
+},
+{
+  "name": "link_x5y2_x5y3",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component23:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 2
+  }
+},
+{
+  "name": "link_x0y3_x1y3",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component18:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component19:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y3_x0y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component18:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component23:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y3_x0y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component18:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component24:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y3_x2y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component19:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component20:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y3_x1y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component19:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component25:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y3_x3y3",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component20:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component21:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y3_x2y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component20:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component26:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y3_x4y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component21:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component22:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y3_x3y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component21:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component27:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y3_x5y3",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component22:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component23:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y3_x4y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component22:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component28:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y3_x5y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component23:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component29:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y4_x1y4",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component24:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component25:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y4_x0y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component24:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component29:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y4_x0y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component24:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component30:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y4_x2y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component25:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component26:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y4_x1y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component25:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component31:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y4_x3y4",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component26:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component27:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y4_x2y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component26:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component32:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y4_x4y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component27:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component28:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y4_x3y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component27:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component33:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y4_x5y4",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component28:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component29:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y4_x4y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component28:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component34:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y4_x5y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component29:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y5_x1y5",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component30:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component31:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y5_x0y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component30:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y5_x2y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component31:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component32:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y5_x3y5",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component32:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component33:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y5_x4y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component33:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component34:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y5_x5y5",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component34:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+}
+]
+}

--- a/tests/json_parallel/test_MessageMesh_6_6_3r1t.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_3r1t.json
@@ -1,0 +1,2942 @@
+{
+"program_options":{
+  "verbose": "0",
+  "stop-at": "10us",
+  "print-timing-info": "0",
+  "timing-info-json": "",
+  "heartbeat-sim-period": "",
+  "heartbeat-wall-period": "0",
+  "timebase": "1ps",
+  "partitioner": "sst.linear",
+  "timeVortex": "sst.timevortex.priority_queue",
+  "interthread-links": "false",
+  "output-prefix-core": "@x SST Core: ",
+  "checkpoint-sim-period": "",
+  "checkpoint-wall-period": "0"
+},
+"statistics_options":{
+  "statisticLoadLevel": 2,
+  "statisticOutput": "sst.statOutputCSV"
+},
+"components": [
+{
+  "name": "component0",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "0",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component1",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "1",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component2",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "2",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component3",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "3",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component4",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "4",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component5",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "5",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component6",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "6",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component7",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "7",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component8",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "8",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component9",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "9",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component10",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "10",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component11",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "11",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component12",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "12",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component13",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "13",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component14",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "14",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component15",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "15",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component16",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "16",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component17",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "17",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component18",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "18",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component19",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "19",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component20",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "20",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component21",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "21",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component22",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "22",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component23",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "23",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component24",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "24",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component25",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "25",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component26",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "26",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component27",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "27",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component28",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "28",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component29",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "29",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component30",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "30",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component31",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "31",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component32",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "32",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component33",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "33",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component34",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "34",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+},
+{
+  "name": "component35",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "35",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ]
+}
+],
+"statistics_group": null,
+"links": [
+{
+  "name": "link_x0y0_x1y0",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component1:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y0_x0y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component5:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y0_x0y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component6:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y5_x0y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component30:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y0_x2y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component1:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component2:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y0_x1y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component1:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component7:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y5_x1y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component1:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component31:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y0_x3y0",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component2:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component3:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y0_x2y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component2:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component8:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y5_x2y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component2:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component32:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y0_x4y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component3:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component4:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y0_x3y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component3:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component9:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y5_x3y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component3:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component33:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y0_x5y0",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component4:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component5:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y0_x4y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component4:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component10:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y5_x4y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component4:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component34:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y0_x5y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component5:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component11:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y5_x5y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component5:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y1_x1y1",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component6:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component7:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y1_x0y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component6:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component11:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y1_x0y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component6:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component12:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y1_x2y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component7:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component8:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y1_x1y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component7:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component13:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y1_x3y1",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component8:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component9:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y1_x2y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component8:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component14:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y1_x4y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component9:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component10:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y1_x3y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component9:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component15:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y1_x5y1",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component10:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component11:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y1_x4y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component10:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component16:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y1_x5y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component11:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component17:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y2_x1y2",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component12:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component13:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y2_x0y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component12:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component17:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y2_x0y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component12:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component18:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y2_x2y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component13:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component14:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y2_x1y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component13:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component19:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y2_x3y2",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component14:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component15:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y2_x2y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component14:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component20:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y2_x4y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component15:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component16:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y2_x3y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component15:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component21:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y2_x5y2",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component16:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component17:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y2_x4y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component16:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component22:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y2_x5y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component17:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component23:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y3_x1y3",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component18:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component19:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y3_x0y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component18:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component23:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y3_x0y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component18:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component24:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y3_x2y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component19:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component20:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y3_x1y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component19:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component25:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y3_x3y3",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component20:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component21:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y3_x2y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component20:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component26:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y3_x4y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component21:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component22:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y3_x3y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component21:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component27:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y3_x5y3",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component22:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component23:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y3_x4y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component22:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component28:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y3_x5y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component23:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component29:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y4_x1y4",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component24:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component25:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y4_x0y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component24:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component29:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y4_x0y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component24:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component30:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y4_x2y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component25:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component26:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y4_x1y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component25:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component31:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y4_x3y4",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component26:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component27:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y4_x2y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component26:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component32:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y4_x4y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component27:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component28:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y4_x3y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component27:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component33:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y4_x5y4",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component28:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component29:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y4_x4y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component28:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component34:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y4_x5y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component29:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y5_x1y5",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component30:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component31:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y5_x0y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component30:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y5_x2y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component31:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component32:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y5_x3y5",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component32:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component33:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y5_x4y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component33:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component34:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y5_x5y5",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component34:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+}
+]
+}

--- a/tests/json_parallel/test_MessageMesh_6_6_3r1t_paraload0.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_3r1t_paraload0.json
@@ -1,0 +1,1124 @@
+{
+"program_options":{
+  "verbose": "0",
+  "stop-at": "10us",
+  "print-timing-info": "0",
+  "timing-info-json": "",
+  "heartbeat-sim-period": "",
+  "heartbeat-wall-period": "0",
+  "timebase": "1ps",
+  "partitioner": "sst.linear",
+  "timeVortex": "sst.timevortex.priority_queue",
+  "interthread-links": "false",
+  "output-prefix-core": "@x SST Core: ",
+  "checkpoint-sim-period": "",
+  "checkpoint-wall-period": "0"
+},
+"statistics_options":{
+  "statisticLoadLevel": 2,
+  "statisticOutput": "sst.statOutputCSV"
+},
+"components": [
+{
+  "name": "component0",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "0",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component1",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "1",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component2",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "2",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component3",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "3",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component4",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "4",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component5",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "5",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component6",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "6",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component7",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "7",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component8",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "8",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component9",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "9",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component10",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "10",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "component11",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "11",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 0,
+    "thread": 0
+  }
+}
+],
+"statistics_group": null,
+"links": [
+{
+  "name": "link_x0y0_x1y0",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component1:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y0_x0y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component5:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y0_x0y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component0:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component6:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y5_x0y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component0:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x1y0_x2y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component1:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component2:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y0_x1y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component1:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component7:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y5_x1y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component1:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x2y0_x3y0",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component2:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component3:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y0_x2y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component2:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component8:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y5_x2y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component2:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x3y0_x4y0",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component3:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component4:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y0_x3y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component3:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component9:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y5_x3y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component3:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x4y0_x5y0",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component4:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component5:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y0_x4y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component4:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component10:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y5_x4y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component4:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x5y0_x5y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component5:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component11:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y5_x5y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component5:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x0y1_x1y1",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component6:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component7:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y1_x0y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component6:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component11:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y1_x0y2",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component6:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x1y1_x2y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component7:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component8:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y1_x1y2",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component7:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x2y1_x3y1",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component8:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component9:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y1_x2y2",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component8:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x3y1_x4y1",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component9:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component10:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y1_x3y2",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component9:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x4y1_x5y1",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component10:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component11:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y1_x4y2",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component10:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x5y1_x5y2",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component11:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 0
+  }
+}
+]
+}

--- a/tests/json_parallel/test_MessageMesh_6_6_3r1t_paraload1.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_3r1t_paraload1.json
@@ -1,0 +1,1124 @@
+{
+"program_options":{
+  "verbose": "0",
+  "stop-at": "10us",
+  "print-timing-info": "0",
+  "timing-info-json": "",
+  "heartbeat-sim-period": "",
+  "heartbeat-wall-period": "0",
+  "timebase": "1ps",
+  "partitioner": "sst.linear",
+  "timeVortex": "sst.timevortex.priority_queue",
+  "interthread-links": "false",
+  "output-prefix-core": "@x SST Core: ",
+  "checkpoint-sim-period": "",
+  "checkpoint-wall-period": "0"
+},
+"statistics_options":{
+  "statisticLoadLevel": 2,
+  "statisticOutput": "sst.statOutputCSV"
+},
+"components": [
+{
+  "name": "component12",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "12",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "component13",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "13",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "component14",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "14",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "component15",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "15",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "component16",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "16",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "component17",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "17",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "component18",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "18",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "component19",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "19",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "component20",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "20",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "component21",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "21",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "component22",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "22",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "component23",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "23",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 1,
+    "thread": 0
+  }
+}
+],
+"statistics_group": null,
+"links": [
+{
+  "name": "link_x0y1_x0y2",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component12:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x1y1_x1y2",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component13:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x2y1_x2y2",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component14:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x3y1_x3y2",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component15:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x4y1_x4y2",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component16:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x5y1_x5y2",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component17:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x0y2_x1y2",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component12:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component13:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y2_x0y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component12:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component17:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y2_x0y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component12:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component18:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y2_x2y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component13:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component14:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y2_x1y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component13:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component19:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y2_x3y2",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component14:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component15:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y2_x2y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component14:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component20:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y2_x4y2",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component15:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component16:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y2_x3y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component15:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component21:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y2_x5y2",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component16:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component17:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y2_x4y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component16:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component22:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y2_x5y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component17:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component23:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y3_x1y3",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component18:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component19:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y3_x0y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component18:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component23:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y3_x0y4",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component18:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x1y3_x2y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component19:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component20:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y3_x1y4",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component19:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x2y3_x3y3",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component20:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component21:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y3_x2y4",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component20:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x3y3_x4y3",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component21:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component22:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y3_x3y4",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component21:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x4y3_x5y3",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component22:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component23:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y3_x4y4",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component22:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x5y3_x5y4",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component23:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 2,
+    "thread": 0
+  }
+}
+]
+}

--- a/tests/json_parallel/test_MessageMesh_6_6_3r1t_paraload2.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_3r1t_paraload2.json
@@ -1,0 +1,1124 @@
+{
+"program_options":{
+  "verbose": "0",
+  "stop-at": "10us",
+  "print-timing-info": "0",
+  "timing-info-json": "",
+  "heartbeat-sim-period": "",
+  "heartbeat-wall-period": "0",
+  "timebase": "1ps",
+  "partitioner": "sst.linear",
+  "timeVortex": "sst.timevortex.priority_queue",
+  "interthread-links": "false",
+  "output-prefix-core": "@x SST Core: ",
+  "checkpoint-sim-period": "",
+  "checkpoint-wall-period": "0"
+},
+"statistics_options":{
+  "statisticLoadLevel": 2,
+  "statisticOutput": "sst.statOutputCSV"
+},
+"components": [
+{
+  "name": "component24",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "24",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "component25",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "25",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "component26",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "26",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "component27",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "27",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "component28",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "28",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "component29",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "29",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "component30",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "30",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "component31",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "31",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "component32",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "32",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "component33",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "33",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "component34",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "34",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 2,
+    "thread": 0
+  }
+},
+{
+  "name": "component35",
+  "type": "coreTestElement.message_mesh.enclosing_component",
+  "params": {
+    "id": "35",
+    "mod": "1",
+    "verbose": "True",
+    "stats": "0"
+  },
+  "subcomponents": [
+    {
+      "slot_name": "ports",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 1,
+      "type": "coreTestElement.message_mesh.message_port"
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 2,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "ports",
+      "slot_number": 3,
+      "type": "coreTestElement.message_mesh.port_slot",
+      "subcomponents": [
+        {
+          "slot_name": "port",
+          "slot_number": 0,
+          "type": "coreTestElement.message_mesh.message_port"
+        }
+      ]
+    },
+    {
+      "slot_name": "route",
+      "slot_number": 0,
+      "type": "coreTestElement.message_mesh.route_message"
+    }
+  ],
+  "partition": {
+    "rank": 2,
+    "thread": 0
+  }
+}
+],
+"statistics_group": null,
+"links": [
+{
+  "name": "link_x0y5_x0y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component30:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x1y5_x1y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component31:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x2y5_x2y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component32:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x3y5_x3y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component33:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x4y5_x4y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component34:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x5y5_x5y0",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component35:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 0,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x0y3_x0y4",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component24:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x1y3_x1y4",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component25:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x2y3_x2y4",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component26:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x3y3_x3y4",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component27:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x4y3_x4y4",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component28:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x5y3_x5y4",
+  "noCut": false,
+  "nonlocal": true,
+  "left": {
+    "component": "component29:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "rank": 1,
+    "thread": 0
+  }
+},
+{
+  "name": "link_x0y4_x1y4",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component24:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component25:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y4_x0y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component24:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component29:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y4_x0y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component24:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component30:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y4_x2y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component25:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component26:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y4_x1y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component25:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component31:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y4_x3y4",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component26:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component27:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y4_x2y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component26:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component32:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y4_x4y4",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component27:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component28:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y4_x3y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component27:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component33:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y4_x5y4",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component28:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component29:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y4_x4y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component28:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component34:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y4_x5y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component29:ports[2]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[3]:port[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x0y5_x1y5",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component30:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component31:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x5y5_x0y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component30:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x1y5_x2y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component31:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component32:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x2y5_x3y5",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component32:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component33:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x3y5_x4y5",
+  "noCut": false,
+  "nonlocal": false,
+  "left": {
+    "component": "component33:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component34:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+},
+{
+  "name": "link_x4y5_x5y5",
+  "noCut": true,
+  "nonlocal": false,
+  "left": {
+    "component": "component34:ports[0]",
+    "port": "port0",
+    "latency": "1 ns"
+  },
+  "right": {
+    "component": "component35:ports[1]",
+    "port": "port0",
+    "latency": "1 ns"
+  }
+}
+]
+}


### PR DESCRIPTION
This adds parallel loading tests using sequential and parallel json files.  Note that this is only enabled with MPI tests are enabled (`-DENABLE_MPI_TESTS=ON`).  They also currently run for `devel` branches only.  