### PR TITLE
Regression enhancements prior to N2M test inclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,20 +26,25 @@ Flags for test selection include:
 # Enables golden (production) test suite
 ENABLE_ALL_TESTS [OFF]
 
-# Enables NEW tests (non-production) and ALL production tests
+# Enables NEW tests (non-production)
+# This must be used with another test select option like -DENABLE_ALL_TESTS=ON
+# or no tests will be selected
 # For these the test header is: #EXT_TEST TEST_FILE_MINVER NEW
 ENABLE_NEW_TESTS [OFF]
 
 #  Note: The NEW tests will be added only when SST_VERSION is DEV.
 #  This can be achieved two ways:
 #  1. sst executable points to a `devel` branch
-#     `cmake .. -DENABLE_NEW_TESTS=ON`
+#     `cmake .. -DENABLE_NEW_TESTS=ON -DENABLE_ALL_TESTS=ON`
 #  2. Use the SST_VERSION override option
-#     `cmake .. -DENABLE_NEW_TESTS=ON` -DSST_OVERRIDE=DEV
+#     `cmake .. -DENABLE_NEW_TESTS=ON -DENABLE_ALL_TESTS=ON  -DSST_OVERRIDE=DEV`
 
 # Individual suites by ENABLE_ALL_TESTS=ON
 ENABLE_CLI_TESTS [OFF]
 ENABLE_CAPTCRUNCH_TESTS [OFF]
+ENABLE_DEBUG_TESTS [OFF]
+ENABLE_JSON_TESTS [OFF]
+ENABLE_REMAP_TESTS [OFF]
 ENABLE_RTACTION_TESTS [OFF]
 
 # Currently optional tests

--- a/components/core-debug/dbgsst15.cc
+++ b/components/core-debug/dbgsst15.cc
@@ -135,11 +135,17 @@ DbgSST15::finish()
     // See https://github.com/tactcomplabs/sst-core/issues/55
     if (selfCheck==0) return;
 
+    // This avoids a hang in final checks if we shutdown the debugger at cycle 0
+    if ( tickle_counter < 1000 ) {
+        output.fatal(CALL_INFO, -1, "error: tickle_counter must be at least 1000 to run final checks. Test failed\n");
+        return;
+    }
+
     bool success = checkValues();
     if (!success) {
         output.fatal(CALL_INFO, -1, "error: final consistency checks failed\n");
     } else {
-        output.verbose(CALL_INFO,0,0,"final consistency check passed\n");
+        output.verbose(CALL_INFO,5,0,"final consistency check passed\n");
     }
 }
 

--- a/jenkins/exec-sstcore-mpi-build.sh
+++ b/jenkins/exec-sstcore-mpi-build.sh
@@ -30,6 +30,8 @@ export CC=mpicc
 export CXX=mpicxx
 mkdir build
 cd build
-cmake -DENABLE_ALL_TESTS=ON -DENABLE_MPI_TESTS=ON ../
+#TODO cmake $EXTTESTASAN $EXTTESTARGS
+# Need to check Jenkins configuration
+cmake -DENABLE_MPI_TESTS=ON ../
 export SST_COMPONENT_BASE=`pwd`
 make

--- a/jenkins/run.sh
+++ b/jenkins/run.sh
@@ -92,9 +92,9 @@ if [ "$EXTTEST" = true ] ; then
 	mkdir build || exit 51
 	cd build || exit 52
 	if [ "$VALGRIND" = false ]; then
-	    cmake -DENABLE_ALL_TESTS=ON $EXTTESTASAN $EXTTESTARGS ../ || exit 53
+	    cmake $EXTTESTASAN $EXTTESTARGS ../ || exit 53
 	else
-    	cmake -DENABLE_ALL_TESTS=ON -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
+    	cmake -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
 	fi
 	export SST_COMPONENT_BASE=`pwd`
 	make -j || exit 55

--- a/jenkins/sstcore-macos15.3.1-Aarch64-clang17.0.sh
+++ b/jenkins/sstcore-macos15.3.1-Aarch64-clang17.0.sh
@@ -68,9 +68,9 @@ if [ "$EXTTEST" = true ] ; then
 	mkdir build || exit 51
 	cd build || exit 52
 	if [ "$VALGRIND" = false ]; then
-	    cmake -DENABLE_ALL_TESTS=ON $EXTTESTASAN $EXTTESTARGS ../ || exit 53
+	    cmake $EXTTESTASAN $EXTTESTARGS ../ || exit 53
 	else
-    	    cmake -DENABLE_ALL_TESTS=ON -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
+    	cmake -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
 	fi
 	export SST_COMPONENT_BASE=`pwd`
 	make -j4 || exit 55

--- a/jenkins/sstcore-macos15.3.1-Aarch64-clang20.0.sh
+++ b/jenkins/sstcore-macos15.3.1-Aarch64-clang20.0.sh
@@ -68,9 +68,9 @@ if [ "$EXTTEST" = true ] ; then
 	mkdir build || exit 51
 	cd build || exit 52
 	if [ "$VALGRIND" = false ]; then
-	    cmake -DENABLE_ALL_TESTS=ON $EXTTESTASAN $EXTTESTARGS ../ || exit 53
+	    cmake $EXTTESTASAN $EXTTESTARGS ../ || exit 53
 	else
-    	    cmake -DENABLE_ALL_TESTS=ON -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
+    	cmake -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
 	fi
 	export SST_COMPONENT_BASE=`pwd`
 	make -j4 || exit 55

--- a/jenkins/sstcore-macos26.1-Aarch64-clang17.0.sh
+++ b/jenkins/sstcore-macos26.1-Aarch64-clang17.0.sh
@@ -68,9 +68,9 @@ if [ "$EXTTEST" = true ] ; then
 	mkdir build || exit 51
 	cd build || exit 52
 	if [ "$VALGRIND" = false ]; then
-	    cmake -DENABLE_ALL_TESTS=ON $EXTTESTASAN $EXTTESTARGS ../ || exit 53
+	    cmake $EXTTESTASAN $EXTTESTARGS ../ || exit 53
 	else
-    	    cmake -DENABLE_ALL_TESTS=ON -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
+    	cmake -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
 	fi
 	export SST_COMPONENT_BASE=`pwd`
 	make -j10 || exit 55

--- a/jenkins/sstcore-macos26.1-Aarch64-clang20.1.sh
+++ b/jenkins/sstcore-macos26.1-Aarch64-clang20.1.sh
@@ -68,9 +68,9 @@ if [ "$EXTTEST" = true ] ; then
 	mkdir build || exit 51
 	cd build || exit 52
 	if [ "$VALGRIND" = false ]; then
-	    cmake -DENABLE_ALL_TESTS=ON $EXTTESTASAN $EXTTESTARGS ../ || exit 53
+	    cmake $EXTTESTASAN $EXTTESTARGS ../ || exit 53
 	else
-    	    cmake -DENABLE_ALL_TESTS=ON -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
+    	cmake -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
 	fi
 	export SST_COMPONENT_BASE=`pwd`
 	make -j10 || exit 55

--- a/jenkins/sstcore-macos26.1-Aarch64-clang21.1.sh
+++ b/jenkins/sstcore-macos26.1-Aarch64-clang21.1.sh
@@ -68,9 +68,9 @@ if [ "$EXTTEST" = true ] ; then
 	mkdir build || exit 51
 	cd build || exit 52
 	if [ "$VALGRIND" = false ]; then
-	    cmake -DENABLE_ALL_TESTS=ON $EXTTESTASAN $EXTTESTARGS ../ || exit 53
+	    cmake $EXTTESTASAN $EXTTESTARGS ../ || exit 53
 	else
-    	    cmake -DENABLE_ALL_TESTS=ON -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
+    	cmake -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
 	fi
 	export SST_COMPONENT_BASE=`pwd`
 	make -j10 || exit 55

--- a/jenkins/sstcore-sles15-clang20-mpich3.4.sh
+++ b/jenkins/sstcore-sles15-clang20-mpich3.4.sh
@@ -70,9 +70,9 @@ if [ "$EXTTEST" = true ] ; then
 	mkdir build || exit 51
 	cd build || exit 52
 	if [ "$VALGRIND" = false ]; then
-	    cmake -DENABLE_ALL_TESTS=ON $EXTTESTASAN $EXTTESTARGS ../ || exit 53
+	    cmake $EXTTESTASAN $EXTTESTARGS ../ || exit 53
 	else
-    	    cmake -DENABLE_ALL_TESTS=ON -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
+    	cmake -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
 	fi
 	export SST_COMPONENT_BASE=`pwd`
 	make -j || exit 55

--- a/jenkins/sstcore-sles15-clang20-mpich4.1.2.sh
+++ b/jenkins/sstcore-sles15-clang20-mpich4.1.2.sh
@@ -70,9 +70,9 @@ if [ "$EXTTEST" = true ] ; then
 	mkdir build || exit 51
 	cd build || exit 52
 	if [ "$VALGRIND" = false ]; then
-	    cmake -DENABLE_ALL_TESTS=ON $EXTTESTASAN $EXTTESTARGS ../ || exit 53
+	    cmake $EXTTESTASAN $EXTTESTARGS ../ || exit 53
 	else
-    	    cmake -DENABLE_ALL_TESTS=ON -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
+    	cmake -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
 	fi
 	export SST_COMPONENT_BASE=`pwd`
 	make -j || exit 55

--- a/jenkins/sstcore-sles15-clang20-openmpi4.1.7.sh
+++ b/jenkins/sstcore-sles15-clang20-openmpi4.1.7.sh
@@ -70,9 +70,9 @@ if [ "$EXTTEST" = true ] ; then
 	mkdir build || exit 51
 	cd build || exit 52
 	if [ "$VALGRIND" = false ]; then
-	    cmake -DENABLE_ALL_TESTS=ON $EXTTESTASAN $EXTTESTARGS ../ || exit 53
+	    cmake $EXTTESTASAN $EXTTESTARGS ../ || exit 53
 	else
-    	    cmake -DENABLE_ALL_TESTS=ON -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
+    	cmake -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
 	fi
 	export SST_COMPONENT_BASE=`pwd`
 	make -j || exit 55

--- a/jenkins/sstcore-sles15-gcc15-mpich3.4.sh
+++ b/jenkins/sstcore-sles15-gcc15-mpich3.4.sh
@@ -70,9 +70,9 @@ if [ "$EXTTEST" = true ] ; then
 	mkdir build || exit 51
 	cd build || exit 52
 	if [ "$VALGRIND" = false ]; then
-	    cmake -DENABLE_ALL_TESTS=ON $EXTTESTASAN $EXTTESTARGS ../ || exit 53
+	    cmake $EXTTESTASAN $EXTTESTARGS ../ || exit 53
 	else
-    	    cmake -DENABLE_ALL_TESTS=ON -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
+    	cmake -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
 	fi
 	export SST_COMPONENT_BASE=`pwd`
 	make -j || exit 55

--- a/jenkins/sstcore-sles15-gcc15-mpich4.1.2.sh
+++ b/jenkins/sstcore-sles15-gcc15-mpich4.1.2.sh
@@ -70,9 +70,9 @@ if [ "$EXTTEST" = true ] ; then
 	mkdir build || exit 51
 	cd build || exit 52
 	if [ "$VALGRIND" = false ]; then
-	    cmake -DENABLE_ALL_TESTS=ON $EXTTESTASAN $EXTTESTARGS ../ || exit 53
+	    cmake $EXTTESTASAN $EXTTESTARGS ../ || exit 53
 	else
-    	    cmake -DENABLE_ALL_TESTS=ON -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
+    	cmake -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
 	fi
 	export SST_COMPONENT_BASE=`pwd`
 	make -j || exit 55

--- a/jenkins/sstcore-sles15-gcc15-openmpi4.1.7.sh
+++ b/jenkins/sstcore-sles15-gcc15-openmpi4.1.7.sh
@@ -70,9 +70,9 @@ if [ "$EXTTEST" = true ] ; then
 	mkdir build || exit 51
 	cd build || exit 52
 	if [ "$VALGRIND" = false ]; then
-	    cmake -DENABLE_ALL_TESTS=ON $EXTTESTASAN $EXTTESTARGS ../ || exit 53
+	    cmake $EXTTESTASAN $EXTTESTARGS ../ || exit 53
 	else
-    	    cmake -DENABLE_ALL_TESTS=ON -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
+    	cmake -DENABLE_VALGRIND=ON $EXTTESTARGS ../ || exit 54
 	fi
 	export SST_COMPONENT_BASE=`pwd`
 	make -j || exit 55

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,10 +23,6 @@ option(ENABLE_CORE_CHKPT_TESTS "Purely optional: Enable sst-core checkpointing t
 option(ENABLE_MPI_TESTS "Purely optional: Enable multi-rank MPI testing" OFF)
 option(ENABLE_CORE_RESTART_PLATFORM_TESTS "Purely optional: Enable restart test from incorrect OS/Arch" OFF)
 
-if (ENABLE_NEW_TESTS)
-  set(ENABLE_ALL_TESTS ON CACHE BOOL "Enable ALL production tests" FORCE)
-endif()
-
 if (ENABLE_ALL_TESTS)
   set(ENABLE_CLI_TESTS ON CACHE BOOL "Enable CLI testing" FORCE)
   set(ENABLE_DEBUG_TESTS ON CACHE BOOL "Interactive debug mode tests" FORCE)
@@ -60,8 +56,15 @@ if(ENABLE_DEBUG_TESTS)
   endif()
 endif()
 
+if (ENABLE_REMAP_TESTS)
+  add_subdirectory(remap)
+  # TODO
+  # if(SST_MPI_OK)
+  #   add_subdirectory(remap-mpi)
+  # endif()
+endif()
+
 # -- strictly optional tests
-# TODO these have not been updated
 if(ENABLE_CORE_CHKPT_TESTS)
   add_subdirectory(core-chkpt)
 endif()
@@ -78,11 +81,6 @@ endif()
 
 if(ENABLE_CORE_RESTART_PLATFORM_TESTS)
   add_subdirectory(core-restart-platform)
-endif()
-
-if (ENABLE_REMAP_TESTS)
-  add_subdirectory(remap)
-  # add_subdirectory(restart-n2m)
 endif()
 
 # EOF

--- a/tests/debug-console-mpi/CMakeLists.txt
+++ b/tests/debug-console-mpi/CMakeLists.txt
@@ -75,6 +75,8 @@ foreach(testSrc ${TEST_SRCS_TARGET_VER})
     set_property(TEST ${testName} PROPERTY FAIL_REGULAR_EXPRESSION "${failRegex}")
     set_property(TEST ${testName} PROPERTY PASS_REGULAR_EXPRESSION "${passRegex}")
     set_property(TEST ${testName} PROPERTY ENVIRONMENT "SST_COMPONENT_BASE=$ENV{SST_COMPONENT_BASE}")
+    # Run one multi-threaded test at a time
+    set_property(TEST ${testName} PROPERTY RUN_SERIAL TRUE)
     if(NOT ${EXT_TEST_TIMEOUT} EQUAL 0)
       set_property(TEST ${testName} PROPERTY TIMEOUT ${EXT_TEST_TIMEOUT})
       message(STATUS "Runtime ${testSrc} = ${EXT_TEST_TIMEOUT}")

--- a/tests/debug-console-mpi/cmd-r2-t1-actions.sh
+++ b/tests/debug-console-mpi/cmd-r2-t1-actions.sh
@@ -29,8 +29,14 @@ CHKFILE=$TNAME.chk
 RANKS=2
 THREADS=1
 
+OS_TYPE=$(uname -s)
+MPIOPTS=""
+if [ ${OS_TYPE} = "Linux" ]; then
+  MPIOPTS="--bind-to socket"
+fi
+
 # Launch the program to start interactive mode at time 0
-LAUNCH="mpirun -np $RANKS sst -n $THREADS --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
+LAUNCH="mpirun ${MPIOPTS} -np $RANKS sst -n $THREADS --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
 $LAUNCH 2>&1 << EOF | tee $LOGFILE || exit 1
 cd cp0

--- a/tests/debug-console-mpi/cmd-r2-t1-ckptaction.sh
+++ b/tests/debug-console-mpi/cmd-r2-t1-ckptaction.sh
@@ -35,6 +35,13 @@ OUTFILE=$TNAME.console.out
 CMDFILE=$TNAME.cmd
 CHKFILE=$TNAME.chk
 CKPTPREFIX=ckpt_$TNAME
+
+OS_TYPE=$(uname -s)
+MPIOPTS=""
+if [ ${OS_TYPE} = "Linux" ]; then
+  MPIOPTS="--bind-to socket"
+fi
+
 SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
 if [ ! -e "${SPOTCHECKS}" ]; then
   echo "Checker script not found. [${SPOTCHECKS}]"
@@ -69,7 +76,7 @@ fi
 
 
 # Launch the program to start interactive mode at time 0
-LAUNCH="mpirun -np $RANKS sst --verbose=$VERBOSE -n $THREADS --interactive-start=0s --checkpoint-enable --checkpoint-prefix=$CKPTPREFIX $CONFIG"
+LAUNCH="mpirun ${MPIOPTS} -np $RANKS sst --verbose=$VERBOSE -n $THREADS --interactive-start=0s --checkpoint-enable --checkpoint-prefix=$CKPTPREFIX $CONFIG"
 echo $LAUNCH
 ( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
 replay $CMDFILE

--- a/tests/debug-console-mpi/cmd-r2-t1-shutdown-action.sh
+++ b/tests/debug-console-mpi/cmd-r2-t1-shutdown-action.sh
@@ -25,6 +25,13 @@ LOGFILE=$TNAME.log
 OUTFILE=$TNAME.console.out
 CMDFILE=$TNAME.cmd
 CHKFILE=$TNAME.chk
+
+OS_TYPE=$(uname -s)
+MPIOPTS=""
+if [ ${OS_TYPE} = "Linux" ]; then
+  MPIOPTS="--bind-to socket"
+fi
+
 SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
 if [ ! -e "${SPOTCHECKS}" ]; then
   echo "Checker script not found. [${SPOTCHECKS}]"
@@ -52,7 +59,7 @@ EOF
 NUMCHECKS=2
 
 # Launch the program to start interactive mode at time 0
-LAUNCH="mpirun -np $RANKS sst -n $THREADS --interactive-start --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
+LAUNCH="mpirun ${MPIOPTS} -np $RANKS sst -n $THREADS --interactive-start --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
 echo $LAUNCH
 revVal=0
 $LAUNCH << EOF  | tee $LOGFILE

--- a/tests/debug-console-mpi/cmd-r2-t1-watch-fail.sh
+++ b/tests/debug-console-mpi/cmd-r2-t1-watch-fail.sh
@@ -25,6 +25,13 @@ LOGFILE=$TNAME.log
 OUTFILE=$TNAME.console.out
 CMDFILE=$TNAME.cmd
 CHKFILE=$TNAME.chk
+
+OS_TYPE=$(uname -s)
+MPIOPTS=""
+if [ ${OS_TYPE} = "Linux" ]; then
+  MPIOPTS="--bind-to socket"
+fi
+
 SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
 if [ ! -e "${SPOTCHECKS}" ]; then
   echo "Checker script not found. [${SPOTCHECKS}]"
@@ -53,7 +60,7 @@ EOF
 NUMCHECKS=2
 
 # Launch the program to start interactive mode at time 0
-LAUNCH="mpirun -np $RANKS sst -n $THREADS --interactive-start --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
+LAUNCH="mpirun ${MPIOPTS} -np $RANKS sst -n $THREADS --interactive-start --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
 echo $LAUNCH
 revVal=0
 $LAUNCH << EOF  | tee $LOGFILE

--- a/tests/debug-console-mpi/cmd-r2-t1-watch.sh
+++ b/tests/debug-console-mpi/cmd-r2-t1-watch.sh
@@ -25,6 +25,13 @@ LOGFILE=$TNAME.log
 OUTFILE=$TNAME.console.out
 CMDFILE=$TNAME.cmd
 CHKFILE=$TNAME.chk
+
+OS_TYPE=$(uname -s)
+MPIOPTS=""
+if [ ${OS_TYPE} = "Linux" ]; then
+  MPIOPTS="--bind-to socket"
+fi
+
 SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
 if [ ! -e "${SPOTCHECKS}" ]; then
   echo "Checker script not found. [${SPOTCHECKS}]"
@@ -58,7 +65,7 @@ EOF
 NUMCHECKS=3
 
 # Launch the program to start interactive mode at time 0
-LAUNCH="mpirun -np $RANKS sst -n $THREADS --interactive-start --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
+LAUNCH="mpirun ${MPIOPTS} -np $RANKS sst -n $THREADS --interactive-start --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
 echo $LAUNCH
 revVal=0
 $LAUNCH << EOF  | tee $LOGFILE

--- a/tests/debug-console-mpi/cmd-r2-t2-empty-rank-sync.sh
+++ b/tests/debug-console-mpi/cmd-r2-t2-empty-rank-sync.sh
@@ -22,8 +22,14 @@ OUTFILE=$TNAME.console.out
 CMDFILE=$TNAME.cmd
 CHKFILE=$TNAME.chk
 
+OS_TYPE=$(uname -s)
+MPIOPTS=""
+if [ ${OS_TYPE} = "Linux" ]; then
+  MPIOPTS="--bind-to socket"
+fi
+
 # Launch the program to start interactive mode at time 0
-LAUNCH="mpirun -np 2 sst -n 2 --interactive-start --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
+LAUNCH="mpirun ${MPIOPTS} -np 2 sst -n 2 --interactive-start --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
 $LAUNCH | tee $LOGFILE
 

--- a/tests/remap/CMakeLists.txt
+++ b/tests/remap/CMakeLists.txt
@@ -75,6 +75,8 @@ foreach(testSrc ${TEST_SRCS_TARGET_VER})
     set_property(TEST ${testName} PROPERTY FAIL_REGULAR_EXPRESSION "${failRegex}")
     set_property(TEST ${testName} PROPERTY PASS_REGULAR_EXPRESSION "${passRegex}")
     set_property(TEST ${testName} PROPERTY ENVIRONMENT "SST_COMPONENT_BASE=$ENV{SST_COMPONENT_BASE}")
+    # Run one multi-threaded test at a time
+    set_property(TEST ${testName} PROPERTY RUN_SERIAL TRUE)
     if(NOT ${EXT_TEST_TIMEOUT} EQUAL 0)
       set_property(TEST ${testName} PROPERTY TIMEOUT ${EXT_TEST_TIMEOUT})
       message(STATUS "Runtime ${testSrc} = ${EXT_TEST_TIMEOUT}")

--- a/tests/remap/loop101.py
+++ b/tests/remap/loop101.py
@@ -12,6 +12,7 @@ import argparse
 import sst
 
 parser = argparse.ArgumentParser(description="dbg_loop101.py")
+parser.add_argument("--clocks", type=int, help="minimum clock cycles to run", default=1000000)
 parser.add_argument("--numComps", type=int, help="number of components to instantiate", default=101)
 parser.add_argument("--probeStartCycle", type=int, help="cycle to initiate debug probe. 0=Off", default=0)
 parser.add_argument("--probeEndCycle", type=int, help="cycle to end debug probe. 0=Never", default=0)
@@ -45,7 +46,8 @@ TRACE_RECV = 2
 MIN_DATA = 1
 MAX_DATA = 100
 
-NUM_COMPS = args.numComps;
+CLOCKS = args.clocks
+NUM_COMPS = args.numComps
 print(f"Instantiating {NUM_COMPS} components")
 
 components = [None] * NUM_COMPS
@@ -66,7 +68,7 @@ for i in range(NUM_COMPS):
     "minData" : MIN_DATA,
     "maxData" : MAX_DATA,
     "clockDelay" : 100,
-    "clocks" : 1000000,
+    "clocks" : CLOCKS,
     "rngSeed" : 1223,
     "clockFreq" : f"{frequency}Ghz",
     # common probe controls

--- a/tests/remap/remap-threads-1to8.sh.wait
+++ b/tests/remap/remap-threads-1to8.sh.wait
@@ -1,6 +1,0 @@
-#!/bin/bash
-#EXT_TEST TEST_FILE_MINVER NEW
-#EXT_TEST TEST_FILE_DESC "1 thread checkpointed repartitioned to 8 threads on restart"
-#EXT_TEST TIMEOUT 120
-
-./thread2thread.bash 1 8

--- a/tests/remap/remap-threads-2to1.sh
+++ b/tests/remap/remap-threads-2to1.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_DESC "2 thread checkpointed to 1 thread restart"
+#EXT_TEST TIMEOUT 120
+
+./thread2thread.bash 2 1

--- a/tests/remap/remap-threads-3to1.sh
+++ b/tests/remap/remap-threads-3to1.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_DESC "3 thread checkpointed to 1 thread restart"
+#EXT_TEST TIMEOUT 120
+
+./thread2thread.bash 3 1

--- a/tests/remap/remap-threads-4to1.sh
+++ b/tests/remap/remap-threads-4to1.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_DESC "4 thread checkpointed to 1 thread restart"
+#EXT_TEST TIMEOUT 120
+
+./thread2thread.bash 4 1

--- a/tests/remap/remap-threads-5to1.sh
+++ b/tests/remap/remap-threads-5to1.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_DESC "5 thread checkpointed to 1 thread restart"
+#EXT_TEST TIMEOUT 120
+
+./thread2thread.bash 5 1

--- a/tests/remap/remap-threads-6to1.sh
+++ b/tests/remap/remap-threads-6to1.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_DESC "6 thread checkpointed to 1 thread restart"
+#EXT_TEST TIMEOUT 120
+
+./thread2thread.bash 6 1

--- a/tests/remap/remap-threads-7to1.sh
+++ b/tests/remap/remap-threads-7to1.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_DESC "7 thread checkpointed to 1 thread restart"
+#EXT_TEST TIMEOUT 120
+
+./thread2thread.bash 7 1

--- a/tests/remap/thread2thread.bash
+++ b/tests/remap/thread2thread.bash
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+# See LICENSE in the top level directory for licensing details
+#
+# thread2thread.sh
+
 # ensure non-zero exit code in pipe propagates and no unbound variables.
 set -uo pipefail
 
@@ -19,7 +26,7 @@ SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 CLEANUP=1
 SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 SCRIPT_NAME=$(basename "$0")
-TNAME="${SCRIPT_NAME%.*}_${threads_cpt}_${threads_rst}"
+TNAME="${SCRIPT_NAME%.*}_${threads_cpt}_${threads_rst}_$$"
 echo "TESTNAME=$TNAME"
 LOGFILE=${TNAME}.log
 PFX="cpt_${TNAME}"
@@ -68,7 +75,6 @@ for cptfile in ${PFX}/${PFX}_*/${PFX}_*.sstcpt; do
   ((n++))
   LAUNCH="sst --num-threads=${threads_rst} --load-checkpoint --timing-info-json=${TIMING_INFO}  ${cptfile}"
   echo $LAUNCH
-
   $LAUNCH | tee $LOGFILE
   retVal=$?
   echo $TNAME Restart of ${cptfile} complete


### PR DESCRIPTION
This PR resolves a number of issues found while testing the new N2M checkpoint remapping on restart branch.

1) MPI tests running on Linux require the `--bind-to socket` option. The OS type is checked in the scripts rather then in cmake to allow the scripts to run at the command line.

2) ENABLE_NEW_TESTS will no longer automatically enable ENABLE_ALL_TESTS. This way we can just select 
the new tests for a particular feature( e.g. `cmake -DENABLE_NEW_TESTS -DENABLE_REMAP_TESTS` ). This 
is helpful when dealing with new branches, like the restart-n2m branch, that do not include the change in the iconsole branch.

3) Changed Jenkins scripts to not include -DENABLE_ALL_TESTS=ON since this is provided as the default EXT_TEST_ARGS option in the Jenkins configurations.

4) Added some new N to 1 threading tests for completeness.

5) In directories running multi-threads or multi-rank tests,  added the test parameter `RUN_SERIAL` to ensure these tests are run one at a time even when `ctest -j N` is used.

6) Fixed https://github.com/tactcomplabs/sst-core/issues/55 to avoid hang in final checks for DbgSST15.cc


