### PR TITLE
updates for new tests (-DENABLE_NEW_TESTS=ON) for latest iconsole

### DIFF
--- a/tests/core-debug/cmd-multithread-8thds-NEW.sh
+++ b/tests/core-debug/cmd-multithread-8thds-NEW.sh
@@ -81,7 +81,7 @@ fi
 echo "Found pass string \"$PSTR\""
 
 # info all
-PSTR="Rank:0 Thread:7 (Process"
+PSTR="Rank 0/1 Thread 7/8 (Process"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -91,7 +91,7 @@ fi
 echo "Found pass string \"$PSTR\""
 
 # thread curent for threads 0-7
-PSTR="Rank 0/1, Thread 0/8"
+PSTR="Rank 0/1 Thread 0/8"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -100,7 +100,7 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-PSTR="Rank 0/1, Thread 1/8"
+PSTR="Rank 0/1 Thread 1/8"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -109,7 +109,7 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-PSTR="Rank 0/1, Thread 2/8"
+PSTR="Rank 0/1 Thread 2/8"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -118,7 +118,7 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-PSTR="Rank 0/1, Thread 3/8"
+PSTR="Rank 0/1 Thread 3/8"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -127,7 +127,7 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-PSTR="Rank 0/1, Thread 4/8"
+PSTR="Rank 0/1 Thread 4/8"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -136,7 +136,7 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-PSTR="Rank 0/1, Thread 5/8"
+PSTR="Rank 0/1 Thread 5/8"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -145,7 +145,7 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-PSTR="Rank 0/1, Thread 6/8"
+PSTR="Rank 0/1 Thread 6/8"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -154,7 +154,7 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-PSTR="Rank 0/1, Thread 7/8"
+PSTR="Rank 0/1 Thread 7/8"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -174,7 +174,7 @@ fi
 echo "Found pass string \"$PSTR\""
 
 # shutdown
-PSTR="Rank 0/1, Thread 7/8"
+PSTR="Rank 0/1 Thread 7/8"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then

--- a/tests/core-debug/cmd-multithread-NEW.sh
+++ b/tests/core-debug/cmd-multithread-NEW.sh
@@ -71,7 +71,7 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-PSTR="Rank 0/1, Thread 0/2 (Process"
+PSTR="Rank 0/1 Thread 0/2 (Process"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -91,7 +91,7 @@ fi
 echo "Found pass string \"$PSTR\""
 
 # printStatus
-PSTR="Rank 0/1, Thread 1/2 (Process"
+PSTR="Rank 0/1 Thread 1/2 (Process"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then

--- a/tests/core-debug/cmd-multithread-serial-NEW.sh
+++ b/tests/core-debug/cmd-multithread-serial-NEW.sh
@@ -72,7 +72,7 @@ fi
 echo "Found pass string \"$PSTR\""
 
 # info current
-PSTR="Rank 0/1, Thread 0/1 (Process"
+PSTR="Rank 0/1 Thread 0/1 (Process"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -92,7 +92,7 @@ fi
 echo "Found pass string \"$PSTR\""
 
 # info current 
-PSTR="Rank 0/1, Thread 1/2"
+PSTR="Rank 0/1 Thread 1/2"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -eq 0 ]; then

--- a/tests/core-debug/cmd-t2-replay.sh
+++ b/tests/core-debug/cmd-t2-replay.sh
@@ -40,7 +40,7 @@ confirm false
 # CHECK 0 print cp1\ncp1
 print cp1
 
-# CHECK 1 thread 0\n\n---- Rank0:Thread0: Entering interactive mode
+# CHECK 1 thread 0\n---- Rank0:Thread0: Entering interactive mode
 thread 0
 
 # CHECK 2 print cp0\ncp0

--- a/tests/core-debug/cmd-t4-switch.sh
+++ b/tests/core-debug/cmd-t4-switch.sh
@@ -37,16 +37,16 @@ confirm false
 # The checking convention is: CHECK <id> <regexp>
 # regexp and have multiple \n characters but not a trailing \n
 
-# CHECK 0 thread 1\n\n---- Rank0:Thread1: Entering interactive mode
+# CHECK 0 thread 1\n---- Rank0:Thread1: Entering interactive mode
 thread 1
 
-# CHECK 1 thread 2\n\n---- Rank0:Thread2: Entering interactive mode
+# CHECK 1 thread 2\n---- Rank0:Thread2: Entering interactive mode
 thread 2
 
-# CHECK 2 thread 3\n\n---- Rank0:Thread3: Entering interactive mode
+# CHECK 2 thread 3\n---- Rank0:Thread3: Entering interactive mode
 thread 3
 
-# CHECK 3 thread 0\n\n---- Rank0:Thread0: Entering interactive mode
+# CHECK 3 thread 0\n---- Rank0:Thread0: Entering interactive mode
 thread 0
 
 shutdown


### PR DESCRIPTION
Modified some match strings for new tests to match the latest iconsole.
Must use `-DENABLED_NEW_TESTS=ON` to run these.
