### PR TITLE
remap checkpoint on restart test suite

### DIFF
--- a/scripts/gen-testlist.sh
+++ b/scripts/gen-testlist.sh
@@ -26,7 +26,7 @@ for f in *.sh; do
     END { \
       rangeOK = sstver>=min && sstver<=max; \
       devOK = sstver=="DEV" && max>=999.0; \
-      excluded = ennew=="OFF" && min=="NEW";  \
+      excluded = ennew=="OFF" && min=="DEV";  \
       rc = ((rangeOK || devOK) && (!excluded)) ? 0 : 1; \
       if (dbg==1) {printf("sstver=%2.1f\tmin=%2.1f\tmax=%2.1f\trc=%d\n", sstver, min, max, rc)}; \
       exit(rc)}' $f

--- a/scripts/gen-testlist.sh
+++ b/scripts/gen-testlist.sh
@@ -26,7 +26,7 @@ for f in *.sh; do
     END { \
       rangeOK = sstver>=min && sstver<=max; \
       devOK = sstver=="DEV" && max>=999.0; \
-      excluded = ennew=="OFF" && min=="DEV";  \
+      excluded = ennew=="OFF" && min=="NEW";  \
       rc = ((rangeOK || devOK) && (!excluded)) ? 0 : 1; \
       if (dbg==1) {printf("sstver=%2.1f\tmin=%2.1f\tmax=%2.1f\trc=%d\n", sstver, min, max, rc)}; \
       exit(rc)}' $f

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,10 +58,9 @@ endif()
 
 if (ENABLE_REMAP_TESTS)
   add_subdirectory(remap)
-  # TODO
-  # if(SST_MPI_OK)
-  #   add_subdirectory(remap-mpi)
-  # endif()
+  if(SST_MPI_OK)
+    add_subdirectory(remap-mpi)
+  endif()
 endif()
 
 # -- strictly optional tests

--- a/tests/debug-console-mpi/CMakeLists.txt
+++ b/tests/debug-console-mpi/CMakeLists.txt
@@ -19,6 +19,7 @@ else()
 endif()
 
 #-- Test files supporting current sst version
+message(STATUS "${EXT_TEST_LIST_COMMAND} ${SST_VERSION} ${ENABLE_NEW_TESTS}")
 execute_process(COMMAND ${EXT_TEST_LIST_COMMAND} ${SST_VERSION} ${ENABLE_NEW_TESTS}
                 OUTPUT_VARIABLE TEST_SRCS_TARGET_VER
                 RESULT_VARIABLE EXT_TEST_LIST_RTN

--- a/tests/remap-mpi/CMakeLists.txt
+++ b/tests/remap-mpi/CMakeLists.txt
@@ -1,0 +1,89 @@
+#
+# sst-ext-tests/tests/remap-mpi CMake
+#
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+#EXT_TEST TEST_FILE_EXT sh
+#
+
+set(TEST_FILE_EXT "sh")
+set(passRegex "PASS")
+set(failRegex "ERROR")
+
+if (SST_VALGRIND)
+  set(timeout "600")
+else()
+  set(timeout "60")
+endif()
+
+#-- Test files supporting current sst version
+execute_process(COMMAND ${EXT_TEST_LIST_COMMAND} ${SST_VERSION} ${ENABLE_NEW_TESTS}
+                OUTPUT_VARIABLE TEST_SRCS_TARGET_VER
+                RESULT_VARIABLE EXT_TEST_LIST_RTN
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+#-- Convert test string to a list
+if(TEST_SRCS_TARGET_VER)
+string(REPLACE " " ";" TEST_SRCS_TARGET_VER ${TEST_SRCS_TARGET_VER})
+message(STATUS "Included tests from ${CMAKE_CURRENT_SOURCE_DIR}: ${TEST_SRCS_TARGET_VER}")
+else()
+  message(STATUS "No tests included from ${CMAKE_CURRENT_SOURCE_DIR}")
+endif()
+
+#-- Iterate over valid tests for the current SST version
+foreach(testSrc ${TEST_SRCS_TARGET_VER})
+  # Extract the file name
+  get_filename_component(testName ${testSrc} NAME_WLE)
+  # Check SST component dependencies
+  execute_process(COMMAND ${EXT_TEST_DEP_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${testSrc}
+                OUTPUT_VARIABLE EXT_TEST_CHECK
+                RESULT_VARIABLE EXT_TEST_RTN
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+		ERROR_QUIET
+  )
+  message(STATUS "Dep Check ${testSrc} = ${EXT_TEST_CHECK}")
+
+  # Get timeout setting
+  execute_process(COMMAND ${EXT_TEST_TIMEOUT_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${testSrc}
+                OUTPUT_VARIABLE EXT_TEST_TIMEOUT
+                RESULT_VARIABLE EXT_TEST_RTN
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
+  )
+
+  if(NOT EXT_TEST_RTN EQUAL "0")
+      message(FATAL_ERROR "${EXT_TEST_TIMEOUT_COMMAND} failed")
+  endif()
+
+  if (SST_VALGRIND)
+    if(${EXT_TEST_TIMEOUT} EQUAL 0)
+      set(EXT_TEST_TIMEOUT ${timeout})
+    else()
+      math(EXPR EXT_TEST_TIMEOUT "${EXT_TEST_TIMEOUT} * 10")
+    endif()
+  endif()
+
+  # Add the tests for execution
+  if( "${EXT_TEST_CHECK}" STREQUAL "RUN" )
+    add_test(NAME ${testName}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      COMMAND ./${testSrc})
+    set_property(TEST ${testName} PROPERTY LABELS "${SST_VERSION}")
+    set_property(TEST ${testName} PROPERTY FAIL_REGULAR_EXPRESSION "${failRegex}")
+    set_property(TEST ${testName} PROPERTY PASS_REGULAR_EXPRESSION "${passRegex}")
+    set_property(TEST ${testName} PROPERTY ENVIRONMENT "SST_COMPONENT_BASE=$ENV{SST_COMPONENT_BASE}")
+    # Run one MPI test at a time
+    set_property(TEST ${testName} PROPERTY RUN_SERIAL TRUE)
+    if(NOT ${EXT_TEST_TIMEOUT} EQUAL 0)
+      set_property(TEST ${testName} PROPERTY TIMEOUT ${EXT_TEST_TIMEOUT})
+      message(STATUS "Runtime ${testSrc} = ${EXT_TEST_TIMEOUT}")
+    else()
+      set_property(TEST ${testName} PROPERTY TIMEOUT ${timeout})
+    endif()
+  endif()
+endforeach(testSrc)
+
+# EOF

--- a/tests/remap-mpi/remap-combo-2r4t.sh
+++ b/tests/remap-mpi/remap-combo-2r4t.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "2 ranks, 4 threads/rank checkpointed. Restart repartioning with even combos"
+#EXT_TEST TIMEOUT 120
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# first pair is ranks and threads for checkpointed simulation.
+# remaining pairs are for repartioned restart simulations
+
+#            cpt   -- 1r rst  --   - 2r -   - 4r -    -8r-
+./rt2rt.bash 2 4   1 8  1 4  1 2   2 2 2 1  4 2 4 1   8 1   || exit 1
+
+echo "remap-combo-2r4t.sh passed"
+wait

--- a/tests/remap-mpi/remap-combo-2r4t.sh
+++ b/tests/remap-mpi/remap-combo-2r4t.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_MINVER DEV
 #EXT_TEST TEST_FILE_DESC "2 ranks, 4 threads/rank checkpointed. Restart repartioning with even combos"
 #EXT_TEST TIMEOUT 300
 

--- a/tests/remap-mpi/remap-combo-2r4t.sh
+++ b/tests/remap-mpi/remap-combo-2r4t.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER NEW
 #EXT_TEST TEST_FILE_DESC "2 ranks, 4 threads/rank checkpointed. Restart repartioning with even combos"
-#EXT_TEST TIMEOUT 120
+#EXT_TEST TIMEOUT 300
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
 set -uo pipefail

--- a/tests/remap-mpi/remap-combo-4r2t.sh
+++ b/tests/remap-mpi/remap-combo-4r2t.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER NEW
 #EXT_TEST TEST_FILE_DESC "4 ranks, 2 threads/rank checkpointed. Restart repartioning with even combos"
-#EXT_TEST TIMEOUT 120
+#EXT_TEST TIMEOUT 300
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
 set -uo pipefail

--- a/tests/remap-mpi/remap-combo-4r2t.sh
+++ b/tests/remap-mpi/remap-combo-4r2t.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_MINVER DEV
 #EXT_TEST TEST_FILE_DESC "4 ranks, 2 threads/rank checkpointed. Restart repartioning with even combos"
 #EXT_TEST TIMEOUT 300
 

--- a/tests/remap-mpi/remap-combo-4r2t.sh
+++ b/tests/remap-mpi/remap-combo-4r2t.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "4 ranks, 2 threads/rank checkpointed. Restart repartioning with even combos"
+#EXT_TEST TIMEOUT 120
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# first pair is ranks and threads for checkpointed simulation.
+# remaining pairs are for repartioned restart simulations
+
+#            cpt   -- 1r rst  --     - 2r -      -8r-
+./rt2rt.bash 4 2   1 8  1 4  1 2   2 4 2 2 2 1   8 1 || exit 1
+
+echo "remap-combo-4r2t.sh passed"
+wait

--- a/tests/remap-mpi/remap-combo-8r1t.sh
+++ b/tests/remap-mpi/remap-combo-8r1t.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "8 ranks, 1 thread/rank checkpointed. Restart repartioning with even combos"
+#EXT_TEST TIMEOUT 120
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# first pair is ranks and threads for checkpointed simulation.
+# remaining pairs are for repartioned restart simulations
+
+#            cpt   -- 1r rst  --      - 2r -       -4r-
+./rt2rt.bash 8 1   1 8  1 4  1 2   2 4 2 2 2 1   4 2 4 1 || exit 1
+
+echo "remap-combo-8r1t.sh passed"
+wait

--- a/tests/remap-mpi/remap-combo-8r1t.sh
+++ b/tests/remap-mpi/remap-combo-8r1t.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER NEW
 #EXT_TEST TEST_FILE_DESC "8 ranks, 1 thread/rank checkpointed. Restart repartioning with even combos"
-#EXT_TEST TIMEOUT 120
+#EXT_TEST TIMEOUT 300
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
 set -uo pipefail

--- a/tests/remap-mpi/remap-combo-8r1t.sh
+++ b/tests/remap-mpi/remap-combo-8r1t.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_MINVER DEV
 #EXT_TEST TEST_FILE_DESC "8 ranks, 1 thread/rank checkpointed. Restart repartioning with even combos"
 #EXT_TEST TIMEOUT 300
 

--- a/tests/remap-mpi/remap-ranks-2to1.sh
+++ b/tests/remap-mpi/remap-ranks-2to1.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_DESC "2 rank checkpointed to 1 rank restart"
+#EXT_TEST TIMEOUT 120
+
+./rt2rt.bash 2 1 1 1

--- a/tests/remap-mpi/remap-ranks-2to2.sh
+++ b/tests/remap-mpi/remap-ranks-2to2.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_DESC "2 rank checkpointed to 2 rank restart"
+#EXT_TEST TIMEOUT 120
+
+./rt2rt.bash 2 1 2 1

--- a/tests/remap-mpi/remap-ranks-3to1.sh
+++ b/tests/remap-mpi/remap-ranks-3to1.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_DESC "3 rank checkpointed to 1 rank restart"
+#EXT_TEST TIMEOUT 120
+
+./rt2rt.bash 3 1 1 1

--- a/tests/remap-mpi/remap-ranks-3to3.sh
+++ b/tests/remap-mpi/remap-ranks-3to3.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_DESC "3 rank checkpointed to 3 rank restart"
+#EXT_TEST TIMEOUT 120
+
+./rt2rt.bash 3 1 3 1

--- a/tests/remap-mpi/remap-ranks-4to1.sh
+++ b/tests/remap-mpi/remap-ranks-4to1.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_DESC "4 rank checkpointed to 1 rank restart"
+#EXT_TEST TIMEOUT 120
+
+./rt2rt.bash 4 1 1 1

--- a/tests/remap-mpi/remap-ranks-4to4.sh
+++ b/tests/remap-mpi/remap-ranks-4to4.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_DESC "4 rank checkpointed to 4 rank restart"
+#EXT_TEST TIMEOUT 120
+
+./rt2rt.bash 4 1 4 1

--- a/tests/remap-mpi/remap-ranks-5to1.sh
+++ b/tests/remap-mpi/remap-ranks-5to1.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_DESC "5 rank checkpointed to 1 rank restart"
+#EXT_TEST TIMEOUT 120
+
+./rt2rt.bash 5 1 1 1

--- a/tests/remap-mpi/remap-ranks-5to5.sh
+++ b/tests/remap-mpi/remap-ranks-5to5.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_DESC "5 rank checkpointed to 5 rank restart"
+#EXT_TEST TIMEOUT 120
+
+./rt2rt.bash 5 1 5 1

--- a/tests/remap-mpi/remap-ranks-6to1.sh
+++ b/tests/remap-mpi/remap-ranks-6to1.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_DESC "6 rank checkpointed to 1 rank restart"
+#EXT_TEST TIMEOUT 120
+
+./rt2rt.bash 6 1 1 1

--- a/tests/remap-mpi/remap-ranks-6to6.sh
+++ b/tests/remap-mpi/remap-ranks-6to6.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_DESC "6 rank checkpointed to 6 rank restart"
+#EXT_TEST TIMEOUT 120
+
+./rt2rt.bash 6 1 6 1

--- a/tests/remap-mpi/remap-ranks-7to1.sh
+++ b/tests/remap-mpi/remap-ranks-7to1.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_DESC "7 rank checkpointed to 1 rank restart"
+#EXT_TEST TIMEOUT 120
+
+./rt2rt.bash 7 1 1 1

--- a/tests/remap-mpi/remap-ranks-7to7.sh
+++ b/tests/remap-mpi/remap-ranks-7to7.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_DESC "7 rank checkpointed to 7 rank restart"
+#EXT_TEST TIMEOUT 120
+
+./rt2rt.bash 7 1 7 1

--- a/tests/remap-mpi/remap-ranks-8to1.sh
+++ b/tests/remap-mpi/remap-ranks-8to1.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_DESC "8 rank checkpointed repartitioned to 1 rank restart"
+#EXT_TEST TIMEOUT 120
+
+./rt2rt.bash 8 1 1 1

--- a/tests/remap-mpi/remap-ranks-8to8.sh
+++ b/tests/remap-mpi/remap-ranks-8to8.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_DESC "8 rank checkpointed to 8 rank restart"
+#EXT_TEST TIMEOUT 120
+
+./rt2rt.bash 8 1 8 1

--- a/tests/remap-mpi/remap-ranks-Nto2.sh
+++ b/tests/remap-mpi/remap-ranks-Nto2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER NEW
 #EXT_TEST TEST_FILE_DESC "1,3:8 ranks checkpointed repartitioned to 2 ranks on restart"
-#EXT_TEST TIMEOUT 120
+#EXT_TEST TIMEOUT 300
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
 set -uo pipefail

--- a/tests/remap-mpi/remap-ranks-Nto2.sh
+++ b/tests/remap-mpi/remap-ranks-Nto2.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_MINVER DEV
 #EXT_TEST TEST_FILE_DESC "1,3:8 ranks checkpointed repartitioned to 2 ranks on restart"
 #EXT_TEST TIMEOUT 300
 

--- a/tests/remap-mpi/remap-ranks-Nto2.sh
+++ b/tests/remap-mpi/remap-ranks-Nto2.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "1,3:8 ranks checkpointed repartitioned to 2 ranks on restart"
+#EXT_TEST TIMEOUT 120
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+./rt2rt.bash 1 1 2 1|| exit 1
+
+./rt2rt.bash 3 1 2 1|| exit 3
+./rt2rt.bash 4 1 2 1|| exit 4
+./rt2rt.bash 5 1 2 1|| exit 5
+./rt2rt.bash 6 1 2 1|| exit 6
+./rt2rt.bash 7 1 2 1|| exit 7
+./rt2rt.bash 8 1 2 1|| exit 8
+
+echo "remap-ranks-Nto2.sh passed"
+wait
+
+

--- a/tests/remap-mpi/remap-ranks-Nto3.sh
+++ b/tests/remap-mpi/remap-ranks-Nto3.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_MINVER DEV
 #EXT_TEST TEST_FILE_DESC "1:2,4:8 ranks checkpointed repartitioned to 3 ranks on restart"
 #EXT_TEST TIMEOUT 300
 

--- a/tests/remap-mpi/remap-ranks-Nto3.sh
+++ b/tests/remap-mpi/remap-ranks-Nto3.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "1:2,4:8 ranks checkpointed repartitioned to 3 ranks on restart"
+#EXT_TEST TIMEOUT 120
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+./rt2rt.bash 1 1 3 1|| exit 1
+./rt2rt.bash 2 1 3 1|| exit 2
+
+./rt2rt.bash 4 1 3 1|| exit 4
+./rt2rt.bash 5 1 3 1|| exit 5
+./rt2rt.bash 6 1 3 1|| exit 6
+./rt2rt.bash 7 1 3 1|| exit 7
+./rt2rt.bash 8 1 3 1|| exit 8
+
+echo "remap-ranks-Nto3.sh passed"
+wait
+
+

--- a/tests/remap-mpi/remap-ranks-Nto3.sh
+++ b/tests/remap-mpi/remap-ranks-Nto3.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER NEW
 #EXT_TEST TEST_FILE_DESC "1:2,4:8 ranks checkpointed repartitioned to 3 ranks on restart"
-#EXT_TEST TIMEOUT 120
+#EXT_TEST TIMEOUT 300
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
 set -uo pipefail

--- a/tests/remap-mpi/remap-ranks-Nto4.sh
+++ b/tests/remap-mpi/remap-ranks-Nto4.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER NEW
 #EXT_TEST TEST_FILE_DESC "1:3,5:8 ranks checkpointed repartitioned to 4 ranks on restart"
-#EXT_TEST TIMEOUT 120
+#EXT_TEST TIMEOUT 300
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
 set -uo pipefail

--- a/tests/remap-mpi/remap-ranks-Nto4.sh
+++ b/tests/remap-mpi/remap-ranks-Nto4.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "1:3,5:8 ranks checkpointed repartitioned to 4 ranks on restart"
+#EXT_TEST TIMEOUT 120
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+./rt2rt.bash 1 1 4 1|| exit 1
+./rt2rt.bash 2 1 4 1|| exit 2
+./rt2rt.bash 3 1 4 1|| exit 3
+
+./rt2rt.bash 5 1 4 1|| exit 5
+./rt2rt.bash 6 1 4 1|| exit 6
+./rt2rt.bash 7 1 4 1|| exit 7
+./rt2rt.bash 8 1 4 1|| exit 8
+
+echo "remap-ranks-Nto4.sh passed"
+wait
+
+

--- a/tests/remap-mpi/remap-ranks-Nto4.sh
+++ b/tests/remap-mpi/remap-ranks-Nto4.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_MINVER DEV
 #EXT_TEST TEST_FILE_DESC "1:3,5:8 ranks checkpointed repartitioned to 4 ranks on restart"
 #EXT_TEST TIMEOUT 300
 

--- a/tests/remap-mpi/remap-ranks-Nto5.sh
+++ b/tests/remap-mpi/remap-ranks-Nto5.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER NEW
 #EXT_TEST TEST_FILE_DESC "1:4,6:8 ranks checkpointed repartitioned to 5 ranks on restart"
-#EXT_TEST TIMEOUT 120
+#EXT_TEST TIMEOUT 300
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
 set -uo pipefail

--- a/tests/remap-mpi/remap-ranks-Nto5.sh
+++ b/tests/remap-mpi/remap-ranks-Nto5.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "1:4,6:8 ranks checkpointed repartitioned to 5 ranks on restart"
+#EXT_TEST TIMEOUT 120
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+./rt2rt.bash 1 1 5 1|| exit 1
+./rt2rt.bash 2 1 5 1|| exit 2
+./rt2rt.bash 3 1 5 1|| exit 3
+./rt2rt.bash 4 1 5 1|| exit 4
+
+./rt2rt.bash 6 1 5 1|| exit 6
+./rt2rt.bash 7 1 5 1|| exit 7
+./rt2rt.bash 8 1 5 1|| exit 8
+
+echo "remap-ranks-Nto5.sh passed"
+wait
+
+

--- a/tests/remap-mpi/remap-ranks-Nto5.sh
+++ b/tests/remap-mpi/remap-ranks-Nto5.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_MINVER DEV
 #EXT_TEST TEST_FILE_DESC "1:4,6:8 ranks checkpointed repartitioned to 5 ranks on restart"
 #EXT_TEST TIMEOUT 300
 

--- a/tests/remap-mpi/remap-ranks-Nto6.sh
+++ b/tests/remap-mpi/remap-ranks-Nto6.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER NEW
 #EXT_TEST TEST_FILE_DESC "1:5,7:8 ranks checkpointed repartitioned to 6 ranks on restart"
-#EXT_TEST TIMEOUT 120
+#EXT_TEST TIMEOUT 300
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
 set -uo pipefail

--- a/tests/remap-mpi/remap-ranks-Nto6.sh
+++ b/tests/remap-mpi/remap-ranks-Nto6.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_MINVER DEV
 #EXT_TEST TEST_FILE_DESC "1:5,7:8 ranks checkpointed repartitioned to 6 ranks on restart"
 #EXT_TEST TIMEOUT 300
 

--- a/tests/remap-mpi/remap-ranks-Nto6.sh
+++ b/tests/remap-mpi/remap-ranks-Nto6.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "1:5,7:8 ranks checkpointed repartitioned to 6 ranks on restart"
+#EXT_TEST TIMEOUT 120
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+./rt2rt.bash 1 1 6 1|| exit 1
+./rt2rt.bash 2 1 6 1|| exit 2
+./rt2rt.bash 3 1 6 1|| exit 3
+./rt2rt.bash 4 1 6 1|| exit 4
+./rt2rt.bash 5 1 6 1|| exit 5
+
+./rt2rt.bash 7 1 6 1|| exit 7
+./rt2rt.bash 8 1 6 1|| exit 8
+
+echo "remap-ranks-Nto6.sh passed"
+wait
+
+

--- a/tests/remap-mpi/remap-ranks-Nto7.sh
+++ b/tests/remap-mpi/remap-ranks-Nto7.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER NEW
 #EXT_TEST TEST_FILE_DESC "1:6,8 ranks checkpointed repartitioned to 7 ranks on restart"
-#EXT_TEST TIMEOUT 120
+#EXT_TEST TIMEOUT 300
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
 set -uo pipefail

--- a/tests/remap-mpi/remap-ranks-Nto7.sh
+++ b/tests/remap-mpi/remap-ranks-Nto7.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "1:6,8 ranks checkpointed repartitioned to 7 ranks on restart"
+#EXT_TEST TIMEOUT 120
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+./rt2rt.bash 1 1 7 1|| exit 2
+./rt2rt.bash 2 1 7 1|| exit 2
+./rt2rt.bash 3 1 7 1|| exit 3
+./rt2rt.bash 4 1 7 1|| exit 4
+./rt2rt.bash 5 1 7 1|| exit 5
+./rt2rt.bash 6 1 7 1|| exit 6
+
+./rt2rt.bash 8 1 7 1|| exit 8
+
+echo "remap-ranks-Nto7.sh passed"
+wait
+
+

--- a/tests/remap-mpi/remap-ranks-Nto7.sh
+++ b/tests/remap-mpi/remap-ranks-Nto7.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_MINVER DEV
 #EXT_TEST TEST_FILE_DESC "1:6,8 ranks checkpointed repartitioned to 7 ranks on restart"
 #EXT_TEST TIMEOUT 300
 

--- a/tests/remap-mpi/remap-ranks-Nto8.sh
+++ b/tests/remap-mpi/remap-ranks-Nto8.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_MINVER DEV
 #EXT_TEST TEST_FILE_DESC "1 to 7 ranks checkpointed repartitioned to 8 ranks on restart"
 #EXT_TEST TIMEOUT 300
 

--- a/tests/remap-mpi/remap-ranks-Nto8.sh
+++ b/tests/remap-mpi/remap-ranks-Nto8.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER NEW
 #EXT_TEST TEST_FILE_DESC "1 to 7 ranks checkpointed repartitioned to 8 ranks on restart"
-#EXT_TEST TIMEOUT 120
+#EXT_TEST TIMEOUT 300
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
 set -uo pipefail

--- a/tests/remap-mpi/remap-ranks-Nto8.sh
+++ b/tests/remap-mpi/remap-ranks-Nto8.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "1 to 7 ranks checkpointed repartitioned to 8 ranks on restart"
+#EXT_TEST TIMEOUT 120
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+./rt2rt.bash 1 1 8 1 || exit 1
+./rt2rt.bash 2 1 8 1|| exit 2
+./rt2rt.bash 3 1 8 1|| exit 3
+./rt2rt.bash 4 1 8 1|| exit 4
+./rt2rt.bash 5 1 8 1|| exit 5
+./rt2rt.bash 6 1 8 1|| exit 6
+./rt2rt.bash 7 1 8 1|| exit 7
+
+echo "remap-ranks-Nto8.sh passed"
+wait
+
+

--- a/tests/remap-mpi/rt2rt.bash
+++ b/tests/remap-mpi/rt2rt.bash
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+# See LICENSE in the top level directory for licensing details
+#
+# rt2rt.sh
+
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+if [ "$#" -lt 4 ]; then
+  echo "Usage: rt2rt.bash cpt_ranks cpt_threads_per_rank {restart rank thread pairs}"
+  exit 1
+fi
+
+ranks_cpt=$1
+shift
+threads_cpt=$1
+shift
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Settings
+CLEANUP=1
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}_${ranks_cpt}.${threads_cpt}_$$"
+echo "TESTNAME=$TNAME"
+LOGFILE=${TNAME}.log
+PFX="cpt_${TNAME}"
+CONFIG="../remap/loop101.py"
+TIMING_INFO="${TNAME}.json"
+
+OS_TYPE=$(uname -s)
+MPIOPTS=""
+if [ ${OS_TYPE} = "Linux" ]; then
+  MPIOPTS="--bind-to socket"
+fi
+
+# Clean up old checkpoint directory
+rm -rf ${PFX}*
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="mpirun ${MPIOPTS} -np ${ranks_cpt} sst --num-threads=${threads_cpt} --timing-info-json=${TIMING_INFO} --checkpoint-sim-period=98047ns --checkpoint-prefix=$PFX --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
+echo $LAUNCH
+$LAUNCH | tee $LOGFILE
+retVal=$?
+echo $TNAME Checkpointing simulation complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+echo "Checkpoints: "
+ls ${PFX}
+
+n=$(ls ${PFX} | wc -l)
+if [[ $n -lt 10 ]]; then
+  echo "ERROR: expected at least 10 checkpoints but found $n"
+  exit 1
+fi
+
+PSTR="Simulation is complete, simulated time: 1.0017 ms"
+egrep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# Restart each pair from command line argument pairs
+
+while [ "$#" -gt 0 ]; do
+  # get the next rank - thread pair
+  ranks_rst=$1
+  shift
+  if [ $? -ne 0 ]; then
+    echo "[rt2rt.bash] error: invalid pair following $1"
+    exit -1
+  fi
+  threads_rst=$1
+  shift
+
+  # Rerun all the checkpoints for this pair
+  echo "Restarting from all checkpoints using ${ranks_rst} ranks and ${threads_rst} per rank"
+  n=0
+  for cptfile in ${PFX}/${PFX}_*/${PFX}_*.sstcpt; do
+
+    ((n++))
+    LAUNCH="mpirun ${MPIOPTS} -np ${ranks_rst} sst --num-threads=${threads_rst} --load-checkpoint --timing-info-json=${TIMING_INFO}  ${cptfile}"
+    echo $LAUNCH
+    $LAUNCH | tee $LOGFILE
+    retVal=$?
+    echo $TNAME Restart of ${cptfile} complete
+
+    if [ $retVal -ne 0 ]; then
+      echo "ERROR $TNAME restart of ${cptfile} returned $retVal"
+      exit $retVal
+    fi
+
+    egrep "$PSTR" $LOGFILE > /dev/null
+    retVal=$?
+    if [ $retVal -ne 0 ]; then
+      echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+      exit $retVal
+    fi
+    echo "Found pass string \"$PSTR\" for restart of ${cptfile}"
+
+  done
+
+  if [[ $n -lt 10 ]]; then
+    echo "ERROR: expected at least 10 restart simulations but found $n"
+    exit 1
+  fi
+
+done
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $TIMING_INFO
+  rm -rf ${PFX}*
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/remap-mpi/rt2rt.bash
+++ b/tests/remap-mpi/rt2rt.bash
@@ -45,7 +45,7 @@ fi
 rm -rf ${PFX}*
 
 # Launch the program to start interactive mode at time 0
-LAUNCH="mpirun ${MPIOPTS} -np ${ranks_cpt} sst --num-threads=${threads_cpt} --checkpoint-sim-period=98047ns --checkpoint-prefix=$PFX --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
+LAUNCH="mpirun ${MPIOPTS} -np ${ranks_cpt} sst --num-threads=${threads_cpt} --checkpoint-sim-period=330003ns --checkpoint-prefix=$PFX --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0 --numComps=24 --clocks=1000000"
 echo $LAUNCH
 $LAUNCH | tee $LOGFILE
 retVal=$?
@@ -61,8 +61,8 @@ echo "Checkpoints: "
 ls ${PFX}
 
 n=$(ls ${PFX} | wc -l)
-if [[ $n -lt 10 ]]; then
-  echo "ERROR: expected at least 10 checkpoints but found $n"
+if [[ $n -lt 3 ]]; then
+  echo "ERROR: expected at least 3 checkpoints but found $n"
   exit 1
 fi
 
@@ -115,8 +115,8 @@ while [ "$#" -gt 0 ]; do
 
   done
 
-  if [[ $n -lt 10 ]]; then
-    echo "ERROR: expected at least 10 restart simulations but found $n"
+  if [[ $n -lt 3 ]]; then
+    echo "ERROR: expected at least 3 restart simulations but found $n"
     exit 1
   fi
 

--- a/tests/remap-mpi/rt2rt.bash
+++ b/tests/remap-mpi/rt2rt.bash
@@ -34,7 +34,6 @@ echo "TESTNAME=$TNAME"
 LOGFILE=${TNAME}.log
 PFX="cpt_${TNAME}"
 CONFIG="../remap/loop101.py"
-TIMING_INFO="${TNAME}.json"
 
 OS_TYPE=$(uname -s)
 MPIOPTS=""
@@ -46,7 +45,7 @@ fi
 rm -rf ${PFX}*
 
 # Launch the program to start interactive mode at time 0
-LAUNCH="mpirun ${MPIOPTS} -np ${ranks_cpt} sst --num-threads=${threads_cpt} --timing-info-json=${TIMING_INFO} --checkpoint-sim-period=98047ns --checkpoint-prefix=$PFX --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
+LAUNCH="mpirun ${MPIOPTS} -np ${ranks_cpt} sst --num-threads=${threads_cpt} --checkpoint-sim-period=98047ns --checkpoint-prefix=$PFX --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
 echo $LAUNCH
 $LAUNCH | tee $LOGFILE
 retVal=$?
@@ -95,7 +94,7 @@ while [ "$#" -gt 0 ]; do
   for cptfile in ${PFX}/${PFX}_*/${PFX}_*.sstcpt; do
 
     ((n++))
-    LAUNCH="mpirun ${MPIOPTS} -np ${ranks_rst} sst --num-threads=${threads_rst} --load-checkpoint --timing-info-json=${TIMING_INFO}  ${cptfile}"
+    LAUNCH="mpirun ${MPIOPTS} -np ${ranks_rst} sst --num-threads=${threads_rst} --load-checkpoint ${cptfile}"
     echo $LAUNCH
     $LAUNCH | tee $LOGFILE
     retVal=$?
@@ -125,7 +124,7 @@ done
 
 # Cleanup output file on pass
 if [ $CLEANUP -eq 1 ]; then
-  rm -f $LOGFILE $TIMING_INFO
+  rm -f $LOGFILE
   rm -rf ${PFX}*
 fi
 

--- a/tests/remap/remap-threads-Nto2.sh
+++ b/tests/remap/remap-threads-Nto2.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "1,3:8 threads checkpointed repartitioned to 2 threads on restart"
+#EXT_TEST TIMEOUT 120
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+./thread2thread.bash 1 2|| exit 1
+
+./thread2thread.bash 3 2|| exit 3
+./thread2thread.bash 4 2|| exit 4
+./thread2thread.bash 5 2|| exit 5
+./thread2thread.bash 6 2|| exit 6
+./thread2thread.bash 7 2|| exit 7
+./thread2thread.bash 8 2|| exit 8
+
+echo "remap-threads-Nto2.sh passed"
+wait
+
+

--- a/tests/remap/remap-threads-Nto2.sh
+++ b/tests/remap/remap-threads-Nto2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER NEW
 #EXT_TEST TEST_FILE_DESC "1,3:8 threads checkpointed repartitioned to 2 threads on restart"
-#EXT_TEST TIMEOUT 120
+#EXT_TEST TIMEOUT 300
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
 set -uo pipefail

--- a/tests/remap/remap-threads-Nto2.sh
+++ b/tests/remap/remap-threads-Nto2.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_MINVER DEV
 #EXT_TEST TEST_FILE_DESC "1,3:8 threads checkpointed repartitioned to 2 threads on restart"
 #EXT_TEST TIMEOUT 300
 

--- a/tests/remap/remap-threads-Nto3.sh
+++ b/tests/remap/remap-threads-Nto3.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_MINVER DEV
 #EXT_TEST TEST_FILE_DESC "1:2,4:8 threads checkpointed repartitioned to 3 threads on restart"
 #EXT_TEST TIMEOUT 300
 

--- a/tests/remap/remap-threads-Nto3.sh
+++ b/tests/remap/remap-threads-Nto3.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER NEW
 #EXT_TEST TEST_FILE_DESC "1:2,4:8 threads checkpointed repartitioned to 3 threads on restart"
-#EXT_TEST TIMEOUT 120
+#EXT_TEST TIMEOUT 300
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
 set -uo pipefail

--- a/tests/remap/remap-threads-Nto3.sh
+++ b/tests/remap/remap-threads-Nto3.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "1:2,4:8 threads checkpointed repartitioned to 3 threads on restart"
+#EXT_TEST TIMEOUT 120
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+./thread2thread.bash 1 3|| exit 1
+./thread2thread.bash 2 3|| exit 2
+
+./thread2thread.bash 4 3|| exit 4
+./thread2thread.bash 5 3|| exit 5
+./thread2thread.bash 6 3|| exit 6
+./thread2thread.bash 7 3|| exit 7
+./thread2thread.bash 8 3|| exit 8
+
+echo "remap-threads-Nto3.sh passed"
+wait
+
+

--- a/tests/remap/remap-threads-Nto4.sh
+++ b/tests/remap/remap-threads-Nto4.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER NEW
 #EXT_TEST TEST_FILE_DESC "1:3,5:8 threads checkpointed repartitioned to 4 threads on restart"
-#EXT_TEST TIMEOUT 120
+#EXT_TEST TIMEOUT 300
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
 set -uo pipefail

--- a/tests/remap/remap-threads-Nto4.sh
+++ b/tests/remap/remap-threads-Nto4.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "1:3,5:8 threads checkpointed repartitioned to 4 threads on restart"
+#EXT_TEST TIMEOUT 120
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+./thread2thread.bash 1 4|| exit 1
+./thread2thread.bash 2 4|| exit 2
+./thread2thread.bash 3 4|| exit 3
+
+./thread2thread.bash 5 4|| exit 5
+./thread2thread.bash 6 4|| exit 6
+./thread2thread.bash 7 4|| exit 7
+./thread2thread.bash 8 4|| exit 8
+
+echo "remap-threads-Nto4.sh passed"
+wait
+
+

--- a/tests/remap/remap-threads-Nto4.sh
+++ b/tests/remap/remap-threads-Nto4.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_MINVER DEV
 #EXT_TEST TEST_FILE_DESC "1:3,5:8 threads checkpointed repartitioned to 4 threads on restart"
 #EXT_TEST TIMEOUT 300
 

--- a/tests/remap/remap-threads-Nto5.sh
+++ b/tests/remap/remap-threads-Nto5.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER NEW
 #EXT_TEST TEST_FILE_DESC "1:4,6:8 threads checkpointed repartitioned to 5 threads on restart"
-#EXT_TEST TIMEOUT 120
+#EXT_TEST TIMEOUT 300
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
 set -uo pipefail

--- a/tests/remap/remap-threads-Nto5.sh
+++ b/tests/remap/remap-threads-Nto5.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "1:4,6:8 threads checkpointed repartitioned to 5 threads on restart"
+#EXT_TEST TIMEOUT 120
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+./thread2thread.bash 1 5|| exit 1
+./thread2thread.bash 2 5|| exit 2
+./thread2thread.bash 3 5|| exit 3
+./thread2thread.bash 4 5|| exit 4
+
+./thread2thread.bash 6 5|| exit 6
+./thread2thread.bash 7 5|| exit 7
+./thread2thread.bash 8 5|| exit 8
+
+echo "remap-threads-Nto5.sh passed"
+wait
+
+

--- a/tests/remap/remap-threads-Nto5.sh
+++ b/tests/remap/remap-threads-Nto5.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_MINVER DEV
 #EXT_TEST TEST_FILE_DESC "1:4,6:8 threads checkpointed repartitioned to 5 threads on restart"
 #EXT_TEST TIMEOUT 300
 

--- a/tests/remap/remap-threads-Nto6.sh
+++ b/tests/remap/remap-threads-Nto6.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER NEW
 #EXT_TEST TEST_FILE_DESC "1:5,7:8 threads checkpointed repartitioned to 6 threads on restart"
-#EXT_TEST TIMEOUT 120
+#EXT_TEST TIMEOUT 300
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
 set -uo pipefail

--- a/tests/remap/remap-threads-Nto6.sh
+++ b/tests/remap/remap-threads-Nto6.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_MINVER DEV
 #EXT_TEST TEST_FILE_DESC "1:5,7:8 threads checkpointed repartitioned to 6 threads on restart"
 #EXT_TEST TIMEOUT 300
 

--- a/tests/remap/remap-threads-Nto6.sh
+++ b/tests/remap/remap-threads-Nto6.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "1:5,7:8 threads checkpointed repartitioned to 6 threads on restart"
+#EXT_TEST TIMEOUT 120
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+./thread2thread.bash 1 6|| exit 1
+./thread2thread.bash 2 6|| exit 2
+./thread2thread.bash 3 6|| exit 3
+./thread2thread.bash 4 6|| exit 4
+./thread2thread.bash 5 6|| exit 5
+
+./thread2thread.bash 7 6|| exit 7
+./thread2thread.bash 8 6|| exit 8
+
+echo "remap-threads-Nto6.sh passed"
+wait
+
+

--- a/tests/remap/remap-threads-Nto7.sh
+++ b/tests/remap/remap-threads-Nto7.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_MINVER DEV
 #EXT_TEST TEST_FILE_DESC "1:6,8 threads checkpointed repartitioned to 7 threads on restart"
 #EXT_TEST TIMEOUT 300
 

--- a/tests/remap/remap-threads-Nto7.sh
+++ b/tests/remap/remap-threads-Nto7.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER NEW
 #EXT_TEST TEST_FILE_DESC "1:6,8 threads checkpointed repartitioned to 7 threads on restart"
-#EXT_TEST TIMEOUT 120
+#EXT_TEST TIMEOUT 300
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
 set -uo pipefail

--- a/tests/remap/remap-threads-Nto7.sh
+++ b/tests/remap/remap-threads-Nto7.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "1:6,8 threads checkpointed repartitioned to 7 threads on restart"
+#EXT_TEST TIMEOUT 120
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+./thread2thread.bash 1 7|| exit 2
+./thread2thread.bash 2 7|| exit 2
+./thread2thread.bash 3 7|| exit 3
+./thread2thread.bash 4 7|| exit 4
+./thread2thread.bash 5 7|| exit 5
+./thread2thread.bash 6 7|| exit 6
+
+./thread2thread.bash 8 7|| exit 8
+
+echo "remap-threads-Nto7.sh passed"
+wait
+
+

--- a/tests/remap/remap-threads-Nto8.sh
+++ b/tests/remap/remap-threads-Nto8.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_MINVER DEV
 #EXT_TEST TEST_FILE_DESC "1 to 7 threads checkpointed repartitioned to 8 threads on restart"
 #EXT_TEST TIMEOUT 300
 

--- a/tests/remap/remap-threads-Nto8.sh
+++ b/tests/remap/remap-threads-Nto8.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "1 to 7 threads checkpointed repartitioned to 8 threads on restart"
+#EXT_TEST TIMEOUT 120
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+./thread2thread.bash 1 8 || exit 1
+./thread2thread.bash 2 8 || exit 2
+./thread2thread.bash 3 8 || exit 3
+./thread2thread.bash 4 8 || exit 4
+./thread2thread.bash 5 8 || exit 5
+./thread2thread.bash 6 8 || exit 6
+./thread2thread.bash 7 8 || exit 7
+
+echo "remap-threads-Nto8.sh passed"
+wait
+
+

--- a/tests/remap/remap-threads-Nto8.sh
+++ b/tests/remap/remap-threads-Nto8.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #EXT_TEST TEST_FILE_MINVER NEW
 #EXT_TEST TEST_FILE_DESC "1 to 7 threads checkpointed repartitioned to 8 threads on restart"
-#EXT_TEST TIMEOUT 120
+#EXT_TEST TIMEOUT 300
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
 set -uo pipefail

--- a/tests/remap/thread2thread.bash
+++ b/tests/remap/thread2thread.bash
@@ -31,7 +31,6 @@ echo "TESTNAME=$TNAME"
 LOGFILE=${TNAME}.log
 PFX="cpt_${TNAME}"
 CONFIG="loop101.py"
-TIMING_INFO="${TNAME}.json"
 
 
 # Clean up old checkpoint directory
@@ -101,7 +100,7 @@ fi
 
 # Cleanup output file on pass
 if [ $CLEANUP -eq 1 ]; then
-  rm -f $LOGFILE $TIMING_INFO
+  rm -f $LOGFILE
   rm -rf ${PFX}*
 fi
 

--- a/tests/remap/thread2thread.bash
+++ b/tests/remap/thread2thread.bash
@@ -37,7 +37,7 @@ CONFIG="loop101.py"
 rm -rf ${PFX}*
 
 # Launch the program to start interactive mode at time 0
-LAUNCH="sst --num-threads=${threads_cpt} --checkpoint-sim-period=98047ns --checkpoint-prefix=$PFX --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
+LAUNCH="sst --num-threads=${threads_cpt} --checkpoint-sim-period=330003ns --checkpoint-prefix=$PFX --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0 --numComps=24 --clocks=1000000"
 echo $LAUNCH
 $LAUNCH | tee $LOGFILE
 retVal=$?
@@ -53,8 +53,8 @@ echo "Checkpoints: "
 ls ${PFX}
 
 n=$(ls ${PFX} | wc -l)
-if [[ $n -lt 10 ]]; then
-  echo "ERROR: expected at least 10 checkpoints but found $n"
+if [[ $n -lt 3 ]]; then
+  echo "ERROR: expected at least 3 checkpoints but found $n"
   exit 1
 fi
 
@@ -93,8 +93,8 @@ for cptfile in ${PFX}/${PFX}_*/${PFX}_*.sstcpt; do
 
 done
 
-if [[ $n -lt 10 ]]; then
-  echo "ERROR: expected at least 10 restart simulations but found $n"
+if [[ $n -lt 3 ]]; then
+  echo "ERROR: expected at least 3 restart simulations but found $n"
   exit 1
 fi
 


### PR DESCRIPTION
This PR depends on some bug fixes in the sst-core `restart-n2m` branch before we can push it. Even then, the sst-core changes should probable be merged into our `iconsole` feature branch in order to maintain 100% pass rate using `cmake -DENABLE_NEW_TESTS=ON`

This adds the `remap-mpi` test directory which includes combinations for mapping up to 8 ranks or threads ( or combinations ).

All the tests invoke a new script `rt2tr.bash` which takes a series of rank-thread pairs to run a checkpoint simulation (using the 1st rank-thread pair), followed by restarting from every checkpoint using subsequent rank-thread pairs. For now, I'm only testing even values for ranks and threads.  

For example, this command:
```
#            cpt   -- 1r rst  --      - 2r -     -4r-
./rt2rt.bash 8 1   1 8  1 4  1 2   2 4 2 2 2 1   4 2 
```

First, this runs a simulation to generate about 10 checkpoints using 8 ranks and 1 thread.
Next, 10 simulations are launched to restart from each checkpoint using 1 rank and 8 threads.
This is repeated for each pair ( 1 rank 4 threads, 1 rank 2 threads, 2 ranks 4 threads, etc ... )

Mostly, these tests are passing with the sst-core restart-n2m branch. However,
I am seeing a few cases hang the simulation and others that FATAL out with internal sst-core errors.

