### PR TITLE
Adding sst-test-core parallel runs

### DIFF
--- a/jenkins/run.sh
+++ b/jenkins/run.sh
@@ -40,6 +40,7 @@ echo "DEBUG=$DEBUG"
 echo "CLANGFORMAT=$CLANGFORMAT"
 echo "CLANG_FORMAT_EXE=$CLANG_FORMAT_EXE"
 echo "SST_TEST_CORE=$SST_TEST_CORE"
+echo "SST_TEST_CORE_PARALLEL=$SST_TEST_CORE_PARALLEL"
 if [ $SANITIZER = true ] && [ $VALGRIND = true ]; then
 	echo "SANITIZER and VALGRIND are mutually exclusive. Using SANITIZER only"
 	VALGRIND=false
@@ -103,6 +104,14 @@ if [ "$SST_TEST_CORE" = true ]; then
                 fi
 
 	fi
+        if [ "$SST_TEST_CORE_PARALLEL" = true ]; then
+            echo "!!! BEGIN EXECUTING PARALLEL SST-TEST-CORE !!!"
+            sst-test-core -r 1 -t 2 || exit 42
+            sst-test-core -r 1 -t 4 || exit 43
+            sst-test-core -r 2 -t 1 || exit 44
+            sst-test-core -r 2 -t 2 || exit 45
+            echo "!!! END EXECUTING PARALLEL SST-TEST-CORE !!!"
+        fi
 fi
 
 #-- Run EXT tests

--- a/jenkins/sstcore-macos15.3.1-Aarch64-clang17.0.sh
+++ b/jenkins/sstcore-macos15.3.1-Aarch64-clang17.0.sh
@@ -60,6 +60,13 @@ export PATH=$PATH:$SST_INSTALL/bin
 if [ "$SST_TEST_CORE" = true ]; then
   which sst-test-core || exit 40
   sst-test-core || exit 41
+
+  if [ "$SST_TEST_CORE_PARALLEL" = true ]; then
+    echo "!!! BEGIN EXECUTING PARALLEL SST-TEST-CORE !!!"
+    sst-test-core -r 1 -t 2 || exit 42
+    sst-test-core -r 1 -t 4 || exit 43
+    echo "!!! END EXECUTING PARALLEL SST-TEST-CORE !!!"
+  fi
 fi
 
 if [ "$EXTTEST" = true ] ; then

--- a/jenkins/sstcore-macos15.3.1-Aarch64-clang20.0.sh
+++ b/jenkins/sstcore-macos15.3.1-Aarch64-clang20.0.sh
@@ -58,8 +58,15 @@ export PATH=$PATH:$SST_INSTALL/bin
 
 #-- Run SST tests
 if [ "$SST_TEST_CORE" = true ]; then
-        which sst-test-core || exit 40
-        sst-test-core || exit 41
+  which sst-test-core || exit 40
+  sst-test-core || exit 41
+
+  if [ "$SST_TEST_CORE_PARALLEL" = true ]; then
+    echo "!!! BEGIN EXECUTING PARALLEL SST-TEST-CORE !!!"
+    sst-test-core -r 1 -t 2 || exit 42
+    sst-test-core -r 1 -t 4 || exit 43
+    echo "!!! END EXECUTING PARALLEL SST-TEST-CORE !!!"
+  fi
 fi
 
 if [ "$EXTTEST" = true ] ; then

--- a/jenkins/sstcore-macos26.1-Aarch64-clang17.0.sh
+++ b/jenkins/sstcore-macos26.1-Aarch64-clang17.0.sh
@@ -59,8 +59,15 @@ export DYLD_LIBRARY_PATH="/opt/homebrew/opt/expat/lib"
 
 #-- Run SST tests
 if [ "$SST_TEST_CORE" = true ]; then
-        which sst-test-core || exit 40
-        sst-test-core || exit 41
+  which sst-test-core || exit 40
+  sst-test-core || exit 41
+
+  if [ "$SST_TEST_CORE_PARALLEL" = true ]; then
+    echo "!!! BEGIN EXECUTING PARALLEL SST-TEST-CORE !!!"
+    sst-test-core -r 1 -t 2 || exit 42
+    sst-test-core -r 1 -t 4 || exit 43
+    echo "!!! END EXECUTING PARALLEL SST-TEST-CORE !!!"
+  fi
 fi
 
 if [ "$EXTTEST" = true ] ; then

--- a/jenkins/sstcore-macos26.1-Aarch64-clang20.1.sh
+++ b/jenkins/sstcore-macos26.1-Aarch64-clang20.1.sh
@@ -59,8 +59,15 @@ export DYLD_LIBRARY_PATH="/opt/homebrew/opt/expat/lib"
 
 #-- Run SST tests
 if [ "$SST_TEST_CORE" = true ]; then
-        which sst-test-core || exit 40
-        sst-test-core || exit 41
+  which sst-test-core || exit 40
+  sst-test-core || exit 41
+
+  if [ "$SST_TEST_CORE_PARALLEL" = true ]; then
+    echo "!!! BEGIN EXECUTING PARALLEL SST-TEST-CORE !!!"
+    sst-test-core -r 1 -t 2 || exit 42
+    sst-test-core -r 1 -t 4 || exit 43
+    echo "!!! END EXECUTING PARALLEL SST-TEST-CORE !!!"
+  fi
 fi
 
 if [ "$EXTTEST" = true ] ; then

--- a/jenkins/sstcore-macos26.1-Aarch64-clang21.1.sh
+++ b/jenkins/sstcore-macos26.1-Aarch64-clang21.1.sh
@@ -59,8 +59,15 @@ export DYLD_LIBRARY_PATH="/opt/homebrew/opt/expat/lib"
 
 #-- Run SST tests
 if [ "$SST_TEST_CORE" = true ]; then
-        which sst-test-core || exit 40
-        sst-test-core || exit 41
+  which sst-test-core || exit 40
+  sst-test-core || exit 41
+
+  if [ "$SST_TEST_CORE_PARALLEL" = true ]; then
+    echo "!!! BEGIN EXECUTING PARALLEL SST-TEST-CORE !!!"
+    sst-test-core -r 1 -t 2 || exit 42
+    sst-test-core -r 1 -t 4 || exit 43
+    echo "!!! END EXECUTING PARALLEL SST-TEST-CORE !!!"
+  fi
 fi
 
 if [ "$EXTTEST" = true ] ; then

--- a/jenkins/sstcore-sles15-clang20-mpich3.4.sh
+++ b/jenkins/sstcore-sles15-clang20-mpich3.4.sh
@@ -68,6 +68,8 @@ if [ "$SST_TEST_CORE" = true ]; then
     echo "!!! BEGIN EXECUTING PARALLEL SST-TEST-CORE !!!"
     sst-test-core -r 1 -t 2 || exit 42
     sst-test-core -r 1 -t 4 || exit 43
+    sst-test-core -r 2 -t 1 || exit 44
+    sst-test-core -r 2 -t 2 || exit 45
     echo "!!! END EXECUTING PARALLEL SST-TEST-CORE !!!"
   fi
 fi

--- a/jenkins/sstcore-sles15-clang20-mpich3.4.sh
+++ b/jenkins/sstcore-sles15-clang20-mpich3.4.sh
@@ -61,8 +61,15 @@ export PATH=$PATH:$SST_INSTALL/bin
 
 #-- Run SST tests
 if [ "$SST_TEST_CORE" = true ]; then
-        which sst-test-core || exit 40
-        sst-test-core || exit 41
+  which sst-test-core || exit 40
+  sst-test-core || exit 41
+
+  if [ "$SST_TEST_CORE_PARALLEL" = true ]; then
+    echo "!!! BEGIN EXECUTING PARALLEL SST-TEST-CORE !!!"
+    sst-test-core -r 1 -t 2 || exit 42
+    sst-test-core -r 1 -t 4 || exit 43
+    echo "!!! END EXECUTING PARALLEL SST-TEST-CORE !!!"
+  fi
 fi
 
 if [ "$EXTTEST" = true ] ; then

--- a/jenkins/sstcore-sles15-clang20-mpich4.1.2.sh
+++ b/jenkins/sstcore-sles15-clang20-mpich4.1.2.sh
@@ -68,6 +68,8 @@ if [ "$SST_TEST_CORE" = true ]; then
     echo "!!! BEGIN EXECUTING PARALLEL SST-TEST-CORE !!!"
     sst-test-core -r 1 -t 2 || exit 42
     sst-test-core -r 1 -t 4 || exit 43
+    sst-test-core -r 2 -t 1 || exit 44
+    sst-test-core -r 2 -t 2 || exit 45
     echo "!!! END EXECUTING PARALLEL SST-TEST-CORE !!!"
   fi
 fi

--- a/jenkins/sstcore-sles15-clang20-mpich4.1.2.sh
+++ b/jenkins/sstcore-sles15-clang20-mpich4.1.2.sh
@@ -61,8 +61,15 @@ export PATH=$PATH:$SST_INSTALL/bin
 
 #-- Run SST tests
 if [ "$SST_TEST_CORE" = true ]; then
-        which sst-test-core || exit 40
-        sst-test-core || exit 41
+  which sst-test-core || exit 40
+  sst-test-core || exit 41
+
+  if [ "$SST_TEST_CORE_PARALLEL" = true ]; then
+    echo "!!! BEGIN EXECUTING PARALLEL SST-TEST-CORE !!!"
+    sst-test-core -r 1 -t 2 || exit 42
+    sst-test-core -r 1 -t 4 || exit 43
+    echo "!!! END EXECUTING PARALLEL SST-TEST-CORE !!!"
+  fi
 fi
 
 if [ "$EXTTEST" = true ] ; then

--- a/jenkins/sstcore-sles15-clang20-openmpi4.1.7.sh
+++ b/jenkins/sstcore-sles15-clang20-openmpi4.1.7.sh
@@ -68,6 +68,8 @@ if [ "$SST_TEST_CORE" = true ]; then
     echo "!!! BEGIN EXECUTING PARALLEL SST-TEST-CORE !!!"
     sst-test-core -r 1 -t 2 || exit 42
     sst-test-core -r 1 -t 4 || exit 43
+    sst-test-core -r 2 -t 1 || exit 44
+    sst-test-core -r 2 -t 2 || exit 45
     echo "!!! END EXECUTING PARALLEL SST-TEST-CORE !!!"
   fi
 fi

--- a/jenkins/sstcore-sles15-clang20-openmpi4.1.7.sh
+++ b/jenkins/sstcore-sles15-clang20-openmpi4.1.7.sh
@@ -61,8 +61,15 @@ export PATH=$PATH:$SST_INSTALL/bin
 
 #-- Run SST tests
 if [ "$SST_TEST_CORE" = true ]; then
-        which sst-test-core || exit 40
-        sst-test-core || exit 41
+  which sst-test-core || exit 40
+  sst-test-core || exit 41
+
+  if [ "$SST_TEST_CORE_PARALLEL" = true ]; then
+    echo "!!! BEGIN EXECUTING PARALLEL SST-TEST-CORE !!!"
+    sst-test-core -r 1 -t 2 || exit 42
+    sst-test-core -r 1 -t 4 || exit 43
+    echo "!!! END EXECUTING PARALLEL SST-TEST-CORE !!!"
+  fi
 fi
 
 if [ "$EXTTEST" = true ] ; then

--- a/jenkins/sstcore-sles15-gcc15-mpich3.4.sh
+++ b/jenkins/sstcore-sles15-gcc15-mpich3.4.sh
@@ -68,6 +68,8 @@ if [ "$SST_TEST_CORE" = true ]; then
     echo "!!! BEGIN EXECUTING PARALLEL SST-TEST-CORE !!!"
     sst-test-core -r 1 -t 2 || exit 42
     sst-test-core -r 1 -t 4 || exit 43
+    sst-test-core -r 2 -t 1 || exit 44
+    sst-test-core -r 2 -t 2 || exit 45
     echo "!!! END EXECUTING PARALLEL SST-TEST-CORE !!!"
   fi
 fi

--- a/jenkins/sstcore-sles15-gcc15-mpich3.4.sh
+++ b/jenkins/sstcore-sles15-gcc15-mpich3.4.sh
@@ -61,8 +61,15 @@ export PATH=$PATH:$SST_INSTALL/bin
 
 #-- Run SST tests
 if [ "$SST_TEST_CORE" = true ]; then
-        which sst-test-core || exit 40
-        sst-test-core || exit 41
+  which sst-test-core || exit 40
+  sst-test-core || exit 41
+
+  if [ "$SST_TEST_CORE_PARALLEL" = true ]; then
+    echo "!!! BEGIN EXECUTING PARALLEL SST-TEST-CORE !!!"
+    sst-test-core -r 1 -t 2 || exit 42
+    sst-test-core -r 1 -t 4 || exit 43
+    echo "!!! END EXECUTING PARALLEL SST-TEST-CORE !!!"
+  fi
 fi
 
 if [ "$EXTTEST" = true ] ; then

--- a/jenkins/sstcore-sles15-gcc15-mpich4.1.2.sh
+++ b/jenkins/sstcore-sles15-gcc15-mpich4.1.2.sh
@@ -68,6 +68,8 @@ if [ "$SST_TEST_CORE" = true ]; then
     echo "!!! BEGIN EXECUTING PARALLEL SST-TEST-CORE !!!"
     sst-test-core -r 1 -t 2 || exit 42
     sst-test-core -r 1 -t 4 || exit 43
+    sst-test-core -r 2 -t 1 || exit 44
+    sst-test-core -r 2 -t 2 || exit 45
     echo "!!! END EXECUTING PARALLEL SST-TEST-CORE !!!"
   fi
 fi

--- a/jenkins/sstcore-sles15-gcc15-mpich4.1.2.sh
+++ b/jenkins/sstcore-sles15-gcc15-mpich4.1.2.sh
@@ -61,8 +61,15 @@ export PATH=$PATH:$SST_INSTALL/bin
 
 #-- Run SST tests
 if [ "$SST_TEST_CORE" = true ]; then
-        which sst-test-core || exit 40
-        sst-test-core || exit 41
+  which sst-test-core || exit 40
+  sst-test-core || exit 41
+
+  if [ "$SST_TEST_CORE_PARALLEL" = true ]; then
+    echo "!!! BEGIN EXECUTING PARALLEL SST-TEST-CORE !!!"
+    sst-test-core -r 1 -t 2 || exit 42
+    sst-test-core -r 1 -t 4 || exit 43
+    echo "!!! END EXECUTING PARALLEL SST-TEST-CORE !!!"
+  fi
 fi
 
 if [ "$EXTTEST" = true ] ; then

--- a/jenkins/sstcore-sles15-gcc15-openmpi4.1.7.sh
+++ b/jenkins/sstcore-sles15-gcc15-openmpi4.1.7.sh
@@ -68,6 +68,8 @@ if [ "$SST_TEST_CORE" = true ]; then
     echo "!!! BEGIN EXECUTING PARALLEL SST-TEST-CORE !!!"
     sst-test-core -r 1 -t 2 || exit 42
     sst-test-core -r 1 -t 4 || exit 43
+    sst-test-core -r 2 -t 1 || exit 44
+    sst-test-core -r 2 -t 2 || exit 45
     echo "!!! END EXECUTING PARALLEL SST-TEST-CORE !!!"
   fi
 fi

--- a/jenkins/sstcore-sles15-gcc15-openmpi4.1.7.sh
+++ b/jenkins/sstcore-sles15-gcc15-openmpi4.1.7.sh
@@ -61,8 +61,15 @@ export PATH=$PATH:$SST_INSTALL/bin
 
 #-- Run SST tests
 if [ "$SST_TEST_CORE" = true ]; then
-        which sst-test-core || exit 40
-        sst-test-core || exit 41
+  which sst-test-core || exit 40
+  sst-test-core || exit 41
+
+  if [ "$SST_TEST_CORE_PARALLEL" = true ]; then
+    echo "!!! BEGIN EXECUTING PARALLEL SST-TEST-CORE !!!"
+    sst-test-core -r 1 -t 2 || exit 42
+    sst-test-core -r 1 -t 4 || exit 43
+    echo "!!! END EXECUTING PARALLEL SST-TEST-CORE !!!"
+  fi
 fi
 
 if [ "$EXTTEST" = true ] ; then


### PR DESCRIPTION
Enabled with setting `SST_TEST_CORE_PARALLEL` to `true`.  

On Linux systems, we run: 
```
sst-test-core -r 1 -t 2 || exit 42
sst-test-core -r 1 -t 4 || exit 43
sst-test-core -r 2 -t 1 || exit 44
sst-test-core -r 2 -t 2 || exit 45
```

On macOS, we run:
```
sst-test-core -r 1 -t 2 || exit 42
sst-test-core -r 1 -t 4 || exit 43
```