### PR TITLE
increasing timeout and adding oversubscribe options

### DIFF
--- a/tests/remap-mpi/CMakeLists.txt
+++ b/tests/remap-mpi/CMakeLists.txt
@@ -15,7 +15,7 @@ set(failRegex "ERROR")
 if (SST_VALGRIND)
   set(timeout "600")
 else()
-  set(timeout "60")
+  set(timeout "600")
 endif()
 
 #-- Test files supporting current sst version

--- a/tests/remap-mpi/rt2rt.bash
+++ b/tests/remap-mpi/rt2rt.bash
@@ -38,7 +38,7 @@ CONFIG="../remap/loop101.py"
 OS_TYPE=$(uname -s)
 MPIOPTS=""
 if [ ${OS_TYPE} = "Linux" ]; then
-  MPIOPTS="--bind-to socket"
+  MPIOPTS="--bind-to socket --oversubscribe"
 fi
 
 # Clean up old checkpoint directory

--- a/tests/remap/CMakeLists.txt
+++ b/tests/remap/CMakeLists.txt
@@ -15,7 +15,7 @@ set(failRegex "ERROR")
 if (SST_VALGRIND)
   set(timeout "600")
 else()
-  set(timeout "60")
+  set(timeout "600")
 endif()
 
 #-- Test files supporting current sst version


### PR DESCRIPTION
this is changes that will hopefully fix the nosferatu runs when thread/rank remap tests are enabled