### PR TITLE
added back sst16 compatible debug tests with suffix -16.0.sh

### DIFF
--- a/tests/debug-console-mpi/cmd-r2-t1-ckptaction-16.0.sh
+++ b/tests/debug-console-mpi/cmd-r2-t1-ckptaction-16.0.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Test checkpoint action triggers for RankSerial: 2 ranks, 1 thread/rank in rank0"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Convenience environment variables
+set +u
+if [[ -z "${CLEANUP}" ]]; then
+CLEANUP=1
+fi
+if [[ -z "${VERBOSE}" ]]; then
+  VERBOSE=0
+fi
+
+set -u
+
+# Common settings
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG=$(realpath ../debug-console/test_Checkpoint_4ms.py)
+RANKS=2
+THREADS=1
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+CKPTPREFIX=ckpt_$TNAME
+
+OS_TYPE=$(uname -s)
+MPIOPTS=""
+if [ ${OS_TYPE} = "Linux" ]; then
+  MPIOPTS="--bind-to socket"
+fi
+
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+# Console commands
+cat << EOF > $CMDFILE
+cd c0
+cd xorshift
+trace w changed : 32 4 : w x y z : checkpoint
+setHandler 0 ae ac
+# CHECK 0 printWatchpoint 0\nWP0: TriggerCount 0 : AC AE : c0/xorshift/w CHANGED  : bufsize = 32 postDelay = 4 : c0/xorshift/w c0/xorshift/x c0/xorshift/y c0/xorshift/z  : checkpoint
+printWatchpoint 0
+run 100us
+unwatch 0
+run
+EOF
+
+# Update this whenever adding checks in the command comments above
+NUMCHECKS=1
+
+# Remove stale checkpoint directory if necessary
+if [ -d "$CKPTPREFIX" ]; then
+        echo "Removing stale checkpoint directory '$CKPTPREFIX'"
+        rm -rf $CKPTPREFIX
+fi
+
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="mpirun ${MPIOPTS} -np $RANKS sst --verbose=$VERBOSE -n $THREADS --interactive-start=0s --checkpoint-enable --checkpoint-prefix=$CKPTPREFIX $CONFIG"
+echo $LAUNCH
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# Simulation Checkpoint
+PSTR="# Simulation Checkpoint: Simulated Time 97 us"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# Simulation Complete
+PSTR="Simulation is complete, simulated time: 4.007 ms"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# Check that checkpoint files exist
+if [ ! -d "$CKPTPREFIX" ]; then
+	echo "ERROR checkpoint directory '$CKPTPREFIX' does not exist"
+	exit $retVal
+else 
+	CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000.sstcpt"
+	if [ ! "$CKPTFILE" ]; then
+		echo "ERROR missing $CKPTFILE"
+		exit $retVal
+	fi
+	CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000_0_0.bin"
+	if [ ! "$CKPTFILE" ]; then
+		echo "ERROR missing $CKPTFILE"
+		exit $retVal
+	fi
+        # Should be a bin file for each thread
+        CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000_0_1.bin"
+        if [ ! "$CKPTFILE" ]; then
+                echo "ERROR missing $CKPTFILE"
+                exit $retVal
+        fi
+        CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000_0_2.bin"
+        if [ ! "$CKPTFILE" ]; then
+                echo "ERROR missing $CKPTFILE"
+                exit $retVal
+        fi
+        CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000_0_3.bin"
+        if [ ! "$CKPTFILE" ]; then
+                echo "ERROR missing $CKPTFILE"
+                exit $retVal
+        fi
+	CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000_globals.bin"
+	if [ ! "$CKPTFILE" ]; then
+		echo "ERROR missing $CKPTFILE"
+		exit $retVal
+	fi
+fi
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+  rm -rf $CKPTPREFIX
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console-mpi/cmd-r2-t1-rank1-actions-16.0.sh
+++ b/tests/debug-console-mpi/cmd-r2-t1-rank1-actions-16.0.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER DEV
-#EXT_TEST TEST_FILE_DESC "Basic interactive command check: cd, ls, pwd, run, continue"
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Test trace actions for RankSerial: 2 ranks, 1 thread/rank in rank1"
 #EXT_TEST TIMEOUT 30
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
@@ -10,13 +11,21 @@ set -uo pipefail
 # Set default ensure failure if not set and component not installed
 SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
+
 # Settings
 CLEANUP=1
 SCRIPT_NAME=$(basename "$0")
 TNAME="${SCRIPT_NAME%.*}"
 echo "TESTNAME=$TNAME"
-CONFIG="dbgsst15.py"
-PSTR="^Entering interactive mode at time 140000000"
+CONFIG=$(realpath ../debug-console/dbgsst15.py)
+RANKS=2
+THREADS=1
+
+OS_TYPE=$(uname -s)
+MPIOPTS=""
+if [ ${OS_TYPE} = "Linux" ]; then
+  MPIOPTS="--bind-to socket"
+fi
 
 LOGFILE=$TNAME.log
 OUTFILE=$TNAME.console.out
@@ -24,22 +33,30 @@ CMDFILE=$TNAME.cmd
 CHKFILE=$TNAME.chk
 
 # Launch the program to start interactive mode at time 0
-LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
+LAUNCH="mpirun ${MPIOPTS} -np $RANKS sst -n $THREADS --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF  | tee $LOGFILE
-pwd
-ls
-cd cp0
-chdir my_info_
-list -l
+$LAUNCH 2>&1 << EOF | tee $LOGFILE || exit 1
+rank 1
+cd cp1
+trace size changed : 8 0 : size : printTrace
 run 1us
-time
-r 1us
-continue 1us
-tm
-c 4us
-confirm false
-shutd
+rank 1
+unwatch 0
+trace size changed : 8 0 : size : set size 50
+run 1us
+rank 1
+print size
+unwatch 1
+trace size changed : 8 0 : size : printStatus
+run 1us
+rank 1
+unwatch 2
+trace size changed : 8 0 : size : interactive
+run 1us
+rank 1
+unwatch 3
+trace size changed : 8 0 : size : shutdown
+run 
 EOF
 
 retVal=$?
@@ -52,37 +69,7 @@ if [ $retVal -ne 0 ]; then
   exit $retVal
 fi
 
-# pwd
-PSTR="/"
-grep "$PSTR" $LOGFILE > /dev/null
-retVal=$?
-if [ $retVal -ne 0 ]; then
-  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
-  exit $retVal
-fi
-echo "Found pass string \"$PSTR\""
-
-# ls
-PSTR="cp0/"
-grep "$PSTR" $LOGFILE > /dev/null
-retVal=$?
-if [ $retVal -ne 0 ]; then
-  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
-  exit $retVal
-fi
-echo "Found pass string \"$PSTR\""
-
-# cd cp0, chdir my_info_, list
-PSTR="defaultTimeBase (ro) = 1 ns"
-grep "$PSTR" $LOGFILE > /dev/null
-retVal=$?
-if [ $retVal -ne 0 ]; then
-  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
-  exit $retVal
-fi
-echo "Found pass string \"$PSTR\""
-
-# run 1us
+# Interactive
 PSTR="Entering interactive mode at time 1000000"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
@@ -92,8 +79,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# time
-PSTR="current time = 1000000"
+# rank 1 thread 0 cp1
+PSTR=" ---- Rank1:Thread0: Entering interactive mode at time 1000000"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -102,8 +89,18 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# r 1us
-PSTR="Entering interactive mode at time 2000000"
+# printTrace
+PSTR="LastTriggerRecord:@cycle1100000: SamplesLost=0: cp1/size=92"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+    exit $retVal
+    fi
+    echo "Found pass string \"$PSTR\""
+
+#set size 50
+PSTR="set cp1/size 50"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -112,8 +109,7 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# continue 1us
-PSTR="Entering interactive mode at time 3000000"
+PSTR="size = 50"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -122,8 +118,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# tm
-PSTR="> current time = 3000000"
+# printStatus
+PSTR="CurrentSimCycle:  3000000"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -132,8 +128,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# c 1us
-PSTR="Entering interactive mode at time 7000000"
+# interactive
+PSTR="Rank:1/2 Thread:0/1 (Triggered)"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -142,8 +138,18 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# Simulation Complete
-PSTR="Simulation is complete"
+# shutdown
+PSTR=" Trigger action shutting down simulation"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+
+PSTR="Simulation is complete, simulated time: 0 s"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then

--- a/tests/debug-console-mpi/cmd-r2-t1-rank1-ckptaction-16.0.sh
+++ b/tests/debug-console-mpi/cmd-r2-t1-rank1-ckptaction-16.0.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Check trace checkpoint action triggers for RankSerial: 2 ranks, 1 thread/rank for rank1"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Convenience environment variables
+set +u
+if [[ -z "${CLEANUP}" ]]; then
+CLEANUP=1
+fi
+if [[ -z "${VERBOSE}" ]]; then
+  VERBOSE=0
+fi
+
+set -u
+
+# Common settings
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG=$(realpath ../debug-console/test_Checkpoint_4ms.py)
+RANKS=2
+THREADS=1
+
+OS_TYPE=$(uname -s)
+MPIOPTS=""
+if [ ${OS_TYPE} = "Linux" ]; then
+  MPIOPTS="--bind-to socket"
+fi
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+CKPTPREFIX=ckpt_$TNAME
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+# Console commands
+cat << EOF > $CMDFILE
+rank 1
+cd c4
+cd xorshift
+trace w changed : 32 4 : w x y z : checkpoint
+setHandler 0 ae ac
+# CHECK 0 printWatchpoint 0\nWP0: TriggerCount 0 : AC AE : c4/xorshift/w CHANGED  : bufsize = 32 postDelay = 4 : c4/xorshift/w c4/xorshift/x c4/xorshift/y c4/xorshift/z  : checkpoint
+printWatchpoint 0
+run 100us
+rank 1
+unwatch 0
+run
+EOF
+
+# Update this whenever adding checks in the command comments above
+NUMCHECKS=1
+
+# Remove stale checkpoint directory if necessary
+if [ -d "$CKPTPREFIX" ]; then
+        echo "Removing stale checkpoint directory '$CKPTPREFIX'"
+        rm -rf $CKPTPREFIX
+fi
+
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="mpirun ${MPIOPTS} -np $RANKS sst --verbose=$VERBOSE -n $THREADS --interactive-start=0s --checkpoint-enable --checkpoint-prefix=$CKPTPREFIX $CONFIG"
+echo $LAUNCH
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# rank 1
+PSTR="Rank1:Thread0: Entering interactive mode at time 1000000"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# Simulation Checkpoint
+PSTR="# Simulation Checkpoint: Simulated Time 97 us"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# Simulation Complete
+PSTR="Simulation is complete, simulated time: 4.007 ms"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# Check that checkpoint files exist
+if [ ! -d "$CKPTPREFIX" ]; then
+	echo "ERROR checkpoint directory '$CKPTPREFIX' does not exist"
+	exit $retVal
+else 
+	CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000.sstcpt"
+	if [ ! "$CKPTFILE" ]; then
+		echo "ERROR missing $CKPTFILE"
+		exit $retVal
+	fi
+	CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000_0_0.bin"
+	if [ ! "$CKPTFILE" ]; then
+		echo "ERROR missing $CKPTFILE"
+		exit $retVal
+	fi
+        # Should be a bin file for each thread
+        CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000_0_1.bin"
+        if [ ! "$CKPTFILE" ]; then
+                echo "ERROR missing $CKPTFILE"
+                exit $retVal
+        fi
+        CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000_0_2.bin"
+        if [ ! "$CKPTFILE" ]; then
+                echo "ERROR missing $CKPTFILE"
+                exit $retVal
+        fi
+        CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000_0_3.bin"
+        if [ ! "$CKPTFILE" ]; then
+                echo "ERROR missing $CKPTFILE"
+                exit $retVal
+        fi
+	CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000_globals.bin"
+	if [ ! "$CKPTFILE" ]; then
+		echo "ERROR missing $CKPTFILE"
+		exit $retVal
+	fi
+fi
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+  rm -rf $CKPTPREFIX
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console-mpi/cmd-r4-t2-ckptaction-16.0.sh
+++ b/tests/debug-console-mpi/cmd-r4-t2-ckptaction-16.0.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Check trace checkpoint action for RankParallel: 4 ranks, 2 threads/rank for ranks 1 & 3"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Convenience environment variables
+set +u
+if [[ -z "${CLEANUP}" ]]; then
+CLEANUP=1
+fi
+if [[ -z "${VERBOSE}" ]]; then
+  VERBOSE=0
+fi
+
+set -u
+
+# Common settings
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG=$(realpath ../debug-console/test_Checkpoint_4ms.py)
+RANKS=4
+THREADS=2
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+CKPTPREFIX=ckpt_$TNAME
+
+OS_TYPE=$(uname -s)
+MPIOPTS=""
+if [ ${OS_TYPE} = "Linux" ]; then
+  MPIOPTS="--bind-to socket"
+fi
+
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+# Console commands
+cat << EOF > $CMDFILE
+# rank 1 thread 0 c2
+# CHECK 0 rank 1\n---- Rank1:Thread0: Entering interactive mode at time 1000000
+rank 1
+cd c2
+cd xorshift
+trace w changed : 32 4 : w x y z : checkpoint
+setHandler 0 ae ac
+# CHECK 1 printWatchpoint 0\nWP0: TriggerCount 0 : AC AE : c2/xorshift/w CHANGED  : bufsize = 32 postDelay = 4 : c2/xorshift/w c2/xorshift/x c2/xorshift/y c2/xorshift/z  : checkpoint
+printWatchpoint 0
+run 40us
+rank 1
+wl
+unwatch 0
+# rank 3 thread 1 c7
+rank 3
+# CHECK 2 thread 1\n---- Rank3:Thread1: Entering interactive mode at time 41000000
+thread 1
+cd c7
+cd xorshift
+trace w changed : 32 4 : w x y z : checkpoint
+setHandler 0 ae ac
+# CHECK 3 printWatchpoint 0\nWP0: TriggerCount 0 : AC AE : c7/xorshift/w CHANGED  : bufsize = 32 postDelay = 4 : c7/xorshift/w c7/xorshift/x c7/xorshift/y c7/xorshift/z  : checkpoint
+printWatchpoint 0
+run 40us
+rank 3
+thread 1
+wl
+unwatch 0
+run
+EOF
+
+# for later
+# CHECK 1 run100us.+\n# Simulation Checkpoint: Simulated Time 96 us
+# CHECK 2 shutdown.+\nSimulation is complete, simulated time: 0 s
+
+# Update this whenever adding checks in the command comments above
+NUMCHECKS=4
+
+# Remove stale checkpoint directory if necessary
+if [ -d "$CKPTPREFIX" ]; then
+        echo "Removing stale checkpoint directory '$CKPTPREFIX'"
+        rm -rf $CKPTPREFIX
+fi
+
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="mpirun ${MPIOPTS} -np $RANKS sst --verbose=$VERBOSE -n $THREADS --interactive-start=0s --checkpoint-enable --checkpoint-prefix=$CKPTPREFIX $CONFIG"
+echo $LAUNCH
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# ---- rank 1 thread 0 c2
+# Checkpoint @ 41us
+PSTR="# Simulation Checkpoint: Simulated Time 41 us"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+    exit $retVal
+    fi
+    echo "Found pass string \"$PSTR\""
+
+# Checkpoint in WL
+PSTR="0: TriggerCount 0 : AC AE : c2/xorshift/w CHANGED  : bufsize = 32 postDelay = 4 : c2/xorshift/w c2/xorshift/x c2/xorshift/y c2/xorshift/z  : checkpoint"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# ---- rank 3 thread 1 c7
+# Checkpoint @ 81us
+PSTR="# Simulation Checkpoint: Simulated Time 81 us"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# Checkpoint in WL
+PSTR="0: TriggerCount 1 : AC AE : c7/xorshift/w CHANGED  : bufsize = 32 postDelay = 4 : c7/xorshift/w c7/xorshift/x c7/xorshift/y c7/xorshift/z  : checkpoint"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# Simulation Complete
+PSTR="Simulation is complete, simulated time: 4.007 ms"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# Check that checkpoint files exist
+if [ ! -d "$CKPTPREFIX" ]; then
+	echo "ERROR checkpoint directory '$CKPTPREFIX' does not exist"
+	exit $retVal
+else 
+	CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000.sstcpt"
+	if [ ! "$CKPTFILE" ]; then
+		echo "ERROR missing $CKPTFILE"
+		exit $retVal
+	fi
+	CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000_0_0.bin"
+	if [ ! "$CKPTFILE" ]; then
+		echo "ERROR missing $CKPTFILE"
+		exit $retVal
+	fi
+        # Should be a bin file for each thread
+        CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000_0_1.bin"
+        if [ ! "$CKPTFILE" ]; then
+                echo "ERROR missing $CKPTFILE"
+                exit $retVal
+        fi
+        CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000_0_2.bin"
+        if [ ! "$CKPTFILE" ]; then
+                echo "ERROR missing $CKPTFILE"
+                exit $retVal
+        fi
+        CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000_0_3.bin"
+        if [ ! "$CKPTFILE" ]; then
+                echo "ERROR missing $CKPTFILE"
+                exit $retVal
+        fi
+	CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000_globals.bin"
+	if [ ! "$CKPTFILE" ]; then
+		echo "ERROR missing $CKPTFILE"
+		exit $retVal
+	fi
+fi
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+  rm -rf $CKPTPREFIX
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console-mpi/cmd-r4-t2-rank1-actions-16.0.sh
+++ b/tests/debug-console-mpi/cmd-r4-t2-rank1-actions-16.0.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Check action triggers for RankParallel: 4 ranks, 2 threads/rank for rank1, thread0"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Convenience environment variables
+set +u
+if [[ -z "${CLEANUP}" ]]; then
+CLEANUP=1
+fi
+if [[ -z "${VERBOSE}" ]]; then
+  VERBOSE=0
+fi
+
+set -u
+
+# Common settings
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG=$(realpath ../debug-console/test_Checkpoint_4ms.py)
+RANKS=4
+THREADS=2
+
+OS_TYPE=$(uname -s)
+MPIOPTS=""
+if [ ${OS_TYPE} = "Linux" ]; then
+  MPIOPTS="--bind-to socket"
+fi
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+CKPTPREFIX=ckpt_$TNAME
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+# Console commands
+cat << EOF > $CMDFILE
+# rank 1 thread 0 c2
+# CHECK 0 rank 1\n---- Rank1:Thread0: Entering interactive mode at time 1000000
+rank 1
+cd c2
+cd xorshift
+# printTrace action
+trace w changed : 32 4 : w x y z : printTrace
+setHandler 0 ac ae
+# CHECK 1 printWatchpoint 0\nWP0: TriggerCount 0 : AC AE : c2/xorshift/w CHANGED  : bufsize = 32 postDelay = 4 : c2/xorshift/w c2/xorshift/x c2/xorshift/y c2/xorshift/z  : printTrace
+printWatchpoint 0
+run 40us
+rank 1
+unwatch 0
+#set action
+trace w changed : 32 4 : w x y z : set z 50
+setHandler 1 ac ae
+# CHECK 2 printWatchpoint 1\nWP1: TriggerCount 0 : AC AE : c2/xorshift/w CHANGED  : bufsize = 32 postDelay = 4 : c2/xorshift/w c2/xorshift/x c2/xorshift/y c2/xorshift/z  : set c2/xorshift/z 50
+printWatchpoint 1
+run 40us
+rank 1
+unwatch 1
+#printStatus action
+trace w changed : 32 0 : w x y z : printStatus
+setHandler 2 ac ae
+# CHECK 3 printWatchpoint 2\nWP2: TriggerCount 0 : AC AE : c2/xorshift/w CHANGED  : bufsize = 32 postDelay = 0 : c2/xorshift/w c2/xorshift/x c2/xorshift/y c2/xorshift/z  : printStatus
+printWatchpoint 2
+run 40us
+rank 1
+unwatch 2
+#interactive action
+trace w changed : 32 4 : w x y z : interactive
+setHandler 3 ac ae
+# CHECK 4 printWatchpoint 3\nWP3: TriggerCount 0 : AC AE : c2/xorshift/w CHANGED  : bufsize = 32 postDelay = 4 : c2/xorshift/w c2/xorshift/x c2/xorshift/y c2/xorshift/z  : interactive
+printWatchpoint 3
+run 40us
+rank 1
+watchlist
+unwatch 3
+run
+EOF
+
+# for later
+# CHECK 1 run100us.+\n# Simulation Checkpoint: Simulated Time 96 us
+# CHECK 2 shutdown.+\nSimulation is complete, simulated time: 0 s
+
+# Update this whenever adding checks in the command comments above
+NUMCHECKS=5
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="mpirun ${MPIOPTS} --np $RANKS sst --verbose=$VERBOSE -n $THREADS --interactive-start=0s $CONFIG"
+echo $LAUNCH
+#( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+( $LAUNCH 2>&1 << EOF || exit 11 ) | tee  $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# ---- rank 1 thread 0 c2
+# printTrace action
+PSTR="LastTriggerRecord:@cycle10000000: SamplesLost=0: c2/xorshift/w=24684 c2/xorshift/x=0 c2/xorshift/y=0 c2/xorshift/z=
+0"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+    exit $retVal
+    fi
+    echo "Found pass string \"$PSTR\""
+
+# set action
+PSTR="set c2/xorshift/z 50"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# printStatus
+PSTR="CurrentSimCycle:  9000000"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# interactive
+PSTR="Rank:1/4 Thread:0/2 (Triggered)"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+#PSTR=" Last Trigger: WP3: AE : c2/xorshift/w ..."
+PSTR="3: TriggerCount 2 : AC AE : c2/xorshift/w CHANGED  : bufsize = 32 postDelay = 4 : c2/xorshift/w c2/xorshift/x c2/xorshift/y c2/xorshift/z  : interactive"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# Simulation Complete
+PSTR="Simulation is complete, simulated time: 4.007 ms"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+  rm -rf $CKPTPREFIX
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console-mpi/cmd-r4-t2-rank3-actions-16.0.sh
+++ b/tests/debug-console-mpi/cmd-r4-t2-rank3-actions-16.0.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Check action triggers for RankParallel: 4 ranks, 2 threads/rank for rank3, thread1"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Convenience environment variables
+set +u
+if [[ -z "${CLEANUP}" ]]; then
+CLEANUP=1
+fi
+if [[ -z "${VERBOSE}" ]]; then
+  VERBOSE=0
+fi
+
+set -u
+
+# Common settings
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG=$(realpath ../debug-console/test_Checkpoint_4ms.py)
+RANKS=4
+THREADS=2
+
+OS_TYPE=$(uname -s)
+MPIOPTS=""
+if [ ${OS_TYPE} = "Linux" ]; then
+  MPIOPTS="--bind-to socket"
+fi
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+CKPTPREFIX=ckpt_$TNAME
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+# Console commands
+cat << EOF > $CMDFILE
+# rank 3 thread 1 c7
+rank 3
+# CHECK 0 thread 1\n---- Rank3:Thread1: Entering interactive mode at time 1000000
+thread 1
+cd c7
+cd xorshift
+# printTrace action
+trace w changed : 32 4 : w x y z : printTrace
+setHandler 0 ae ac
+# CHECK 1 printWatchpoint 0\nWP0: TriggerCount 0 : AC AE : c7/xorshift/w CHANGED  : bufsize = 32 postDelay = 4 : c7/xorshift/w c7/xorshift/x c7/xorshift/y c7/xorshift/z  : printTrace
+printWatchpoint 0
+run 40us
+rank 3
+thread 1
+unwatch 0
+#set action
+trace w changed : 32 4 : w x y z : set z 50
+setHandler 1 ac ae
+# CHECK 2 printWatchpoint 1\nWP1: TriggerCount 0 : AC AE : c7/xorshift/w CHANGED  : bufsize = 32 postDelay = 4 : c7/xorshift/w c7/xorshift/x c7/xorshift/y c7/xorshift/z  : set c7/xorshift/z 50
+printWatchpoint 1
+run 40us
+rank 3
+thread 1
+unwatch 1
+#printStatus action
+trace w changed : 32 0 : w x y z : printStatus
+setHandler 2 ac ae
+# CHECK 3 printWatchpoint 2\nWP2: TriggerCount 0 : AC AE : c7/xorshift/w CHANGED  : bufsize = 32 postDelay = 0 : c7/xorshift/w c7/xorshift/x c7/xorshift/y c7/xorshift/z  : printStatus
+printWatchpoint 2
+run 40us
+rank 3
+thread 1
+unwatch 2
+#interactive action
+trace w changed : 32 4 : w x y z : interactive
+setHandler 3 ac ae
+# CHECK 4 printWatchpoint 3\nWP3: TriggerCount 0 : AC AE : c7/xorshift/w CHANGED  : bufsize = 32 postDelay = 4 : c7/xorshift/w c7/xorshift/x c7/xorshift/y c7/xorshift/z  : interactive
+printWatchpoint 3
+run 40us
+rank 3
+thread 1
+watchlist
+unwatch 3
+run
+EOF
+
+
+# Update this whenever adding checks in the command comments above
+NUMCHECKS=5
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="mpirun ${MPIOPTS} -np $RANKS sst --verbose=$VERBOSE -n $THREADS --interactive-start=0s $CONFIG"
+echo $LAUNCH
+#( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+( $LAUNCH 2>&1 << EOF || exit 11 ) | tee  $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# ---- rank 3 thread 1 c2
+# printTrace action
+PSTR="LastTriggerRecord:@cycle10000000: SamplesLost=0: c7/xorshift/w=24684 c7/xorshift/x=0 c7/xorshift/y=0 c7/xorshift/z=0"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+    exit $retVal
+    fi
+    echo "Found pass string \"$PSTR\""
+
+# set action
+PSTR="set c7/xorshift/z 50"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# printStatus
+PSTR="CurrentSimCycle:  9000000"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# interactive
+PSTR="Rank:3/4 Thread:1/2 (Triggered)"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+#PSTR=" Last Trigger: WP3: AC : c7/xorshift/w ..."
+PSTR="3: TriggerCount 3 : AC AE : c7/xorshift/w CHANGED  : bufsize = 32 postDelay = 4 : c7/xorshift/w c7/xorshift/x c7/xorshift/y c7/xorshift/z  : interactive"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# Simulation Complete
+PSTR="Simulation is complete, simulated time: 4.007 ms"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+  rm -rf $CKPTPREFIX
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console/cmd-actions-16.0.sh
+++ b/tests/debug-console/cmd-actions-16.0.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER DEV
-#EXT_TEST TEST_FILE_DESC "Basic interactive command check: cd, ls, pwd, run, continue"
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Check for interactive, printTrace, printStatus, and set actions"
 #EXT_TEST TIMEOUT 30
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
@@ -16,7 +17,7 @@ SCRIPT_NAME=$(basename "$0")
 TNAME="${SCRIPT_NAME%.*}"
 echo "TESTNAME=$TNAME"
 CONFIG="dbgsst15.py"
-PSTR="^Entering interactive mode at time 140000000"
+PSTR=""
 
 LOGFILE=$TNAME.log
 OUTFILE=$TNAME.console.out
@@ -26,20 +27,26 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF  | tee $LOGFILE
-pwd
-ls
+$LAUNCH 2>&1 << EOF | tee $LOGFILE
 cd cp0
-chdir my_info_
-list -l
+ls
+trace maxData > 10 : 8 0 : maxData : interactive
+run
+printTrace 0
+unwatch 0
+trace maxData > 11 : 8 0 : maxData : printTrace
 run 1us
-time
-r 1us
-continue 1us
-tm
-c 4us
-confirm false
-shutd
+unwatch 1
+trace maxData > 12 : 8 0 : maxData : printStatus
+run 1us
+unwatch 2
+ls
+trace maxData > 13 : 8 0 : minData : set minData 10
+run 1us
+print minData
+trace maxData > 14 : 8 0 : maxData : shutdown
+run
+# previous trace will trigger shutdown
 EOF
 
 retVal=$?
@@ -52,8 +59,18 @@ if [ $retVal -ne 0 ]; then
   exit $retVal
 fi
 
-# pwd
-PSTR="/"
+# Avoid diff due to differences btwn mac and linux
+#diff $LOGFILE $CHKFILE > /dev/null
+#retVal=$?
+#if [ $retVal -ne 0 ]; then
+#  echo "ERROR in diff $LOGFILE $CHKFILE"
+#  exit $retVal
+#fi
+#echo "Log file matches check file"
+
+# Need one for each action
+# Interactive
+PSTR="Entering interactive mode at time 1000"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -62,8 +79,7 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# ls
-PSTR="cp0/"
+PSTR="LastTriggerRecord:@cycle1000: SamplesLost=0: cp0/maxData=100"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -72,8 +88,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# cd cp0, chdir my_info_, list
-PSTR="defaultTimeBase (ro) = 1 ns"
+# printTrace
+PSTR="LastTriggerRecord:@cycle68000: SamplesLost=0: cp0/maxData=100"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -82,8 +98,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# run 1us
-PSTR="Entering interactive mode at time 1000000"
+# printStatus
+PSTR="to be delivered at time: 1100000"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -92,8 +108,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# time
-PSTR="current time = 1000000"
+#set
+PSTR="> minData = 10"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -102,38 +118,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# r 1us
-PSTR="Entering interactive mode at time 2000000"
-grep "$PSTR" $LOGFILE > /dev/null
-retVal=$?
-if [ $retVal -ne 0 ]; then
-  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
-  exit $retVal
-fi
-echo "Found pass string \"$PSTR\""
-
-# continue 1us
-PSTR="Entering interactive mode at time 3000000"
-grep "$PSTR" $LOGFILE > /dev/null
-retVal=$?
-if [ $retVal -ne 0 ]; then
-  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
-  exit $retVal
-fi
-echo "Found pass string \"$PSTR\""
-
-# tm
-PSTR="> current time = 3000000"
-grep "$PSTR" $LOGFILE > /dev/null
-retVal=$?
-if [ $retVal -ne 0 ]; then
-  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
-  exit $retVal
-fi
-echo "Found pass string \"$PSTR\""
-
-# c 1us
-PSTR="Entering interactive mode at time 7000000"
+# shutdown
+PSTR="Trigger action shutting down simulation"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -143,7 +129,7 @@ fi
 echo "Found pass string \"$PSTR\""
 
 # Simulation Complete
-PSTR="Simulation is complete"
+PSTR="Simulation is complete, simulated time: 0 s"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then

--- a/tests/debug-console/cmd-basic-15.1.sh
+++ b/tests/debug-console/cmd-basic-15.1.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER DEV
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_MAXVER 16.0
 #EXT_TEST TEST_FILE_DESC "Basic interactive command check: cd, ls, pwd, run, continue"
 #EXT_TEST TIMEOUT 30
 
@@ -31,7 +32,7 @@ pwd
 ls
 cd cp0
 chdir my_info_
-list -l
+list
 run 1us
 time
 r 1us
@@ -53,7 +54,7 @@ if [ $retVal -ne 0 ]; then
 fi
 
 # pwd
-PSTR="/"
+PSTR="()"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -73,7 +74,7 @@ fi
 echo "Found pass string \"$PSTR\""
 
 # cd cp0, chdir my_info_, list
-PSTR="defaultTimeBase (ro) = 1 ns"
+PSTR="defaultTimeBase = 1 ns"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then

--- a/tests/debug-console/cmd-define-16.0.sh
+++ b/tests/debug-console/cmd-define-16.0.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Exercise std::bitset and std::vector<bool>"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Settings
+CLEANUP=1
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="dbgsst15.py"
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+cat << EOF > $CMDFILE
+confirm false
+
+# The checking convention is: CHECK <id> <regexp>
+# regexp and have multiple \n characters but not a trailing \n
+
+# CHECK 0 define ls\nCannot overwrite built-in command "ls"
+define ls
+
+# CHECK 1 define fubar\nEnter commands for "fubar" terminated by "end"\n.+ fubar\nfubar cannot call itself
+define fubar
+fubar
+end
+
+# CHECK 2 define fubar\nEnter commands for "fubar" terminated by "end"\n.+ def\nIgnoring entry: define/def
+define fubar
+def
+end
+
+# CHECK 3 define fubar\nEnter commands for "fubar" terminated by "end"\n.+ doc\nIgnoring entry: document/doc
+define fubar
+doc
+end
+
+# CHECK 4 define fubar\nEnter commands for "fubar" terminated by "end"\n.+ doc\nIgnoring entry: document/doc
+define fubar
+doc
+end
+
+# CHECK 5 def ls\nCannot overwrite built-in command "ls"
+def ls
+
+# CHECK 6 doc ls\nCannot overwrite built-in command "ls"
+doc ls
+
+# CHECK 7 doc nothing\n"nothing" must be defined before documenting
+doc nothing
+
+# empty commands should do nothing
+define empty
+end
+
+# CHECK 8 empty\n.+ #nada
+empty
+#nada
+
+# define a more useful command using built-in commands only
+define tuple_0
+cd cp0
+cd v_tuple_u32_dbl_str/
+p 0
+cd ..
+cd ..
+end
+
+doc tuple_0
+First line of tuple_0 doc string
+Second line of tuple_0 doc string
+end
+
+# define a more useful command using built-in commands only
+define pair_0
+cd cp0
+cd v_pair_u64_str/
+p first
+cd ..
+cd ..
+end
+
+doc pair_0
+First line of pair_0 doc string
+Second line of pair_0 doc string
+end
+
+# Show help ( not checked )
+help
+
+# CHECK 9 tuple_0\n0 = 8 \(
+tuple_0
+
+# CHECK 10 pair_0\nfirst = 42 \(
+pair_0
+
+# combine into another macro
+define duo
+tuple_0
+pair_0
+end
+
+# CHECK 11 duo\n0 = 8 \(.+\nfirst = 42 \(
+duo
+
+# multiple levels of nesting
+define trio
+duo
+pair_0
+tuple_0
+end
+
+# CHECK 12 trio\n0 = 8 \(.+\nfirst = 42 \(.+\nfirst = 42 \(.+\n0 = 8 \(
+trio
+
+EOF
+
+# Update this whenever adding checks in the command comments above
+NUMCHECKS=13
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
+echo $LAUNCH
+revVal=0
+$LAUNCH << EOF  | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console/cmd-handler-16.0.sh
+++ b/tests/debug-console/cmd-handler-16.0.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER DEV
-#EXT_TEST TEST_FILE_DESC "Basic interactive command check: cd, ls, pwd, run, continue"
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Check setHandler commands with trace"
 #EXT_TEST TIMEOUT 30
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
@@ -26,20 +27,30 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF  | tee $LOGFILE
-pwd
-ls
+$LAUNCH << EOF  | tee $LOGFILE 
 cd cp0
-chdir my_info_
-list -l
-run 1us
-time
-r 1us
-continue 1us
-tm
-c 4us
-confirm false
-shutd
+run 2us
+trace size changed : 16 14 : size : interactive
+printWatchpoint 0
+run
+printTrace 0
+sethandler 0 ac ae
+printWatchpoint 0
+run
+printTrace 0
+setHandler 0 bc be
+printWatchpoint 0
+run
+printTrace 0
+setHandler 0 ae
+printWatchpoint 0
+run
+printTrace 0
+setHandler 0 all
+printWatchpoint 0
+run
+printTrace 0
+shutdown
 EOF
 
 retVal=$?
@@ -52,8 +63,8 @@ if [ $retVal -ne 0 ]; then
   exit $retVal
 fi
 
-# pwd
-PSTR="/"
+# all
+PSTR="WP0: TriggerCount 0 : ALL : cp0/size CHANGED  : bufsize = 16 postDelay = 14 : cp0/size  : interactive"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -62,8 +73,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# ls
-PSTR="cp0/"
+# ac ae
+PSTR="WP0: TriggerCount 2 : AC AE : cp0/size CHANGED  : bufsize = 16 postDelay = 14 : cp0/size  : interactive"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -72,8 +83,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# cd cp0, chdir my_info_, list
-PSTR="defaultTimeBase (ro) = 1 ns"
+# bc be
+PSTR="WP0: TriggerCount 1 : BC BE : cp0/size CHANGED  : bufsize = 16 postDelay = 14 : cp0/size  : interactive"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -82,58 +93,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# run 1us
-PSTR="Entering interactive mode at time 1000000"
-grep "$PSTR" $LOGFILE > /dev/null
-retVal=$?
-if [ $retVal -ne 0 ]; then
-  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
-  exit $retVal
-fi
-echo "Found pass string \"$PSTR\""
-
-# time
-PSTR="current time = 1000000"
-grep "$PSTR" $LOGFILE > /dev/null
-retVal=$?
-if [ $retVal -ne 0 ]; then
-  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
-  exit $retVal
-fi
-echo "Found pass string \"$PSTR\""
-
-# r 1us
-PSTR="Entering interactive mode at time 2000000"
-grep "$PSTR" $LOGFILE > /dev/null
-retVal=$?
-if [ $retVal -ne 0 ]; then
-  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
-  exit $retVal
-fi
-echo "Found pass string \"$PSTR\""
-
-# continue 1us
-PSTR="Entering interactive mode at time 3000000"
-grep "$PSTR" $LOGFILE > /dev/null
-retVal=$?
-if [ $retVal -ne 0 ]; then
-  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
-  exit $retVal
-fi
-echo "Found pass string \"$PSTR\""
-
-# tm
-PSTR="> current time = 3000000"
-grep "$PSTR" $LOGFILE > /dev/null
-retVal=$?
-if [ $retVal -ne 0 ]; then
-  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
-  exit $retVal
-fi
-echo "Found pass string \"$PSTR\""
-
-# c 1us
-PSTR="Entering interactive mode at time 7000000"
+# ae
+PSTR="WP0: TriggerCount 2 : AE : cp0/size CHANGED  : bufsize = 16 postDelay = 14 : cp0/size  : interactive"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then

--- a/tests/debug-console/cmd-multithread-serial-16.0.sh
+++ b/tests/debug-console/cmd-multithread-serial-16.0.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER DEV
-#EXT_TEST TEST_FILE_DESC "Basic interactive command check: cd, ls, pwd, run, continue"
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Test basic thread commands in serial exec: thread, info"
 #EXT_TEST TIMEOUT 30
+#
+# SST DEV: 
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
 set -uo pipefail
@@ -10,13 +13,14 @@ set -uo pipefail
 # Set default ensure failure if not set and component not installed
 SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
 
+
 # Settings
 CLEANUP=1
 SCRIPT_NAME=$(basename "$0")
 TNAME="${SCRIPT_NAME%.*}"
 echo "TESTNAME=$TNAME"
 CONFIG="dbgsst15.py"
-PSTR="^Entering interactive mode at time 140000000"
+PSTR=""
 
 LOGFILE=$TNAME.log
 OUTFILE=$TNAME.console.out
@@ -26,20 +30,17 @@ CHKFILE=$TNAME.chk
 # Launch the program to start interactive mode at time 0
 LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
-$LAUNCH << EOF  | tee $LOGFILE
-pwd
-ls
+$LAUNCH 2>&1 << EOF | tee $LOGFILE || exit 1
+info current
+info all
+thread 1
+info current
+thread 0
 cd cp0
-chdir my_info_
-list -l
-run 1us
-time
-r 1us
-continue 1us
-tm
-c 4us
-confirm false
-shutd
+watch size changed
+run
+unwatch 0
+run
 EOF
 
 retVal=$?
@@ -52,8 +53,17 @@ if [ $retVal -ne 0 ]; then
   exit $retVal
 fi
 
-# pwd
-PSTR="/"
+# Avoid diff due to differences btwn mac and linux
+#diff $LOGFILE $CHKFILE > /dev/null
+#retVal=$?
+#if [ $retVal -ne 0 ]; then
+#  echo "ERROR in diff $LOGFILE $CHKFILE"
+#  exit $retVal
+#fi
+#echo "Log file matches check file"
+
+# Interactive
+PSTR="Entering interactive mode at time 0"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -62,8 +72,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# ls
-PSTR="cp0/"
+# info current
+PSTR="Rank 0/1 Thread 0/1 (Process"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -72,8 +82,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# cd cp0, chdir my_info_, list
-PSTR="defaultTimeBase (ro) = 1 ns"
+# thread 1
+PSTR="ThreadID 1 out of range"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -82,8 +92,18 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# run 1us
-PSTR="Entering interactive mode at time 1000000"
+# info current 
+PSTR="Rank 0/1 Thread 1/2"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -eq 0 ]; then
+  echo "ERROR found fail string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "No fail string \"$PSTR\""
+
+# watch
+PSTR="Added watchpoint #0"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -92,8 +112,7 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# time
-PSTR="current time = 1000000"
+PSTR="Entering interactive mode at time 100000"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -102,38 +121,7 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# r 1us
-PSTR="Entering interactive mode at time 2000000"
-grep "$PSTR" $LOGFILE > /dev/null
-retVal=$?
-if [ $retVal -ne 0 ]; then
-  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
-  exit $retVal
-fi
-echo "Found pass string \"$PSTR\""
-
-# continue 1us
-PSTR="Entering interactive mode at time 3000000"
-grep "$PSTR" $LOGFILE > /dev/null
-retVal=$?
-if [ $retVal -ne 0 ]; then
-  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
-  exit $retVal
-fi
-echo "Found pass string \"$PSTR\""
-
-# tm
-PSTR="> current time = 3000000"
-grep "$PSTR" $LOGFILE > /dev/null
-retVal=$?
-if [ $retVal -ne 0 ]; then
-  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
-  exit $retVal
-fi
-echo "Found pass string \"$PSTR\""
-
-# c 1us
-PSTR="Entering interactive mode at time 7000000"
+PSTR=" WP0: AC : cp0/size"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -143,8 +131,8 @@ fi
 echo "Found pass string \"$PSTR\""
 
 # Simulation Complete
-PSTR="Simulation is complete"
-grep "$PSTR" $LOGFILE > /dev/null
+PSTR="Simulation is complete, simulated time: 1.0017 ms"
+egrep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""

--- a/tests/debug-console/cmd-set-15.1.sh
+++ b/tests/debug-console/cmd-set-15.1.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER DEV
-#EXT_TEST TEST_FILE_DESC "Basic interactive command check: cd, ls, pwd, run, continue"
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Check for set and print commands"
 #EXT_TEST TIMEOUT 30
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
@@ -27,17 +28,38 @@ CHKFILE=$TNAME.chk
 LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
 $LAUNCH << EOF  | tee $LOGFILE
-pwd
-ls
 cd cp0
-chdir my_info_
-list -l
+ls
+set v_bool false
+set v_char 9
+set v_schar -9
+set v_short -10
+set v_ushort 10
+s v_int -11
+s v_uint 11
+s v_long -12
+s v_ulong 12
+s v_ll -13
+s v_ull 13
+s v_float 9.14159
+s v_double 10.14159
+s v_ldouble 11.14159
 run 1us
-time
-r 1us
-continue 1us
-tm
-c 4us
+print v_bool
+print v_char
+print v_schar
+print v_short
+print v_ushort
+p v_int
+p v_uint
+p v_long
+p v_ulong
+p v_ll
+p v_ull
+p v_float
+p v_double
+p v_ldouble
+run 5us
 confirm false
 shutd
 EOF
@@ -52,8 +74,18 @@ if [ $retVal -ne 0 ]; then
   exit $retVal
 fi
 
-# pwd
-PSTR="/"
+# v_bool
+PSTR="v_bool = (0|false)"
+egrep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# v_char
+PSTR="v_char = 9"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -62,8 +94,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# ls
-PSTR="cp0/"
+# v_schar
+PSTR="v_schar = -9"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -72,8 +104,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# cd cp0, chdir my_info_, list
-PSTR="defaultTimeBase (ro) = 1 ns"
+# v_short
+PSTR="v_short = -10"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -82,8 +114,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# run 1us
-PSTR="Entering interactive mode at time 1000000"
+# v_ushort
+PSTR="v_ushort = 10"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -92,8 +124,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# time
-PSTR="current time = 1000000"
+# v_int
+PSTR="v_int = -11"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -102,8 +134,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# r 1us
-PSTR="Entering interactive mode at time 2000000"
+# v_uint
+PSTR="v_uint = 11"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -112,8 +144,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# continue 1us
-PSTR="Entering interactive mode at time 3000000"
+# v_long
+PSTR="v_long = -12"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -122,8 +154,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# tm
-PSTR="> current time = 3000000"
+# v_ulong
+PSTR="v_ulong = 12"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -132,9 +164,49 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# c 1us
-PSTR="Entering interactive mode at time 7000000"
+# v_ll
+PSTR="v_ll = -13"
 grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# v_ull
+PSTR="v_ull = 13"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# v_float
+PSTR="v_float = 9.141590"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# v_double (full precision value varies across platforms)
+PSTR="v_double = 10.1415900000000[0-9]+"
+egrep "v_double = 10.1415900000000[0-9]+" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# v_ldouble (full precision value varies across platforms)
+PSTR="vl_double = 11.1415900000000[0-9]+"
+egrep "v_ldouble = 11.1415900000000[0-9]+" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
@@ -151,6 +223,7 @@ if [ $retVal -ne 0 ]; then
   exit $retVal
 fi
 echo "Found pass string \"$PSTR\""
+
 
 # Cleanup output file on pass
 if [ $CLEANUP -eq 1 ]; then

--- a/tests/debug-console/cmd-setstr-15.1.sh
+++ b/tests/debug-console/cmd-setstr-15.1.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_MINVER 15.1
+#EXT_TEST TEST_FILE_MAXVER 16.0
 #EXT_TEST TEST_FILE_DESC "Check set string with spaces"
 #EXT_TEST TIMEOUT 30
 
@@ -16,7 +17,7 @@ SCRIPT_NAME=$(basename "$0")
 TNAME="${SCRIPT_NAME%.*}"
 echo "TESTNAME=$TNAME"
 CONFIG="test_Checkpoint_4ms.py"
-PSTR="test_string = \"my big beautiful string\" (std::string)"
+PSTR="test_string = my big beautiful string (std::string)"
 
 LOGFILE=$TNAME.log
 OUTFILE=$TNAME.console.out
@@ -31,7 +32,7 @@ cd c0
 ls
 set test_string my big beautiful string
 run 1us
-print -v 2 test_string
+print test_string
 shutdown
 EOF
 

--- a/tests/debug-console/cmd-t2-define-16.0.sh
+++ b/tests/debug-console/cmd-t2-define-16.0.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Check user-defined commands in multiple threads."
+#NOTE: User defined commands are currently context sensitive, meaning they 
+#     are tied to the thread in which they are defined. 
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Settings
+CLEANUP=1
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="dbgsst15.py"
+RANKS=1
+THREADS=2
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+cat << EOF > $CMDFILE
+confirm false
+
+# The checking convention is: CHECK <id> <regexp>
+# regexp and have multiple \n characters but not a trailing \n
+
+define foo0
+cd cp0
+print v_short
+end
+
+thread 1
+
+define foo1
+cd cp1
+print v_int
+end
+ 
+thread 0
+
+
+# CHECK 0 foo0\nv_short = -2 \(
+foo0
+
+thread 1
+
+# CHECK 1 foo1\nv_int = -3 \(
+foo1
+
+shutdown
+EOF
+
+# Update this whenever adding checks in the command comments above
+NUMCHECKS=2
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst -n $THREADS --interactive-start --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
+echo $LAUNCH
+revVal=0
+$LAUNCH << EOF  | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console/cmd-t4-ckptaction-16.0.sh
+++ b/tests/debug-console/cmd-t4-ckptaction-16.0.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Check that trace checkpoint action triggers checkpoints with 4 threads"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Convenience environment variables
+set +u
+if [[ -z "${CLEANUP}" ]]; then
+CLEANUP=1
+fi
+if [[ -z "${VERBOSE}" ]]; then
+  VERBOSE=0
+fi
+
+set -u
+
+# Common settings
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="test_Checkpoint_4ms.py"
+RANKS=1
+THREADS=4
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+CKPTPREFIX=ckpt_$TNAME
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+# Console commands
+cat << EOF > $CMDFILE
+cd c0
+cd xorshift
+trace w changed : 32 4 : w x y z : checkpoint
+setHandler 0 ae ac
+# CHECK 0 printWatchpoint 0\nWP0: TriggerCount 0 : AC AE : c0/xorshift/w CHANGED  : bufsize = 32 postDelay = 4 : c0/xorshift/w c0/xorshift/x c0/xorshift/y c0/xorshift/z  : checkpoint
+printWatchpoint 0
+run 100us
+shutdown
+EOF
+
+# for later
+# CHECK 1 run100us.+\n# Simulation Checkpoint: Simulated Time 96 us
+# CHECK 2 shutdown.+\nSimulation is complete, simulated time: 0 s
+
+# Update this whenever adding checks in the command comments above
+NUMCHECKS=1
+
+# Remove stale checkpoint directory if necessary
+if [ -d "$CKPTPREFIX" ]; then
+        echo "Removing stale checkpoint directory '$CKPTPREFIX'"
+        rm -rf $CKPTPREFIX
+fi
+
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --verbose=$VERBOSE -n $THREADS --interactive-start=0s --checkpoint-enable --checkpoint-prefix=$CKPTPREFIX $CONFIG"
+echo $LAUNCH
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# Simulation Complete
+PSTR="# Simulation Checkpoint: Simulated Time 97 us"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# Simulation Complete
+PSTR="Simulation is complete, simulated time: 0 s"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# Check that checkpoint files exist
+if [ ! -d "$CKPTPREFIX" ]; then
+	echo "ERROR checkpoint directory '$CKPTPREFIX' does not exits"
+	exit $retVal
+else 
+	CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000.sstcpt"
+	if [ ! "$CKPTFILE" ]; then
+		echo "ERROR missing $CKPTFILE"
+		exit $retVal
+	fi
+	CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000_0_0.bin"
+	if [ ! "$CKPTFILE" ]; then
+		echo "ERROR missing $CKPTFILE"
+		exit $retVal
+	fi
+        # Should be a bin file for each thread
+        CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000_0_1.bin"
+        if [ ! "$CKPTFILE" ]; then
+                echo "ERROR missing $CKPTFILE"
+                exit $retVal
+        fi
+        CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000_0_2.bin"
+        if [ ! "$CKPTFILE" ]; then
+                echo "ERROR missing $CKPTFILE"
+                exit $retVal
+        fi
+        CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000_0_3.bin"
+        if [ ! "$CKPTFILE" ]; then
+                echo "ERROR missing $CKPTFILE"
+                exit $retVal
+        fi
+	CKPTFILE="${CKPTPREFIX}/${CKPTPREFIX}_1_30000000/${CKPTPREFIX}_1_30000000_globals.bin"
+	if [ ! "$CKPTFILE" ]; then
+		echo "ERROR missing $CKPTFILE"
+		exit $retVal
+	fi
+fi
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+  rm -rf $CKPTPREFIX
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console/cmd-trace-16.0.sh
+++ b/tests/debug-console/cmd-trace-16.0.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER DEV
-#EXT_TEST TEST_FILE_DESC "Basic interactive command check: cd, ls, pwd, run, continue"
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Check for trace commands: trace, printWatchpoint, addTraceVar, printTrace, resetTrace, unwatch, quit"
 #EXT_TEST TIMEOUT 30
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
@@ -27,19 +28,36 @@ CHKFILE=$TNAME.chk
 LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
 $LAUNCH << EOF  | tee $LOGFILE
-pwd
-ls
 cd cp0
-chdir my_info_
-list -l
-run 1us
-time
-r 1us
-continue 1us
-tm
-c 4us
-confirm false
-shutd
+trace size > 50 : 32 4 : size : interactive
+printWatchpoint 0
+addTraceVar 0 rCheck
+printWatchpoint 0
+run
+printTrace 0
+resetTrace 0
+printTrace 0
+unwatch 0
+trace size changed : 10 2 : size rCheck : interactive
+printWatchpoint 1
+run
+prt 1
+rst 1
+prt 1
+uw 1
+trace minData < size : 8 0 : size : interactive
+printWatchpoint 2
+add 2 maxData
+printWatchpoint 2
+run 
+printTrace 2
+unwatch 2
+trace size changed && maxData > 90 || minData < maxData || rCheck changed : 4 2 : rCheck size minData maxData : interactive
+printWatchpoint 3
+run
+printTrace 3
+quit
+yes
 EOF
 
 retVal=$?
@@ -52,8 +70,8 @@ if [ $retVal -ne 0 ]; then
   exit $retVal
 fi
 
-# pwd
-PSTR="/"
+#trace size > 50, printWatchpoint
+PSTR="WP0: TriggerCount 0 : ALL : cp0/size > 50  : bufsize = 32 postDelay = 4 : cp0/size  : interactive"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -62,8 +80,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# ls
-PSTR="cp0/"
+# addTraceVar, printWatchpoint
+PSTR="WP0: TriggerCount 0 : ALL : cp0/size > 50  : bufsize = 32 postDelay = 4 : cp0/size cp0/rCheck  : interactive"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -72,8 +90,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# cd cp0, chdir my_info_, list
-PSTR="defaultTimeBase (ro) = 1 ns"
+# run, printTrace
+PSTR="LastTriggerRecord:@cycle202000: SamplesLost=0: cp0/size=100 cp0/rCheck=1"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -82,8 +100,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# run 1us
-PSTR="Entering interactive mode at time 1000000"
+# resetTrace, printTrace 
+PSTR="No trace samples in current buffer"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -92,8 +110,9 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# time
-PSTR="current time = 1000000"
+
+# trace size changed, printWatchpoint 
+PSTR="WP1: TriggerCount 0 : ALL : cp0/size CHANGED  : bufsize = 10 postDelay = 2 : cp0/size cp0/rCheck  : interactive"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -102,8 +121,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# r 1us
-PSTR="Entering interactive mode at time 2000000"
+# run, printTrace
+PSTR="LastTriggerRecord:@cycle300000: SamplesLost=0: cp0/size=53 cp0/rCheck=-46"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -112,8 +131,9 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# continue 1us
-PSTR="Entering interactive mode at time 3000000"
+
+# trace minData < size, printWP
+PSTR="WP2: TriggerCount 0 : ALL : cp0/minData < cp0/size  : bufsize = 8 postDelay = 0 : cp0/size  : interactive"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -122,8 +142,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# tm
-PSTR="> current time = 3000000"
+# add, printWatchpoint
+PSTR="WP2: TriggerCount 0 : ALL : cp0/minData < cp0/size  : bufsize = 8 postDelay = 0 : cp0/size cp0/maxData  : interactive"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -132,8 +152,38 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# c 1us
-PSTR="Entering interactive mode at time 7000000"
+# run, printTrace 0
+PSTR="LastTriggerRecord:@cycle302000: SamplesLost=0: cp0/size=53 cp0/maxData=100"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# trace size changed && maxData > 90, printWatchpoint
+PSTR="WP3: TriggerCount 0 : ALL : cp0/size CHANGED cp0/maxData > 90 cp0/minData < cp0/maxData cp0/rCheck CHANGED  : bufsize = 4 postDelay = 2 : cp0/rCheck cp0/size cp0/minData cp0/maxData  : interactive"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# run, printTrace 0
+PSTR="LastTriggerRecord:@cycle304000: SamplesLost=0: cp0/rCheck=-46 cp0/size=53 cp0/minData=1 cp0/maxData=100"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+
+# quit
+PSTR="Removing all watchpoints and exiting ObjectExplorer"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -151,6 +201,7 @@ if [ $retVal -ne 0 ]; then
   exit $retVal
 fi
 echo "Found pass string \"$PSTR\""
+
 
 # Cleanup output file on pass
 if [ $CLEANUP -eq 1 ]; then

--- a/tests/debug-console/cmd-unwatch-16.0.sh
+++ b/tests/debug-console/cmd-unwatch-16.0.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER NEW
-#EXT_TEST TEST_FILE_DESC "Check set string with spaces"
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Check interactive console unwatch command"
 #EXT_TEST TIMEOUT 30
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
@@ -15,8 +16,8 @@ CLEANUP=1
 SCRIPT_NAME=$(basename "$0")
 TNAME="${SCRIPT_NAME%.*}"
 echo "TESTNAME=$TNAME"
-CONFIG="test_Checkpoint_4ms.py"
-PSTR="test_string = \"my big beautiful string\" (std::string)"
+CONFIG="dbgsst15.py"
+PSTR=""
 
 LOGFILE=$TNAME.log
 OUTFILE=$TNAME.console.out
@@ -24,14 +25,22 @@ CMDFILE=$TNAME.cmd
 CHKFILE=$TNAME.chk
 
 # Launch the program to start interactive mode at time 0
-LAUNCH="sst --interactive-start=0s $CONFIG"
+LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
 $LAUNCH << EOF  | tee $LOGFILE
-cd c0
-ls
-set test_string my big beautiful string
-run 1us
-print -v 2 test_string
+cd cp0
+watch maxData > 10
+watch maxData > 100
+unwatch 
+yes
+watchlist
+watch maxData > 111
+watch maxData > 222
+watch maxData > 333
+unwatch 1
+unwatch 
+no
+watchlist
 shutdown
 EOF
 
@@ -45,6 +54,16 @@ if [ $retVal -ne 0 ]; then
   exit $retVal
 fi
 
+# Check for correct watchlist result
+PSTR="0: TriggerCount 0 : ALL : cp0/maxData > 111  : interactive"
+grep "$PSTR" $LOGFILE > /dev/null
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $retVal
+fi
+echo "Found pass string \"$PSTR\""
+PSTR="2: TriggerCount 0 : ALL : cp0/maxData > 333  : interactive"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -65,7 +84,7 @@ echo "Found pass string \"$PSTR\""
 
 # Cleanup output file on pass
 if [ $CLEANUP -eq 1 ]; then
-  rm -f $LOGFILE $OUTFILE $CMDFILE
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
 fi
 
 wait

--- a/tests/debug-console/cmd-watch-16.0.sh
+++ b/tests/debug-console/cmd-watch-16.0.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER DEV
-#EXT_TEST TEST_FILE_DESC "Basic interactive command check: cd, ls, pwd, run, continue"
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Check watch commands with different trigger types"
 #EXT_TEST TIMEOUT 30
 
 # ensure non-zero exit code in pipe propagates and no unbound variables.
@@ -27,19 +28,20 @@ CHKFILE=$TNAME.chk
 LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG"
 echo $LAUNCH
 $LAUNCH << EOF  | tee $LOGFILE
-pwd
-ls
 cd cp0
-chdir my_info_
-list -l
-run 1us
-time
-r 1us
-continue 1us
-tm
-c 4us
-confirm false
-shutd
+watch size > 0
+printWatchpoint 0
+run
+watch size changed
+printWatchpoint 1
+run
+watch size > minData
+printWatchpoint 2
+run
+watch size > minData && size < maxData || rCheck changed
+printWatchpoint 3
+run
+shutdown
 EOF
 
 retVal=$?
@@ -52,8 +54,8 @@ if [ $retVal -ne 0 ]; then
   exit $retVal
 fi
 
-# pwd
-PSTR="/"
+# watch size > 0, printWatchpoint 0
+PSTR="WP0: TriggerCount 0 : ALL : cp0/size > 0  : interactive"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -62,8 +64,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# ls
-PSTR="cp0/"
+# run
+PSTR="Entering interactive mode at time 100000"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -72,8 +74,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# cd cp0, chdir my_info_, list
-PSTR="defaultTimeBase (ro) = 1 ns"
+# watch size changed, printWatchpoint
+PSTR="WP1: TriggerCount 0 : ALL : cp0/size CHANGED  : interactive"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -82,8 +84,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# run 1us
-PSTR="Entering interactive mode at time 1000000"
+# run
+PSTR="Entering interactive mode at time 101000"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -92,8 +94,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# time
-PSTR="current time = 1000000"
+# watch size > minData, printWatchpoint 0
+PSTR="WP2: TriggerCount 0 : ALL : cp0/size > cp0/minData  : interactive"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -102,8 +104,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# r 1us
-PSTR="Entering interactive mode at time 2000000"
+# run
+PSTR="Entering interactive mode at time 102000"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -112,8 +114,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# continue 1us
-PSTR="Entering interactive mode at time 3000000"
+# watch size > minData && size < maxData || rCheck changed, printWatchpoint
+PSTR="WP3: TriggerCount 0 : ALL : cp0/size > cp0/minData cp0/size < cp0/maxData cp0/rCheck CHANGED  : interactive"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -122,8 +124,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# tm
-PSTR="> current time = 3000000"
+# run
+PSTR="Entering interactive mode at time 103000"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -132,8 +134,8 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Found pass string \"$PSTR\""
 
-# c 1us
-PSTR="Entering interactive mode at time 7000000"
+# shutdown
+PSTR="Exiting ObjectExplorer and shutting down simulation"
 grep "$PSTR" $LOGFILE > /dev/null
 retVal=$?
 if [ $retVal -ne 0 ]; then

--- a/tests/debug-console/type-aggregate-16.0.sh
+++ b/tests/debug-console/type-aggregate-16.0.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Exercise aggregate types"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Convenience environment variables
+set +u
+if [[ -z "${CLEANUP}" ]]; then
+  CLEANUP=1
+fi
+if [[ -z "${VERBOSE}" ]]; then
+  VERBOSE=0
+fi
+set -u
+
+# Common settings
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="dbgsst15.py"
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+cat << EOF > $CMDFILE
+confirm false
+
+# The checking convention is: CHECK <id> <regexp>
+# regexp and have multiple \n characters but not a trailing \n
+
+cd cp0
+ls
+
+#-- Print intial values
+
+# CHECK 0 p v_ag_class\nv_ag_class \(SSTDEBUG::DbgSST15::ag_class_t\)\n 0 = 42 \(.+\n 1 = ag_class_t \(
+p v_ag_class
+
+# CHECK 1 p v_ag_struct\nv_ag_struct \(SSTDEBUG::DbgSST15::ag_struct_t\)\n 0 = 42 \(.+\n 1 = ag_struct_t \(
+p v_ag_struct
+
+# Trivially serializable types do not automatically map
+# CHECK 2 p v_ag_union\nUnknown object in print command: v_ag_union
+p v_ag_union
+
+# CHECK 3 p v_ag_union_struct\nUnknown object in print command: v_ag_union_struct
+p v_ag_union_struct
+
+#-- Navigate into objects, print, set and check values
+
+cd v_ag_class
+# CHECK 4 ls\n0 = 42 \(.+\n1 = ag_class_t \(
+ls
+set 0 100
+set 1 howdy_class
+# CHECK 5 ls\n0 = 100 \(.+\n1 = howdy_class \(
+ls
+
+cd ..
+cd v_ag_struct
+# CHECK 6 ls\n0 = 42 \(.+\n1 = ag_struct_t \(
+ls
+set 0 200
+set 1 howdy_struct
+# CHECK 7 ls\n0 = 200 \(.+\n1 = howdy_struct \(
+ls
+
+cd ..
+
+### Set watchpoints and run
+
+cd v_ag_class
+watch 0 changed
+# CHECK 8 setHandler 0 ac\nWP 0 - cp0/v_ag_class/0
+setHandler 0 ac
+run
+# CHECK 9 ls\n0 = 101 \(.+\n1 = 19 \(
+ls
+run
+# CHECK 10 ls\n0 = 102 \(.+\n1 = 38 \(
+ls
+run
+# CHECK 11 ls\n0 = 103 \(.+\n1 = 57 \(
+ls
+unwatch
+
+cd ..
+cd v_ag_struct
+watch 0 changed
+# CHECK 12 setHandler 0 ac\nWP 0 - cp0/v_ag_struct/0
+setHandler 0 ac
+run
+# CHECK 13 ls\n0 = 203 \(.+\n1 = 69 \(
+ls
+run
+# CHECK 14 ls\n0 = 204 \(.+\n1 = 92 \(
+ls
+run
+# CHECK 15 ls\n0 = 205 \(.+\n1 = 115 \(
+ls
+unwatch
+
+cd ..
+
+#TODO Traces
+
+shutdown
+
+EOF
+
+# Update this whenever adding checks in the command comments above
+NUMCHECKS=16
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug --verbose=$VERBOSE $CONFIG"
+echo $LAUNCH
+revVal=0
+$LAUNCH << EOF  | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console/type-arrays-16.0.sh
+++ b/tests/debug-console/type-arrays-16.0.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Exercise arrays with one component"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Convenience environment variables
+set +u
+if [[ -z "${CLEANUP}" ]]; then
+CLEANUP=1
+fi
+if [[ -z "${VERBOSE}" ]]; then
+  VERBOSE=0
+fi
+
+set -u
+
+# Common settings
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="omni.py"
+CONFIG_OPTS="--function0=dbgsst15.OMArrays"
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+cat << EOF > $CMDFILE
+confirm false
+
+# The checking convention is: CHECK <id> <regexp>
+# regexp and have multiple \n characters but not a trailing \n
+
+cd c0
+cd function0/
+cd v_ping_t/
+# CHECK 0 pwd\nc0/function0/v_ping_t \(unsigned short \[1000\]\)
+pwd
+
+# CHECK 1 p 0\n0 = 1 \(unsigned short\)
+p 0
+
+# CHECK 2 p 999\n999 = 1000 \(unsigned short\)
+p 999
+
+# CHECK 3 p 1000\nUnknown object in print command: 1000
+p 1000
+
+# CHECK 4 p -1\nUnknown object in print command: -1
+p -1
+
+run 8ns
+# CHECK 5 p 42\n42 = 50 \(unsigned short\)
+p 42
+
+watch 42 changed
+run 5ns
+
+# CHECK 6 p 42\n42 = 51 \(
+p 42
+
+unwatch
+watch 42 > 55
+run 10ns
+# CHECK 7 p 42\n42 = 55 \(
+p 42
+
+# now check pong which performs memcopy of ping.
+cd ..
+cd v_pong_t
+
+# CHECK 8 pwd\nc0/function0/v_pong_t \(unsigned short \[1000\]\)
+pwd
+# CHECK 9 p 42\n42 = 54 \(
+p 42
+
+# TODO operator== not working for integers (overloaded with indices)
+# https://github.com/tactcomplabs/sst-core/issues/38
+# unwatch
+# watch 42 == 60
+# run 20ns
+
+# But we can use array of floats
+cd ..
+cd ..
+cd function0
+cd v_xyz
+cd 2
+cd 4
+
+# CHECK 10 p 6\n6 = 117.000.+ \(
+p 6
+
+unwatch
+watch 6 > 120.0 && 6 < 122.0
+run 20ns
+# CHECK 11 p 6\n6 = 121.000.+ \(
+p 6
+
+# TODO Post BUG: this is not less than 122.0
+run 20ns
+# CHECK 12 p 6\n6 = 122.000.+ \(
+p 6
+
+# TODO see above. Why breaking here?
+run 20ns
+# CHECK 13 p 6\n6 = 122.000.+ \(
+p 6
+
+run 20ns
+# CHECK 14 p 6\n6 = 137.000.+ \(
+p 6
+
+shutdown
+
+EOF
+
+# IMPORTANT: Update this whenever adding checks in the command comments above
+NUMCHECKS=15
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug --verbose=$VERBOSE $CONFIG -- $CONFIG_OPTS"
+echo $LAUNCH
+revVal=0
+$LAUNCH << EOF  | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console/type-bitset-16.0.sh
+++ b/tests/debug-console/type-bitset-16.0.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Exercise std::bitset and std::vector<bool>"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Settings
+CLEANUP=1
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="dbgsst15.py"
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+cat << EOF > $CMDFILE
+confirm false
+cd cp0
+ls
+cd v_bitset42/
+ls
+# CHECK 0 p 0\n0 = false \(bool\)
+p 0
+# CHECK 1 p 3\n3 = true \(bool\)
+p 3
+# CHECK 2 p 38\n38 = false \(bool\)
+p 38
+# CHECK 3 p 39\n39 = true \(bool\)
+p 39
+# Flip bits 38 and 39
+set 38 1
+set 39 0
+run 1ns
+# CHECK 4 p 38\n38 = true \(bool\)
+p 38
+# CHECK 5 p 39\n39 = false \(bool\)
+p 39
+cd ..
+# std::vector<bool> v_vecbool  =  { true, false, true, true, false, false, true, true};
+p v_vecbool
+cd v_vecbool
+ls
+# CHECK 6 p 5\n5 = false \(bool\)
+p 5
+# CHECK 7 p 6\n6 = true \(bool\)
+p 6
+# flip 5 and 6
+set 5 1
+set 6 0
+run 1ns
+ls
+# CHECK 8 p 5\n5 = true \(bool\)
+p 5
+# CHECK 9 p 6\n6 = false \(bool\)
+p 6
+
+# Invalid setting
+set 5 0x10
+# CHECK 10 p 5\n5 = true \(bool\)
+p 5
+
+# Watch a vector bool bit
+watch 7 changed
+# CHECK 11 run\n---- Rank0:Thread0: Entering interactive mode
+run
+ls
+
+# clear all watches
+unwatch
+
+# back up to bitset and do the same
+cd ..
+cd v_bitset42/
+watch 41 changed
+# CHECK 12 run\n---- Rank0:Thread0: Entering interactive mode
+run
+ls
+
+EOF
+
+# Update this whenever adding checks in the command comments above
+NUMCHECKS=13
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
+echo $LAUNCH
+revVal=0
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console/type-f0array-f1queue-16.0.sh
+++ b/tests/debug-console/type-f0array-f1queue-16.0.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Exercise arrays and tuples in 1 component with 2 slots"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Convenience environment variables
+set +u
+if [[ -z "${CLEANUP}" ]]; then
+CLEANUP=1
+fi
+if [[ -z "${VERBOSE}" ]]; then
+  VERBOSE=0
+fi
+
+set -u
+
+# Common settings
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="omni.py"
+CONFIG_OPTS="--function0=dbgsst15.OMArrays --function1=dbgsst15.OMQueue"
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+cat << EOF > $CMDFILE
+confirm false
+
+# The checking convention is: CHECK <id> <regexp>
+# regexp and have multiple \n characters but not a trailing \n
+
+cd c0
+cd function0/
+cd v_ping_t/
+# CHECK 0 pwd\nc0/function0/v_ping_t \(unsigned short \[1000\]\)
+pwd
+
+# CHECK 1 p 0\n0 = 1 \(unsigned short\)
+p 0
+
+# CHECK 2 p 999\n999 = 1000 \(unsigned short\)
+p 999
+
+# CHECK 3 p 1000\nUnknown object in print command: 1000
+p 1000
+
+# CHECK 4 p -1\nUnknown object in print command: -1
+p -1
+
+run 8ns
+# CHECK 5 p 42\n42 = 50 \(unsigned short\)
+p 42
+
+watch 42 changed
+run 5ns
+
+# CHECK 6 p 42\n42 = 51 \(
+p 42
+
+unwatch
+watch 42 > 55
+run 10ns
+# CHECK 7 p 42\n42 = 55 \(
+p 42
+
+# now check pong which performs memcopy of ping.
+cd ..
+cd v_pong_t
+
+# CHECK 8 pwd\nc0/function0/v_pong_t \(unsigned short \[1000\]\)
+pwd
+# CHECK 9 p 42\n42 = 54 \(
+p 42
+
+# TODO operator== appears to not be working. ( test all of them )
+# unwatch
+# watch 42 == 60
+# run 20ns
+
+shutdown
+
+EOF
+
+# IMPORTANT: Update this whenever adding checks in the command comments above
+NUMCHECKS=10
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug --verbose=$VERBOSE $CONFIG -- $CONFIG_OPTS"
+echo $LAUNCH
+revVal=0
+$LAUNCH << EOF  | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console/type-nested-containers-16.0.sh
+++ b/tests/debug-console/type-nested-containers-16.0.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "show handling (or not) of rediculously long type strings"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Convenience environment variables
+set +u
+if [[ -z "${CLEANUP}" ]]; then
+CLEANUP=1
+fi
+if [[ -z "${VERBOSE}" ]]; then
+  VERBOSE=0
+fi
+
+set -u
+
+# Common settings
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="omni.py"
+CONFIG_OPTS="--function0=dbgsst15.OMNestedContainers"
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+cat << EOF > $CMDFILE
+confirm false
+
+# The checking convention is: CHECK <id> <regexp>
+# regexp and have multiple \n characters but not a trailing \n
+
+cd c0
+cd function0/
+ls
+cd v_type3_
+ls
+cd 0
+ls
+cd 0
+ls
+cd first
+ls
+
+# CHECK 1 ls\n0 = one \(.+\n1 = two \(.+\n2 = three \(
+ls
+
+shutdown
+
+EOF
+
+# IMPORTANT: Update this whenever adding checks in the command comments above
+NUMCHECKS=1
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug --verbose=$VERBOSE $CONFIG -- $CONFIG_OPTS"
+echo $LAUNCH
+revVal=0
+$LAUNCH << EOF  | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console/type-pair-16.0.sh
+++ b/tests/debug-console/type-pair-16.0.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "short std::pair watch test"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Settings
+CLEANUP=1
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="dbgsst15.py"
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+cat << EOF > $CMDFILE
+cd cp0
+p v_pair_u64_str
+cd v_pair_u64_str/
+watch first changed
+run
+# CHECK 0 p first\nfirst = 5 \(unsigned long( long)?\)
+p first
+# CHECK 1 p second\nsecond = S5 \(std::string\)
+p second
+confirm false
+unwatch
+EOF
+
+# Update this whenever adding checks in the command comments above
+NUMCHECKS=2
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
+echo $LAUNCH
+revVal=0
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console/type-priority-queue-16.0.sh
+++ b/tests/debug-console/type-priority-queue-16.0.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Exercise std::priority_queue<unsigned>"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Settings
+CLEANUP=1
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="dbgsst15.py"
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+cat << EOF > $CMDFILE
+confirm false
+
+# The checking convention is: CHECK <id> <regexp>
+# regexp and have multiple \n characters but not a trailing \n
+
+# Extend the test time
+cd cp1
+ls
+set clocks 1000000
+cd ..
+cd cp0
+set clocks 1000000
+
+# CHECK 0 p v_priority_queue_unsigned\nv_priority_queue_unsigned \(
+p v_priority_queue_unsigned
+
+cd v_priority_queue_unsigned
+# CHECK 1 ls\ncontainer/ \(
+ls
+
+# CHECK 2 p container\ncontainer .+\n 0 = 3 .+\n 1 = 2 .+\n 2 = 1
+p container
+
+cd container
+# CHECK 3 ls\n0 = 3 .+\n1 = 2 .+\n2 = 1
+ls
+
+# CHECK 4 p 0\n0 = 3
+p 0
+
+# CHECK 5 p 1\n1 = 2
+p 1
+
+# CHECK 6 p 2\n2 = 1
+p 2
+
+set 0 1300
+set 1 1200
+set 2 1100
+# CHECK 7 ls\n0 = 1300 .+\n1 = 1200 .+\n2 = 1100
+ls
+
+# advance simulator sufficiently to observe change in front data
+run 10400ns
+
+# Here we see only the original values changing
+# 1300000: v_queue_unsigned.front()=200
+# 1300000: v_queue_unsigned.front()=200
+# 2600000: v_queue_unsigned.front()=300
+# 2600000: v_queue_unsigned.front()=300
+# 3900000: v_queue_unsigned.front()=101
+# 3900000: v_queue_unsigned.front()=101
+# 5200000: v_queue_unsigned.front()=201
+# 5200000: v_queue_unsigned.front()=201
+# 6500000: v_queue_unsigned.front()=301
+# 6500000: v_queue_unsigned.front()=301
+# 7800000: v_queue_unsigned.front()=102
+# 7800000: v_queue_unsigned.front()=102
+# 9100000: v_queue_unsigned.front()=202
+# 9100000: v_queue_unsigned.front()=202
+
+# CHECK 8 pwd\ncp0/v_priority_queue_unsigned/container \(
+pwd
+
+# The values read do not match what is printed.
+ls
+# 0 = 1306 (unsigned int) <- this has changed!
+# 1 = 1100 (unsigned int)
+# 2 = 1200 (unsigned int)
+
+#TODO Depending on how we handle the above add trace testing.
+
+shutdown
+
+EOF
+
+# Update this whenever adding checks in the command comments above
+NUMCHECKS=9
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
+echo $LAUNCH
+revVal=0
+$LAUNCH << EOF  | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console/type-queue-1-16.0.sh
+++ b/tests/debug-console/type-queue-1-16.0.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Exercise std::queue<unsigned> with one component"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Settings
+CLEANUP=1
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="omni.py"
+CONFIG_OPTS="--function0=dbgsst15.OMQueue --verbose=0"
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+cat << EOF > $CMDFILE
+confirm false
+
+# The checking convention is: CHECK <id> <regexp>
+# regexp and have multiple \n characters but not a trailing \n
+
+cd c0
+cd function0/
+cd v_queue_unsigned_/
+cd container/
+# CHECK 0 pwd\nc0/function0/v_queue_unsigned_/container \(
+pwd
+
+# CHECK 1 ls\n0 = 100 \(.+\n1 = 200 \(.+\n2 = 300 \(
+ls
+# 0 = 100 (unsigned int)
+# 1 = 200 (unsigned int)
+# 2 = 300 (unsigned int)
+run 10ns
+# 1000: v_queue_unsigned_.front()=200
+# 2000: v_queue_unsigned_.front()=300
+# 3000: v_queue_unsigned_.front()=101
+# 4000: v_queue_unsigned_.front()=201
+# 5000: v_queue_unsigned_.front()=301
+# 6000: v_queue_unsigned_.front()=102
+# 7000: v_queue_unsigned_.front()=202
+# 8000: v_queue_unsigned_.front()=302
+# 9000: v_queue_unsigned_.front()=103
+# Entering interactive mode at time 10000 
+# Ran clock for 10000 sim cycles
+
+# CHECK 2 ls\n0 = 103 \(.+\n1 = 203 \(.+\n2 = 303 \(
+ls
+# 0 = 103 (unsigned int)
+# 1 = 203 (unsigned int)
+# 2 = 303 (unsigned int)
+
+# sst-core #1517 refreshes object map on break into interactive mode.
+# Solution for watchpoints is....?
+
+# watch 0 changed
+# run
+# # check- 3 ls\n0 = 104 \(.+\n1 = 204 \(.+\n2 = 304 \(
+# ls
+
+# run
+# # check- 4 ls\n0 = 105 \(.+\n1 = 205 \(.+\n2 = 305 \(
+# ls
+
+# unwatch 0
+# watch 0 > 200
+# # check- 5 ls\n0 = 201 \(.+\n1 = 301 \(.+\n2 = 401 \(
+# ls
+
+shutdown
+
+EOF
+
+# Update this whenever adding checks in the command comments above
+NUMCHECKS=3
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- $CONFIG_OPTS"
+echo $LAUNCH
+revVal=0
+$LAUNCH << EOF  | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console/type-queue-16.0.sh
+++ b/tests/debug-console/type-queue-16.0.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Exercise std::queue<unsigned>"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Settings
+CLEANUP=1
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="dbgsst15.py"
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+cat << EOF > $CMDFILE
+confirm false
+
+# The checking convention is: CHECK <id> <regexp>
+# regexp and have multiple \n characters but not a trailing \n
+
+# Extend the test time
+cd cp1
+ls
+set clocks 1000000
+cd ..
+cd cp0
+set clocks 1000000
+
+# CHECK 0 p v_queue_unsigned\nv_queue_unsigned \(
+p v_queue_unsigned
+
+cd v_queue_unsigned
+# CHECK 1 ls\ncontainer/ \(
+ls
+
+# CHECK 2 p container\ncontainer .+\n 0 = 100 .+\n 1 = 200 .+\n 2 = 300
+p container
+
+cd container
+# CHECK 3 ls\n0 = 100 .+\n1 = 200 .+\n2 = 300
+ls
+
+# CHECK 4 p 0\n0 = 100
+p 0
+
+# CHECK 5 p 1\n1 = 200
+p 1
+
+# CHECK 6 p 2\n2 = 300
+p 2
+
+set 0 1100
+set 1 1200
+set 2 1300
+# CHECK 7 ls\n0 = 1100 .+\n1 = 1200 .+\n2 = 1300
+ls
+
+# advance simulator sufficiently to observe change in front data
+run 10400ns
+
+# confirm cp0 front value is changing
+# DbgSST15[cp0:tickleBits:1300000]: v_queue_unsigned.front()=1200
+# DbgSST15[cp0:tickleBits:2600000]: v_queue_unsigned.front()=1300
+# DbgSST15[cp0:tickleBits:3900000]: v_queue_unsigned.front()=1101
+# DbgSST15[cp0:tickleBits:5200000]: v_queue_unsigned.front()=1201
+# DbgSST15[cp0:tickleBits:6500000]: v_queue_unsigned.front()=1301
+# DbgSST15[cp0:tickleBits:7800000]: v_queue_unsigned.front()=1102
+# DbgSST15[cp0:tickleBits:9100000]: v_queue_unsigned.front()=1202
+
+# CHECK 8 pwd\ncp0/v_queue_unsigned/container \(
+pwd
+
+# CHECK 9 ls\n0 = 1202 \(.+\n1 = 1302 \(.+\n2 = 1103 \(
+ls
+# 0 = 1202 (unsigned int)
+# 1 = 1302 (unsigned int)
+# 2 = 1103 (unsigned int)
+
+shutdown
+
+EOF
+
+# Update this whenever adding checks in the command comments above
+NUMCHECKS=10
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
+echo $LAUNCH
+revVal=0
+$LAUNCH << EOF  | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console/type-stack-16.0.sh
+++ b/tests/debug-console/type-stack-16.0.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Exercise std::stack<unsigned>"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Settings
+CLEANUP=1
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="dbgsst15.py"
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+cat << EOF > $CMDFILE
+confirm false
+
+# The checking convention is: CHECK <id> <regexp>
+# regexp and have multiple \n characters but not a trailing \n
+
+cd cp0
+ls
+# CHECK 0 p v_stack_unsigned\nv_stack_unsigned \(
+p v_stack_unsigned
+
+cd v_stack_unsigned
+# CHECK 1 ls\ncontainer/ \(
+ls
+
+# CHECK 2 p container\ncontainer .+\n 0 = 10 .+\n 1 = 20 .+\n 2 = 30
+p container
+
+cd container
+# CHECK 3 ls\n0 = 10 .+\n1 = 20 .+\n2 = 30
+ls
+
+# CHECK 4 p 0\n0 = 10
+p 0
+
+# CHECK 5 p 1\n1 = 20
+p 1
+
+# CHECK 6 p 2\n2 = 30
+p 2
+
+watch 0 changed
+watch 1 changed
+watch 2 changed
+run
+
+# CHECK 7 pwd\ncp0/v_stack_unsigned/container
+pwd
+
+# CHECK 8 ls\n0 = 10 .+\n1 = 20 .+\n2 = 31 .+
+ls
+
+run
+# CHECK 9 ls\n0 = 10 .+\n1 = 20 .+\n2 = 32 .+
+ls
+
+run
+# CHECK 10 ls\n0 = 10 .+\n1 = 20 .+\n2 = 33 .+
+ls
+
+run
+# CHECK 11 ls\n0 = 10 .+\n1 = 20 .+\n2 = 34 .+
+ls
+
+set 2 200
+# CHECK 12 ls\n0 = 10 .+\n1 = 20 .+\n2 = 200 .+
+ls
+
+run
+run
+# CHECK 13 ls\n0 = 10 .+\n1 = 20 .+\n2 = 201 .+
+ls
+
+# stack does not have an emplace member function but we can still write values in the debugger
+set 0 100
+set 1 150
+# CHECK 14 ls\n0 = 100 .+\n1 = 150 .+\n2 = 201 .+
+ls
+
+run
+run
+# CHECK 15 ls\n0 = 100 .+\n1 = 150 .+\n2 = 202 .+
+ls
+
+# now do a trace
+unwatch
+
+# CHECK 16 trace 2 changed  : 4 2 : 0 1 2 : interactive\nAdded watchpoint #0
+trace 2 changed  : 4 2 : 0 1 2 : interactive
+
+sethandler 0 ac
+run
+
+# TODO add this check when iconsole is merged. The current checker can't handle optional lines.
+# --check-- 17 printTrace 0\nTriggerRecord:@cycle7700000: samples lost = 0:.+\nbuf\[2] AC .+ \(-) cp0.+/2=202[ ]*\nbuf\[3] AC .+ \(\!) cp0.+/2=203[ ]*\nbuf\[0] AC .+ \(\+) cp0.+/2=203[ ]*\nbuf\[1] AC .+ \(\+) cp0.+/2=203
+printTrace 0
+
+# Expected when iconsole branch merged
+# TriggerCount=1 <-- HERE this is being added
+# TriggerRecord:@cycle7700000: samples lost = 0: cp0/v_stack_unsigned/container/0=100 cp0/v_stack_unsigned/container/1=150 cp0/v_stack_unsigned/container/2=203 
+# buf[2] AC @7699000 (-) cp0/v_stack_unsigned/container/0=100 cp0/v_stack_unsigned/container/1=150 cp0/v_stack_unsigned/container/2=202 
+# buf[3] AC @7700000 (!) cp0/v_stack_unsigned/container/0=100 cp0/v_stack_unsigned/container/1=150 cp0/v_stack_unsigned/container/2=203 
+# buf[0] AC @7701000 (+) cp0/v_stack_unsigned/container/0=100 cp0/v_stack_unsigned/container/1=150 cp0/v_stack_unsigned/container/2=203 
+# buf[1] AC @7702000 (+) cp0/v_stack_unsigned/container/0=100 cp0/v_stack_unsigned/container/1=150 cp0/v_stack_unsigned/container/2=203 
+
+
+shutdown
+
+EOF
+
+# Update this whenever adding checks in the command comments above
+NUMCHECKS=17
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
+echo $LAUNCH
+revVal=0
+$LAUNCH << EOF  | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console/type-tuple-16.0.sh
+++ b/tests/debug-console/type-tuple-16.0.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Exercise std::pair and std::tuple"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Settings
+CLEANUP=1
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="dbgsst15.py"
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+cat << EOF > $CMDFILE
+confirm false
+cd cp0
+ls
+
+# The pair
+p v_pair_u64_str
+cd v_pair_u64_str/
+ls
+# CHECK 0 p first\nfirst = 42 \(unsigned long( long)?\)
+p first
+# CHECK 1 p second\nsecond = forty-two \(std::string\)
+p second
+# Change values
+set first 11
+set second eleven
+run 1ns
+# CHECK 2 p first\nfirst = 11 \(unsigned long( long)?\)
+p first
+# CHECK 3 p second\nsecond = eleven \(std::string\)
+p second
+# Set watch on numeric type (cannot do string at the moment)
+watch first changed
+run
+ls
+# CHECK 4 p first\nfirst = 5 \(unsigned long( long)?\)
+p first
+# CHECK 5 p second\nsecond = S5 \(std::string\)
+p second
+unwatch
+
+# The tuple
+cd ..
+p v_tuple_u32_dbl_str
+cd v_tuple_u32_dbl_str/
+ls
+# CHECK 6 p 0\n0 = 8 \(unsigned int\)
+p 0
+# CHECK 7 p 1\n1 = 0.1250.+ \(double\)
+p 1
+# CHECK 8 p 2\n2 = eight \(std::string\)
+p 2
+# Change values
+s 0 1
+s 1 1.0
+s 2 one
+run 1ns
+ls
+# CHECK 9 p 0\n0 = 1 \(unsigned int\)
+p 0
+# CHECK 10 p 1\n1 = 1.0.+ \(double\)
+p 1
+# CHECK 11 p 2\n2 = one \(std::string\)
+p 2
+# watch it
+watch 0 changed
+run
+ls
+# CHECK 12 p 0\n0 = 7 \(unsigned int\)
+p 0
+# CHECK 13 p 1\n1 = 0.142.+ \(double\)
+p 1
+# CHECK 14 p 2\n2 = S7 \(std::string\)
+p 2
+shutdown
+EOF
+
+# Update this whenever adding checks in the command comments above
+NUMCHECKS=15
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
+echo $LAUNCH
+revVal=0
+( $LAUNCH << EOF || exit 11 ) | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console/type-union-16.0.sh
+++ b/tests/debug-console/type-union-16.0.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER 16.0
+#EXT_TEST TEST_FILE_MAXVER 16.0
+#EXT_TEST TEST_FILE_DESC "Exercise unions with one component"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Convenience environment variables
+set +u
+if [[ -z "${CLEANUP}" ]]; then
+CLEANUP=1
+fi
+if [[ -z "${VERBOSE}" ]]; then
+  VERBOSE=0
+fi
+
+set -u
+
+# Common settings
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="omni.py"
+CONFIG_OPTS="--function0=dbgsst15.OMUnions"
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+cat << EOF > $CMDFILE
+confirm false
+
+# The checking convention is: CHECK <id> <regexp>
+# regexp and have multiple \n characters but not a trailing \n
+
+cd c0
+cd function0/
+cd v_union_int_float_method_1/
+# CHECK 0 pwd\nc0/function0/v_union_int_float_method_1 \(
+pwd
+
+# CHECK 1 ls\nf = 0\.000000.+
+ls
+
+run 1us
+
+# CHECK 2 ls\nf = 1998\.000000.+
+ls
+
+watch f changed
+run 1us
+
+# CHECK 3 ls\nf = 2000\.000000.+
+ls
+
+cd ..
+cd v_union_struct_method_1/ 
+
+#TODO Values are different between Mac and Ubuntu. Don't check values for now.
+# CHECK 4 ls\nv = 3621246928 \(
+ls
+
+unwatch
+watch v changed
+run 1us
+
+# CHECK 5 ls\nv = 3654932946 \(
+ls
+
+shutdown
+
+EOF
+
+# IMPORTANT: Update this whenever adding checks in the command comments above
+NUMCHECKS=6
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug --verbose=$VERBOSE $CONFIG -- $CONFIG_OPTS"
+echo $LAUNCH
+revVal=0
+$LAUNCH << EOF  | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/rt_action/sigalrm-16.0.sh
+++ b/tests/rt_action/sigalrm-16.0.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER DEV
+#EXT_TEST TEST_FILE_MINVER 16.0
 #EXT_TEST TEST_FILE_DESC "Tests sigalrm for single real time actions"
 #EXT_TEST TIMEOUT 240
 # 

--- a/tests/rt_action/sigalrm_ckpt_comb-16.0.sh
+++ b/tests/rt_action/sigalrm_ckpt_comb-16.0.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#EXT_TEST TEST_FILE_MINVER DEV
+#EXT_TEST TEST_FILE_MINVER 16.0
 #EXT_TEST TEST_FILE_DESC "Tests sigalrm for checkpoint combined with other real time actions"
 # 
 # 0) set pass string 


### PR DESCRIPTION
This is an initial attempt to support sst16 and the object tree branch since sst16 will remain on the old cli. 

- sst16 compatible tests have min/max version of 16.0 which means they will NOT be run on the sandia devel branches. The assumption here is that the object tree will make it's way into the sandia devel branch.

Case 1:
obj_tree_expr is merged into sandia devel branch: All is well, leave new tests with MINVERSION=DEV.

Case 2:
obj_tree_expr is not merged into devel branch: All is less well. Now we have to change the new tests to using MINVERSION=NEW ( and use the -DENABLE_NEW_TESTS=ON ). Tests will need to have MAXVERSION=16.0 removed....

If we maintain a special branch at TCL we'll likely just have to maintain a separate branch of sst-ext-tests. 

Getting back to this PR.  Only tests were added except cmd-basic.sh was changed to use MINVERSION=DEV. The added tests all have _16.0.sh or _15.1.sh suffixes to indicate their limited lifetime.

Here are the tests that failed for me using sst-core/obj_tree_expr branch.

```
The following tests FAILED:
	 66 - cmd-actions (Failed)                              DEV
	 77 - cmd-handler (Failed)                              DEV
	 83 - cmd-multithread-actions (Failed)                  DEV
	118 - cmd-r2-t1-actions (Failed)                        DEV
	121 - cmd-r2-t1-rank1-actions (Failed)                  DEV
	127 - cmd-r4-t2-ckptaction (Failed)                     DEV
	129 - cmd-r4-t2-rank1-actions (Failed)                  DEV
```

Does this correlate to you're results?



