### PR TITLE
fixing issues in upstream devel dropping support for timing-info-json

### DIFF
--- a/tests/json_parallel/test_MessageMesh_6_6_1r4t.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_1r4t.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_parallel/test_MessageMesh_6_6_1r4t.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_1r4t.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_parallel/test_MessageMesh_6_6_1r4t_paraload.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_1r4t_paraload.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_parallel/test_MessageMesh_6_6_1r4t_paraload.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_1r4t_paraload.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_parallel/test_MessageMesh_6_6_2r3t.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_2r3t.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_parallel/test_MessageMesh_6_6_2r3t.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_2r3t.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_parallel/test_MessageMesh_6_6_2r3t_paraload0.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_2r3t_paraload0.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_parallel/test_MessageMesh_6_6_2r3t_paraload0.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_2r3t_paraload0.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_parallel/test_MessageMesh_6_6_2r3t_paraload1.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_2r3t_paraload1.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_parallel/test_MessageMesh_6_6_2r3t_paraload1.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_2r3t_paraload1.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_parallel/test_MessageMesh_6_6_3r1t.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_3r1t.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_parallel/test_MessageMesh_6_6_3r1t.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_3r1t.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_parallel/test_MessageMesh_6_6_3r1t_paraload0.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_3r1t_paraload0.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_parallel/test_MessageMesh_6_6_3r1t_paraload0.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_3r1t_paraload0.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_parallel/test_MessageMesh_6_6_3r1t_paraload1.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_3r1t_paraload1.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_parallel/test_MessageMesh_6_6_3r1t_paraload1.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_3r1t_paraload1.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_parallel/test_MessageMesh_6_6_3r1t_paraload2.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_3r1t_paraload2.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_parallel/test_MessageMesh_6_6_3r1t_paraload2.json
+++ b/tests/json_parallel/test_MessageMesh_6_6_3r1t_paraload2.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/links.json
+++ b/tests/json_seq/links.json
@@ -3,7 +3,7 @@
     "verbose": "0",
     "stop-at": "0ns",
     "print-timing-info": "5",
-    "timing-info-json": "",
+    "profiling-output": "",
     "heartbeat-sim-period": "",
     "heartbeat-wall-period": "0",
     "timebase": "1ps",

--- a/tests/json_seq/links.json
+++ b/tests/json_seq/links.json
@@ -3,7 +3,6 @@
     "verbose": "0",
     "stop-at": "0ns",
     "print-timing-info": "5",
-    "profiling-output": "",
     "heartbeat-sim-period": "",
     "heartbeat-wall-period": "0",
     "timebase": "1ps",

--- a/tests/json_seq/localstats.json
+++ b/tests/json_seq/localstats.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/localstats.json
+++ b/tests/json_seq/localstats.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/prog_opt1.json
+++ b/tests/json_seq/prog_opt1.json
@@ -3,7 +3,7 @@
     "verbose": "0",
     "stop-at": "10us",
     "print-timing-info": "3",
-    "timing-info-json": "",
+    "profiling-output": "",
     "heartbeat-sim-period": "",
     "heartbeat-wall-period": "0",
     "timebase": "1ps",

--- a/tests/json_seq/prog_opt1.json
+++ b/tests/json_seq/prog_opt1.json
@@ -3,7 +3,6 @@
     "verbose": "0",
     "stop-at": "10us",
     "print-timing-info": "3",
-    "profiling-output": "",
     "heartbeat-sim-period": "",
     "heartbeat-wall-period": "0",
     "timebase": "1ps",

--- a/tests/json_seq/prog_opt2.json
+++ b/tests/json_seq/prog_opt2.json
@@ -11,7 +11,7 @@
   "stop-at": "10us",
   "timeVortex": "sst.timevortex.priority_queue",
   "timebase": "1ps",
-  "timing-info-json": "",
+  "profiling-output": "",
   "verbose": "0"
 },
 "statistics_options":{

--- a/tests/json_seq/prog_opt2.json
+++ b/tests/json_seq/prog_opt2.json
@@ -11,7 +11,6 @@
   "stop-at": "10us",
   "timeVortex": "sst.timevortex.priority_queue",
   "timebase": "1ps",
-  "profiling-output": "",
   "verbose": "0"
 },
 "statistics_options":{

--- a/tests/json_seq/simple.json
+++ b/tests/json_seq/simple.json
@@ -3,7 +3,6 @@
     "verbose": "0",
     "stop-at": "0ns",
     "print-timing-info": "7",
-    "profiling-output": "",
     "heartbeat-sim-period": "",
     "heartbeat-wall-period": "0",
     "timebase": "1ps",

--- a/tests/json_seq/simple.json
+++ b/tests/json_seq/simple.json
@@ -3,7 +3,7 @@
     "verbose": "0",
     "stop-at": "0ns",
     "print-timing-info": "7",
-    "timing-info-json": "",
+    "profiling-output": "",
     "heartbeat-sim-period": "",
     "heartbeat-wall-period": "0",
     "timebase": "1ps",

--- a/tests/json_seq/statgroups.json
+++ b/tests/json_seq/statgroups.json
@@ -3,7 +3,6 @@
     "verbose": "0",
     "stop-at": "0ns",
     "print-timing-info": "7",
-    "profiling-output": "",
     "heartbeat-sim-period": "",
     "heartbeat-wall-period": "0",
     "timebase": "1ps",

--- a/tests/json_seq/statgroups.json
+++ b/tests/json_seq/statgroups.json
@@ -3,7 +3,7 @@
     "verbose": "0",
     "stop-at": "0ns",
     "print-timing-info": "7",
-    "timing-info-json": "",
+    "profiling-output": "",
     "heartbeat-sim-period": "",
     "heartbeat-wall-period": "0",
     "timebase": "1ps",

--- a/tests/json_seq/subcomp.json
+++ b/tests/json_seq/subcomp.json
@@ -3,7 +3,6 @@
     "verbose": "0",
     "stop-at": "10us",
     "print-timing-info": "0",
-    "profiling-output": "",
     "heartbeat-sim-period": "",
     "heartbeat-wall-period": "0",
     "timebase": "1ps",

--- a/tests/json_seq/subcomp.json
+++ b/tests/json_seq/subcomp.json
@@ -3,7 +3,7 @@
     "verbose": "0",
     "stop-at": "10us",
     "print-timing-info": "0",
-    "timing-info-json": "",
+    "profiling-output": "",
     "heartbeat-sim-period": "",
     "heartbeat-wall-period": "0",
     "timebase": "1ps",

--- a/tests/json_seq/subsubcomp.json
+++ b/tests/json_seq/subsubcomp.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/subsubcomp.json
+++ b/tests/json_seq/subsubcomp.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test2.json
+++ b/tests/json_seq/test2.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test2.json
+++ b/tests/json_seq/test2.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_Component_serial.json
+++ b/tests/json_seq/test_Component_serial.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "25us",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_Component_serial.json
+++ b/tests/json_seq/test_Component_serial.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "25us",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_MessageMesh_6_6_serial.json
+++ b/tests/json_seq/test_MessageMesh_6_6_serial.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_MessageMesh_6_6_serial.json
+++ b/tests/json_seq/test_MessageMesh_6_6_serial.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "10us",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_ParamComponent_serial.json
+++ b/tests/json_seq/test_ParamComponent_serial.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "25us",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_ParamComponent_serial.json
+++ b/tests/json_seq/test_ParamComponent_serial.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "25us",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_PortModule_drop_recv_sub_serial.json
+++ b/tests/json_seq/test_PortModule_drop_recv_sub_serial.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_PortModule_drop_recv_sub_serial.json
+++ b/tests/json_seq/test_PortModule_drop_recv_sub_serial.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_PortModule_modify_send_sub_serial.json
+++ b/tests/json_seq/test_PortModule_modify_send_sub_serial.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_PortModule_modify_send_sub_serial.json
+++ b/tests/json_seq/test_PortModule_modify_send_sub_serial.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_PortModule_pass_recv_serial.json
+++ b/tests/json_seq/test_PortModule_pass_recv_serial.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_PortModule_pass_recv_serial.json
+++ b/tests/json_seq/test_PortModule_pass_recv_serial.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_PortModule_randomdrop_send_serial.json
+++ b/tests/json_seq/test_PortModule_randomdrop_send_serial.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_PortModule_randomdrop_send_serial.json
+++ b/tests/json_seq/test_PortModule_randomdrop_send_serial.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_StatisticsComponent_basic_serial.json
+++ b/tests/json_seq/test_StatisticsComponent_basic_serial.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_StatisticsComponent_basic_serial.json
+++ b/tests/json_seq/test_StatisticsComponent_basic_serial.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_2a_serial.json
+++ b/tests/json_seq/test_sc_2a_serial.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_2a_serial.json
+++ b/tests/json_seq/test_sc_2a_serial.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_2u2a_serial.json
+++ b/tests/json_seq/test_sc_2u2a_serial.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_2u2a_serial.json
+++ b/tests/json_seq/test_sc_2u2a_serial.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_2u2u_serial.json
+++ b/tests/json_seq/test_sc_2u2u_serial.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_2u2u_serial.json
+++ b/tests/json_seq/test_sc_2u2u_serial.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_2u_serial.json
+++ b/tests/json_seq/test_sc_2u_serial.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_2u_serial.json
+++ b/tests/json_seq/test_sc_2u_serial.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_2ua_serial.json
+++ b/tests/json_seq/test_sc_2ua_serial.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_2ua_serial.json
+++ b/tests/json_seq/test_sc_2ua_serial.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_2uu_serial.json
+++ b/tests/json_seq/test_sc_2uu_serial.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_2uu_serial.json
+++ b/tests/json_seq/test_sc_2uu_serial.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_a_serial.json
+++ b/tests/json_seq/test_sc_a_serial.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_a_serial.json
+++ b/tests/json_seq/test_sc_a_serial.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_u2a_serial.json
+++ b/tests/json_seq/test_sc_u2a_serial.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_u2a_serial.json
+++ b/tests/json_seq/test_sc_u2a_serial.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_u2u_serial.json
+++ b/tests/json_seq/test_sc_u2u_serial.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_u2u_serial.json
+++ b/tests/json_seq/test_sc_u2u_serial.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_u_serial.json
+++ b/tests/json_seq/test_sc_u_serial.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_u_serial.json
+++ b/tests/json_seq/test_sc_u_serial.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_ua_serial.json
+++ b/tests/json_seq/test_sc_ua_serial.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_ua_serial.json
+++ b/tests/json_seq/test_sc_ua_serial.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_uu_serial.json
+++ b/tests/json_seq/test_sc_uu_serial.json
@@ -3,7 +3,6 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/json_seq/test_sc_uu_serial.json
+++ b/tests/json_seq/test_sc_uu_serial.json
@@ -3,7 +3,7 @@
   "verbose": "0",
   "stop-at": "0ns",
   "print-timing-info": "0",
-  "timing-info-json": "",
+  "profiling-output": "",
   "heartbeat-sim-period": "",
   "heartbeat-wall-period": "0",
   "timebase": "1ps",

--- a/tests/remap/thread2thread.bash
+++ b/tests/remap/thread2thread.bash
@@ -38,7 +38,7 @@ TIMING_INFO="${TNAME}.json"
 rm -rf ${PFX}*
 
 # Launch the program to start interactive mode at time 0
-LAUNCH="sst --num-threads=${threads_cpt} --timing-info-json=${TIMING_INFO} --checkpoint-sim-period=98047ns --checkpoint-prefix=$PFX --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
+LAUNCH="sst --num-threads=${threads_cpt} --profiling-output=${TIMING_INFO} --checkpoint-sim-period=98047ns --checkpoint-prefix=$PFX --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
 echo $LAUNCH
 $LAUNCH | tee $LOGFILE
 retVal=$?
@@ -73,7 +73,7 @@ n=0
 for cptfile in ${PFX}/${PFX}_*/${PFX}_*.sstcpt; do
 
   ((n++))
-  LAUNCH="sst --num-threads=${threads_rst} --load-checkpoint --timing-info-json=${TIMING_INFO}  ${cptfile}"
+  LAUNCH="sst --num-threads=${threads_rst} --load-checkpoint --profiling-output=${TIMING_INFO}  ${cptfile}"
   echo $LAUNCH
   $LAUNCH | tee $LOGFILE
   retVal=$?

--- a/tests/remap/thread2thread.bash
+++ b/tests/remap/thread2thread.bash
@@ -38,7 +38,7 @@ TIMING_INFO="${TNAME}.json"
 rm -rf ${PFX}*
 
 # Launch the program to start interactive mode at time 0
-LAUNCH="sst --num-threads=${threads_cpt} --profiling-output=${TIMING_INFO} --checkpoint-sim-period=98047ns --checkpoint-prefix=$PFX --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
+LAUNCH="sst --num-threads=${threads_cpt} --checkpoint-sim-period=98047ns --checkpoint-prefix=$PFX --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
 echo $LAUNCH
 $LAUNCH | tee $LOGFILE
 retVal=$?
@@ -73,7 +73,7 @@ n=0
 for cptfile in ${PFX}/${PFX}_*/${PFX}_*.sstcpt; do
 
   ((n++))
-  LAUNCH="sst --num-threads=${threads_rst} --load-checkpoint --profiling-output=${TIMING_INFO}  ${cptfile}"
+  LAUNCH="sst --num-threads=${threads_rst} --load-checkpoint ${cptfile}"
   echo $LAUNCH
   $LAUNCH | tee $LOGFILE
   retVal=$?


### PR DESCRIPTION
replaces this with `profiling-output`.  changed in all known instances (via grep).  changed in scripts, python and json