### PR TITLE
updating macOS 26 tests to set DYLIB library path

### DIFF
--- a/jenkins/sstcore-macos26.1-Aarch64-clang17.0.sh
+++ b/jenkins/sstcore-macos26.1-Aarch64-clang17.0.sh
@@ -55,6 +55,7 @@ fi
 make -j10 || exit 30
 make install || exit 31
 export PATH=$PATH:$SST_INSTALL/bin
+export DYLD_LIBRARY_PATH="/opt/homebrew/opt/expat/lib"
 
 #-- Run SST tests
 if [ "$SST_TEST_CORE" = true ]; then

--- a/jenkins/sstcore-macos26.1-Aarch64-clang20.1.sh
+++ b/jenkins/sstcore-macos26.1-Aarch64-clang20.1.sh
@@ -55,6 +55,7 @@ fi
 make -j10 || exit 30
 make install || exit 31
 export PATH=$PATH:$SST_INSTALL/bin
+export DYLD_LIBRARY_PATH="/opt/homebrew/opt/expat/lib"
 
 #-- Run SST tests
 if [ "$SST_TEST_CORE" = true ]; then

--- a/jenkins/sstcore-macos26.1-Aarch64-clang21.1.sh
+++ b/jenkins/sstcore-macos26.1-Aarch64-clang21.1.sh
@@ -55,6 +55,7 @@ fi
 make -j10 || exit 30
 make install || exit 31
 export PATH=$PATH:$SST_INSTALL/bin
+export DYLD_LIBRARY_PATH="/opt/homebrew/opt/expat/lib"
 
 #-- Run SST tests
 if [ "$SST_TEST_CORE" = true ]; then


### PR DESCRIPTION
Fixes libexpat path issues with failing tests on macOS 26.1