### PR TITLE
fixing sles mpich builds

### DIFF
--- a/tests/remap-mpi/rt2rt.bash
+++ b/tests/remap-mpi/rt2rt.bash
@@ -37,8 +37,14 @@ CONFIG="../remap/loop101.py"
 
 OS_TYPE=$(uname -s)
 MPIOPTS=""
-if [ ${OS_TYPE} = "Linux" ]; then
-  MPIOPTS="--bind-to socket --oversubscribe"
+if [ "${OS_TYPE}" = "Linux" ]; then
+  if `mpirun --version 2>&1 | grep -q "Open MPI"`; then
+    #-- openmpi
+    MPIOPTS="--bind-to socket --oversubscribe"
+  else
+    #-- mpich
+    MPIOPTS="--bind-to socket"
+  fi
 fi
 
 # Clean up old checkpoint directory


### PR DESCRIPTION
The `tests/remap-mpi/rt2rt.bash` script now detects whether we're running with MPICH (only applicable to our SLES platforms) and removes the `--oversubscribe` option