### PR TITLE
suppress leak detection for sanitizer until we clean/filter them

### DIFF
--- a/jenkins/sstcore-sles15-clang20-mpich3.4.sh
+++ b/jenkins/sstcore-sles15-clang20-mpich3.4.sh
@@ -47,8 +47,9 @@ fi
 if [ "$SANITIZER" = true ]; then
     export CXXFLAGS="${CXX_FLAGS} -g -fsanitize=address -fno-omit-frame-pointer"
     export EXTTESTASAN="-DSST_ASAN=ON"
+	# suppress detecting leaks until we get them cleaned up.
     # detect_leaks is not supported on Mac
-    # export ASAN_OPTIONS=detect_leaks=0
+    export ASAN_OPTIONS=detect_leaks=0
 fi
 ./configure --prefix=$SST_INSTALL $DBGFLAGS $PYFLAGS || exit 11
 if [ "$HEADERCHECK" = true ] ; then

--- a/jenkins/sstcore-sles15-clang20-mpich4.1.2.sh
+++ b/jenkins/sstcore-sles15-clang20-mpich4.1.2.sh
@@ -47,8 +47,9 @@ fi
 if [ "$SANITIZER" = true ]; then
     export CXXFLAGS="${CXX_FLAGS} -g -fsanitize=address -fno-omit-frame-pointer"
     export EXTTESTASAN="-DSST_ASAN=ON"
+	# suppress detecting leaks until we get them cleaned up.
     # detect_leaks is not supported on Mac
-    # export ASAN_OPTIONS=detect_leaks=0
+    export ASAN_OPTIONS=detect_leaks=0
 fi
 ./configure --prefix=$SST_INSTALL $DBGFLAGS $PYFLAGS || exit 11
 if [ "$HEADERCHECK" = true ] ; then

--- a/jenkins/sstcore-sles15-clang20-openmpi4.1.7.sh
+++ b/jenkins/sstcore-sles15-clang20-openmpi4.1.7.sh
@@ -47,8 +47,9 @@ fi
 if [ "$SANITIZER" = true ]; then
     export CXXFLAGS="${CXX_FLAGS} -g -fsanitize=address -fno-omit-frame-pointer"
     export EXTTESTASAN="-DSST_ASAN=ON"
+	# suppress detecting leaks until we get them cleaned up.
     # detect_leaks is not supported on Mac
-    # export ASAN_OPTIONS=detect_leaks=0
+    export ASAN_OPTIONS=detect_leaks=0
 fi
 ./configure --prefix=$SST_INSTALL $DBGFLAGS $PYFLAGS || exit 11
 if [ "$HEADERCHECK" = true ] ; then

--- a/jenkins/sstcore-sles15-gcc15-mpich3.4.sh
+++ b/jenkins/sstcore-sles15-gcc15-mpich3.4.sh
@@ -47,8 +47,9 @@ fi
 if [ "$SANITIZER" = true ]; then
     export CXXFLAGS="${CXX_FLAGS} -g -fsanitize=address -fno-omit-frame-pointer"
     export EXTTESTASAN="-DSST_ASAN=ON"
+	# suppress detecting leaks until we get them cleaned up.
     # detect_leaks is not supported on Mac
-    # export ASAN_OPTIONS=detect_leaks=0
+    export ASAN_OPTIONS=detect_leaks=0
 fi
 ./configure --prefix=$SST_INSTALL $DBGFLAGS $PYFLAGS || exit 11
 if [ "$HEADERCHECK" = true ] ; then

--- a/jenkins/sstcore-sles15-gcc15-mpich4.1.2.sh
+++ b/jenkins/sstcore-sles15-gcc15-mpich4.1.2.sh
@@ -47,8 +47,9 @@ fi
 if [ "$SANITIZER" = true ]; then
     export CXXFLAGS="${CXX_FLAGS} -g -fsanitize=address -fno-omit-frame-pointer"
     export EXTTESTASAN="-DSST_ASAN=ON"
+	# suppress detecting leaks until we get them cleaned up.
     # detect_leaks is not supported on Mac
-    # export ASAN_OPTIONS=detect_leaks=0
+    export ASAN_OPTIONS=detect_leaks=0
 fi
 ./configure --prefix=$SST_INSTALL $DBGFLAGS $PYFLAGS || exit 11
 if [ "$HEADERCHECK" = true ] ; then

--- a/jenkins/sstcore-sles15-gcc15-openmpi4.1.7.sh
+++ b/jenkins/sstcore-sles15-gcc15-openmpi4.1.7.sh
@@ -47,8 +47,9 @@ fi
 if [ "$SANITIZER" = true ]; then
     export CXXFLAGS="${CXX_FLAGS} -g -fsanitize=address -fno-omit-frame-pointer"
     export EXTTESTASAN="-DSST_ASAN=ON"
+	# suppress detecting leaks until we get them cleaned up.
     # detect_leaks is not supported on Mac
-    # export ASAN_OPTIONS=detect_leaks=0
+    export ASAN_OPTIONS=detect_leaks=0
 fi
 ./configure --prefix=$SST_INSTALL $DBGFLAGS $PYFLAGS || exit 11
 if [ "$HEADERCHECK" = true ] ; then


### PR DESCRIPTION
I'll just push this to devel and main branches to get jenkins sanitizer run (more) clean.

The gist is that we want to set this to 0:
`export ASAN_OPTIONS=detect_leaks=0`

The comment was misleading stating `detect_leaks is not supported on mac`. The option itself is not supported on mac so no need to set it to 0. 

This fixed in all the sles15 run scripts.

Rerunning on jenkins and will push to devel when it is successful.

( Someone someday can make an effort to filter out the non-SST related leaks and fix the SST ones then we can leave the checks on )