### PR TITLE
Sanity tests to support debug

### DIFF
--- a/components/core-debug/CMakeLists.txt
+++ b/components/core-debug/CMakeLists.txt
@@ -22,6 +22,8 @@ set(DbgSST15Srcs
   dbgsst15.h
   probe.cc
   probe.h
+  test_cpt.cc
+  test_cpt.h
 )
 
 add_library(dbgsst15 SHARED ${DbgSST15Srcs})

--- a/components/core-debug/CMakeLists.txt
+++ b/components/core-debug/CMakeLists.txt
@@ -18,6 +18,8 @@ set(DbgSST15Srcs
   om-nested-containers.cc
   om-unions.cc
   om-unions.h
+  dbgmin.h
+  dbgmin.cc
   dbgsst15.cc
   dbgsst15.h
   probe.cc

--- a/components/core-debug/dbgmin.cc
+++ b/components/core-debug/dbgmin.cc
@@ -1,0 +1,57 @@
+//
+// _dbgmin_cc_
+//
+// Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "dbgmin.h"
+
+// #include <cinttypes>
+// #include <sstream>
+
+namespace SSTDEBUG::DbgMin {
+
+//------------------------------------------
+// DbgMin
+//------------------------------------------
+DbgMin::DbgMin(SST::ComponentId_t id, const SST::Params& params) :
+    SST::Component(id),
+    clocks(2),
+    curCycle(0)
+{
+    output.init("DbgMin[" + getName() + ":@p:@t]: ", 1, 0, SST::Output::STDOUT);
+    clockHandler               = new SST::Clock::Handler2<DbgMin, &DbgMin::clockTick>(this);
+    timeConverter              = registerClock("1GHz", clockHandler);
+    registerAsPrimaryComponent();
+    primaryComponentDoNotEndSim();
+}
+
+void
+DbgMin::serialize_order(SST::Core::Serialization::serializer& ser)
+{
+    SST::Component::serialize_order(ser);
+    // debug console issue: output object serialization causing asan error
+    #if 1
+    SST_SER(output);
+    #endif
+    SST_SER(clocks);
+}
+
+bool
+DbgMin::clockTick(SST::Cycle_t currentCycle)
+{
+    if ( currentCycle >= clocks ) {
+        primaryComponentOKToEndSim();
+        return true;
+    }
+    curCycle++;
+    return false;
+}
+
+} // namespace SSTDEBUG::DbgMin
+
+// EOF

--- a/components/core-debug/dbgmin.h
+++ b/components/core-debug/dbgmin.h
@@ -1,0 +1,90 @@
+//
+// _dbgmin_h_
+//
+// Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef _SST_EXT_TESTS_DBGMIN_H_
+#define _SST_EXT_TESTS_DBGMIN_H_
+
+// -- Standard Headers
+
+// -- SST Headers
+#include "SST.h"
+
+namespace SSTDEBUG::DbgMin {
+
+// -------------------------------------------------------
+// DbgMin
+// -------------------------------------------------------
+class DbgMin : public SST::Component
+{
+public:
+    /// DbgMin: top-level SST component constructor
+    DbgMin(SST::ComponentId_t id, const SST::Params& params);
+
+    /// DbgMin: top-level SST component destructor
+    ~DbgMin() {};
+
+    /// DbgMin: standard SST component clock function
+    bool clockTick(SST::Cycle_t currentCycle);
+
+    // -------------------------------------------------------
+    // DbgMin Component Registration Data
+    // -------------------------------------------------------
+    SST_ELI_REGISTER_COMPONENT(DbgMin,   // component class
+                             "dbgsst15",   // component library
+                             "DbgMin",   // component name
+                             SST_ELI_ELEMENT_VERSION(1, 0, 0),
+                             "CHKPNT SST COMPONENT",
+                             COMPONENT_CATEGORY_UNCATEGORIZED)
+
+    SST_ELI_DOCUMENT_PARAMS()
+
+    // -------------------------------------------------------
+    // DbgMin Component Port Data
+    // -------------------------------------------------------
+    SST_ELI_DOCUMENT_PORTS()
+
+    // -------------------------------------------------------
+    // DbgMin SubComponent Parameter Data
+    // -------------------------------------------------------
+    SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS()
+
+    // -------------------------------------------------------
+    // DbgMin Component Statistics Data
+    // -------------------------------------------------------
+    SST_ELI_DOCUMENT_STATISTICS()
+
+    // -------------------------------------------------------
+    // DbgMin Component Checkpoint Methods
+    // -------------------------------------------------------
+    /// DbgMin: serialization constructor
+    DbgMin() :
+        SST::Component()
+    {} // For serialization only
+
+    /// DbgMin: serialization
+    void serialize_order(SST::Core::Serialization::serializer& ser) override;
+
+    /// DbgMin: serialization implementations
+    ImplementSerializable(SSTDEBUG::DbgMin::DbgMin)
+
+private:
+    SST::Output              output;                    ///< SST output handler
+    SST::TimeConverter       timeConverter = {};        ///< SST time conversion handler
+    SST::Clock::HandlerBase* clockHandler = nullptr;    ///< Clock Handler
+    uint64_t                 clocks = 2;                ///< number of clocks to execute
+    uint64_t                 curCycle = 0;              ///< current cycle delay
+
+}; // class DbgMin
+
+} // namespace SSTDEBUG::DbgMin
+
+#endif // _SST_EXT_TESTS_DBGMIN_H_
+
+// EOF

--- a/components/core-debug/test_cpt.cc
+++ b/components/core-debug/test_cpt.cc
@@ -1,0 +1,310 @@
+// Copyright 2009-2026 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2026, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#include "test_cpt.h"
+
+#include "sst/core/rng/constant.h"
+#include "sst/core/rng/discrete.h"
+#include "sst/core/rng/expon.h"
+#include "sst/core/rng/gaussian.h"
+#include "sst/core/rng/marsaglia.h"
+#include "sst/core/rng/mersenne.h"
+#include "sst/core/rng/poisson.h"
+#include "sst/core/rng/uniform.h"
+#include "sst/core/rng/xorshift.h"
+
+#include <cassert>
+#include <cinttypes>
+
+// using namespace SST;
+using namespace SST::ExtTest;
+
+coreTestCheckpoint::coreTestCheckpoint(ComponentId_t id, Params& params) :
+    Component(id)
+{
+    bool starter = params.find<bool>("starter", true);
+    if ( starter ) {
+        counter = params.find<uint32_t>("counter", 1000);
+    }
+    else {
+        counter = 0;
+    }
+    registerAsPrimaryComponent();
+    primaryComponentDoNotEndSim();
+
+    link_left =
+        configureLink("port_left", new Event::Handler<coreTestCheckpoint, &coreTestCheckpoint::handleEvent>(this));
+    sst_assert(link_left, CALL_INFO, -1, "Could not configure left link");
+
+    link_right =
+        configureLink("port_right", new Event::Handler<coreTestCheckpoint, &coreTestCheckpoint::handleEvent>(this));
+    sst_assert(link_right, CALL_INFO, -1, "Could not configure right link");
+
+    test_string = params.find<std::string>("test_string", "");
+
+    std::string freq = params.find<std::string>("clock_frequency", "100kHz");
+
+    // Need to keep a pointer to the clock handler so we can
+    // reregister clock
+    clock_handler = new Clock::Handler<coreTestCheckpoint, &coreTestCheckpoint::handleClock>(this);
+
+    // TimeConverter* core_tc = registerClock(freq, clock_handler);
+    clock_tc         = registerClock(freq, clock_handler);
+    // Get a local copy of the clock_tc so we aren't using core's
+    // TimeConverter  local_tc(core_tc);
+    // clock_tc         = local_tc;
+    duty_cycle       = params.find<int>("clock_duty_cycle", 10);
+    duty_cycle_count = duty_cycle;
+
+    self_link = configureSelfLink(
+        "clock_restart", clock_tc, new Event::Handler<coreTestCheckpoint, &coreTestCheckpoint::restartClock>(this));
+
+    // Output
+    output = new Output(params.find<std::string>("output_prefix", ""), params.find<uint32_t>("output_verbose", 0), 0,
+        Output::output_location_t::STDOUT);
+    output_frequency = params.find<int>("output_frequency", 1);
+    if ( output_frequency < 1 ) output_frequency = 1;
+
+    // RNG & Distributions
+    marsaglia =
+        new RNG::MarsagliaRNG(params.find<unsigned int>("rng_seed_w", 7), params.find<unsigned int>("rng_seed_z", 5));
+
+    unsigned int rng_seed = params.find<unsigned int>("rng_seed", 11);
+    mersenne              = new RNG::MersenneRNG(rng_seed);
+    xorshift              = new RNG::XORShiftRNG(rng_seed + 1);
+
+    dist_const = new RNG::ConstantDistribution(params.find<double>("dist_const", 1.5));
+
+    std::vector<double> discrete_probs;
+    params.find_array<double>("dist_discrete_probs", discrete_probs);
+    if ( discrete_probs.empty() ) discrete_probs.push_back(1.0);
+
+    dist_discrete =
+        new RNG::DiscreteDistribution(discrete_probs.data(), (uint32_t) discrete_probs.size(), new RNG::MersenneRNG(rng_seed + 2));
+
+    dist_expon = new RNG::ExponentialDistribution(
+        params.find<double>("dist_exp_lambda", 1.0), new RNG::MersenneRNG(rng_seed + 3));
+
+    dist_gauss = new RNG::GaussianDistribution(params.find<double>("dist_gauss_mean", 1.0),
+        params.find<double>("dist_gauss_stddev", 0.2), new RNG::MersenneRNG(rng_seed + 4));
+
+    dist_poisson = new RNG::PoissonDistribution(
+        params.find<double>("dist_poisson_lambda", 1.0), new RNG::MersenneRNG(rng_seed + 5));
+
+    dist_uniform =
+        new RNG::UniformDistribution(params.find<uint32_t>("dist_uni_bins", 4), new RNG::MersenneRNG(rng_seed + 6));
+
+    stat_eventcount = registerStatistic<uint32_t>("eventcount");
+    stat_rng        = registerStatistic<uint32_t>("rngvals");
+    stat_dist       = registerStatistic<double>("distvals");
+    stat_null       = registerStatistic<uint32_t>("nullstat");
+}
+
+coreTestCheckpoint::~coreTestCheckpoint()
+{
+    delete mersenne;
+    delete marsaglia;
+    delete xorshift;
+    delete dist_const;
+    delete dist_discrete;
+    delete dist_expon;
+    delete dist_gauss;
+    delete dist_poisson;
+    delete dist_uniform;
+}
+
+void
+coreTestCheckpoint::init(unsigned UNUSED(phase))
+{
+    output->output("%s, init()\n", getName().c_str());
+
+    // Put data in the shared objects.  Since there are no IDs, and we can't differentiate the components from each
+    // other, we'll just have all of them put in the same values.
+    shared_array.initialize("shared_array", 10);
+    shared_set.initialize("shared_set");
+    shared_map.initialize("shared_map");
+    for ( int i = 0; i < 10; ++i ) {
+        shared_array.write(i, i);
+        shared_set.insert(i);
+        shared_map.write(i, i);
+    }
+}
+
+void
+coreTestCheckpoint::setup()
+{
+    output->output("%s, setup()\n", getName().c_str());
+    shared_array.publish();
+    shared_set.publish();
+    shared_map.publish();
+    if ( counter > 0 ) link_right->send(new coreTestCheckpointEvent(counter));
+}
+
+void
+coreTestCheckpoint::complete(unsigned UNUSED(phase))
+{
+    output->output("%s, complete()\n", getName().c_str());
+}
+
+// Report state that should persist through checkpoint/restart
+void
+coreTestCheckpoint::finish()
+{
+    output->output("%s finished. teststring=%s, output=('%s',%" PRIu32 ")\n", getName().c_str(), test_string.c_str(),
+        output->getPrefix().c_str(), output->getVerboseLevel());
+
+    // Check the shared objects
+
+    // Shared Array
+    bool error = false;
+    for ( int i = 0; i < 10; ++i ) {
+        if ( shared_array[i] != i ) error = true;
+    }
+
+    if ( error ) {
+        output->output("Error: contents in shared_array do not match");
+    }
+
+    // Shared Set
+    error     = false;
+    int count = 0;
+    for ( auto x : shared_set ) {
+        if ( x != count++ ) error = true;
+    }
+
+    if ( error ) {
+        output->output("Error: contents in shared_set do not match");
+    }
+
+    // Shared Map
+    error = false;
+    for ( auto x : shared_map ) {
+        if ( x.first != x.second ) error = true;
+    }
+
+    if ( error ) {
+        output->output("Error: contents in shared_map do not match");
+    }
+}
+
+// incoming event is bounced back after decrementing its counter
+// if counter is 0, end simulation
+void
+coreTestCheckpoint::handleEvent(Event* ev)
+{
+    coreTestCheckpointEvent* event = static_cast<coreTestCheckpointEvent*>(ev);
+
+    if ( event->decCount() ) {
+        getSimulationOutput().output("%s, OK to end simulation\n", getName().c_str());
+        primaryComponentOKToEndSim();
+    }
+    output->verbose(
+        CALL_INFO, 1, 0, "%s, bounce %d, t=%" PRIu64 "\n", getName().c_str(), event->getCount(), getCurrentSimCycle());
+    link_right->send(event);
+    stat_eventcount->addData(1);
+}
+
+// clock hander just prints
+bool
+coreTestCheckpoint::handleClock(Cycle_t cycle)
+{
+    double   gauss_next     = dist_gauss->getNextDouble();
+    uint32_t mersenne_next  = mersenne->generateNextUInt32();
+    uint32_t marsaglia_next = marsaglia->generateNextUInt32();
+    uint32_t xorshift_next  = xorshift->generateNextUInt32();
+    double   const_next     = dist_const->getNextDouble();
+    double   discrete_next  = dist_discrete->getNextDouble();
+    double   expon_next     = dist_expon->getNextDouble();
+    double   poisson_next   = dist_poisson->getNextDouble();
+    double   uniform_next   = dist_uniform->getNextDouble();
+
+    if ( (cycle % (SST::Cycle_t) output_frequency) == 0 ) {
+        output->verbose(CALL_INFO, 2, 0, "Clock cycle count = %" PRIu64 "\n", cycle);
+
+        output->verbose(CALL_INFO, 1, 0, "RNG: %" PRIu32 ", %" PRIu32 ", %" PRIu32 "\n", marsaglia_next, mersenne_next,
+            xorshift_next);
+        output->verbose(CALL_INFO, 1, 0, "Distributions: %f, %f, %f, %f, %f, %f\n", const_next, discrete_next,
+            expon_next, gauss_next, poisson_next, uniform_next);
+    }
+
+    stat_dist->addData(gauss_next);
+    stat_rng->addData(mersenne_next);
+    stat_null->addData(1);
+    duty_cycle_count--;
+    if ( duty_cycle_count == 0 ) {
+        duty_cycle_count = duty_cycle;
+        // Send a wakeup
+        self_link->send((SST::SimTime_t) duty_cycle, nullptr);
+        return true;
+    }
+    return false;
+}
+
+// restarts the clock
+void
+coreTestCheckpoint::restartClock(Event* UNUSED(ev))
+{
+    // Event passed in is nullptr, no need to do anything with it
+    reregisterClock(clock_tc, clock_handler);
+}
+
+
+void
+coreTestCheckpoint::printStatus(Output& out)
+{
+    out.output(
+        "Component Status: %s, %p, %" PRIu32 ", %s\n", getName().c_str(), link_right, counter, test_string.c_str());
+}
+
+void
+coreTestCheckpoint::emergencyShutdown()
+{
+    output->output("Component %s: Emergency Shutdown\n", getName().c_str());
+}
+
+void
+coreTestCheckpoint::serialize_order(SST::Core::Serialization::serializer& ser)
+{
+    SST::Component::serialize_order(ser);
+    SST_SER(link_left);
+    SST_SER(link_right);
+    SST_SER(self_link);
+    SST_SER(clock_handler);
+    SST_SER(clock_tc);
+    SST_SER(duty_cycle);
+    SST_SER(duty_cycle_count);
+    SST_SER(counter);
+    SST_SER(test_string);
+    SST_SER(output);
+    SST_SER(output_frequency);
+    SST_SER(mersenne);
+    SST_SER(marsaglia);
+    SST_SER(xorshift);
+    SST_SER(dist_const);
+    SST_SER(dist_discrete);
+    SST_SER(dist_expon);
+    SST_SER(dist_gauss);
+    SST_SER(dist_poisson);
+    SST_SER(dist_uniform);
+    SST_SER(stat_eventcount);
+    SST_SER(stat_rng);
+    SST_SER(stat_dist);
+    SST_SER(stat_null);
+    SST_SER(shared_array);
+    SST_SER(shared_array_uninit);
+    SST_SER(shared_set);
+    SST_SER(shared_set_uninit);
+    SST_SER(shared_map);
+    SST_SER(shared_map_uninit);
+}
+
+
+// Element Library / Serialization stuff

--- a/components/core-debug/test_cpt.h
+++ b/components/core-debug/test_cpt.h
@@ -16,18 +16,6 @@
 #define SST_EXT_TESTS_TEST_CPT_H
 
 #include "SST.h"
-// #include "sst/core/component.h"
-// #include "sst/core/event.h"
-// #include "sst/core/link.h"
-// #include "sst/core/rng/distrib.h"
-// #include "sst/core/rng/rng.h"
-// #include "sst/core/shared/sharedArray.h"
-// #include "sst/core/shared/sharedMap.h"
-// #include "sst/core/shared/sharedSet.h"
-
-#include <cstdint>
-#include <string>
-
 namespace SST::ExtTest {
 
 // Very simple starting case

--- a/components/core-debug/test_cpt.h
+++ b/components/core-debug/test_cpt.h
@@ -1,0 +1,186 @@
+// Copyright 2009-2026 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2026, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+// This is an SST16.0 version of sst/core/test/Elements/coreTest_Checkpoint.h
+// The duplicate is here as a baseline reference in case the sst-core version changes
+
+#ifndef SST_EXT_TESTS_TEST_CPT_H
+#define SST_EXT_TESTS_TEST_CPT_H
+
+#include "SST.h"
+// #include "sst/core/component.h"
+// #include "sst/core/event.h"
+// #include "sst/core/link.h"
+// #include "sst/core/rng/distrib.h"
+// #include "sst/core/rng/rng.h"
+// #include "sst/core/shared/sharedArray.h"
+// #include "sst/core/shared/sharedMap.h"
+// #include "sst/core/shared/sharedSet.h"
+
+#include <cstdint>
+#include <string>
+
+namespace SST::ExtTest {
+
+// Very simple starting case
+// Expected to have two components in simulation.
+// The components ping-pong an event until its count reaches 0
+
+class coreTestCheckpointEvent : public SST::Event
+{
+public:
+    coreTestCheckpointEvent() :
+        SST::Event(),
+        counter(1000)
+    {}
+
+    explicit coreTestCheckpointEvent(uint32_t c) :
+        SST::Event(),
+        counter(c)
+    {}
+
+    ~coreTestCheckpointEvent() {}
+
+    bool decCount()
+    {
+        if ( counter != 0 ) counter--;
+        return counter == 0;
+    }
+
+    uint32_t getCount() { return counter; }
+
+private:
+    uint32_t counter;
+
+    void serialize_order(SST::Core::Serialization::serializer& ser) override
+    {
+        Event::serialize_order(ser);
+        SST_SER(counter);
+    }
+
+    ImplementSerializable(SST::ExtTest::coreTestCheckpointEvent);
+};
+
+
+class coreTestCheckpoint : public SST::Component
+{
+public:
+    SST_ELI_REGISTER_COMPONENT(
+        coreTestCheckpoint,   // Component Class
+        "dbgsst15",           // Component Library
+        "coreTestCheckpoint", // component name
+        SST_ELI_ELEMENT_VERSION(1,0,0),
+        "CoreTest Test Checkpoint",
+        COMPONENT_CATEGORY_UNCATEGORIZED
+    )
+
+    SST_ELI_DOCUMENT_PARAMS(
+        { "starter", "Whether this component initiates the ping-pong", "T"},
+        { "count", "Number of times to bounce the message back and forth", "1000" },
+        { "test_string", "A test string", ""},
+        { "clock_frequency", "Frequency for clock", "100kHz"},
+        { "clock_duty_cycle", "Number of cycles to keep clock on and off", "10"},
+        // Testing output options
+        { "output_prefix", "Prefix for output", ""},
+        { "output_verbose", "Verbosity for output", "0"},
+        { "output_frequency", "How often, in terms of clock cycles, to generate output", "1"},
+        // Testing RNG & distributions
+        { "rng_seed_w",        "The first seed for marsaglia", "7" },
+        { "rng_seed_z",        "The second seed for marsaglia", "5" },
+        { "rng_seed",          "The seed for mersenne and xorshift", "11" },
+        { "dist_const",        "Constant for ConstantDistribution", "1.5" },
+        { "dist_discrete_probs", "Probabilities in discrete distribution", "[1.0]"},
+        { "dist_exp_lambda",    "Lambda for exponentional distribution", "1.0"},
+        { "dist_gauss_mean",    "Mean for Gaussian distribution", "1.0"},
+        { "dist_gauss_stddev",  "Standard deviation for Gaussian distribution", "0.2"},
+        { "dist_poisson_lambda", "Lambda for Poisson distribution", "1.0"},
+        { "dist_uni_bins",      "Number of proability bins for the uniform distribution", "4"}
+    )
+
+    SST_ELI_DOCUMENT_PORTS(
+        {"port_left", "Link to another coreTestCheckpoint", { "coreTestElement.coreTestCheckpointEvent", "" } },
+        {"port_right", "Link to another coreTestCheckpoint", { "coreTestElement.coreTestCheckpointEvent", "" } }
+    )
+
+    SST_ELI_DOCUMENT_STATISTICS(
+        {"eventcount", "Total number of events received", "events", 1},
+        {"rngvals", "Numbers from RNG", "number", 2},
+        {"distvals", "Numbers from distribution", "number", 3},
+        {"nullstat", "Test that non-enabled stats are checkpointed correctly", "number", 5}
+    )
+
+    SST_ELI_IS_CHECKPOINTABLE()
+
+    coreTestCheckpoint(ComponentId_t id, SST::Params& params);
+    ~coreTestCheckpoint();
+
+    void init(unsigned phase) override;
+
+    void setup() override;
+
+    void complete(unsigned phase) override;
+
+    void finish() override;
+
+    void printStatus(Output& out) override;
+
+    void emergencyShutdown() override;
+
+    // Serialization functions and macro
+    coreTestCheckpoint() :
+        Component()
+    {} // For serialization only
+    void serialize_order(SST::Core::Serialization::serializer& ser) override;
+    ImplementSerializable(SST::ExtTest::coreTestCheckpoint)
+
+private:
+    void handleEvent(SST::Event* ev);
+    bool handleClock(Cycle_t cycle);
+    void restartClock(SST::Event* ev);
+
+    SST::Link*          link_left;
+    SST::Link*          link_right;
+    SST::Link*          self_link;
+    TimeConverter       clock_tc;
+    Clock::HandlerBase* clock_handler;
+    int                 duty_cycle;       // Used to count clock on and off cycles
+    int                 duty_cycle_count; // Used to count clock on and off cycles
+    uint32_t            counter;          // Unused after setup
+    std::string         test_string;      // Test that string got serialized
+    Output*             output;
+    int                 output_frequency;
+
+    RNG::Random*             mersenne        = nullptr;
+    RNG::Random*             marsaglia       = nullptr;
+    RNG::Random*             xorshift        = nullptr;
+    RNG::RandomDistribution* dist_const      = nullptr;
+    RNG::RandomDistribution* dist_discrete   = nullptr;
+    RNG::RandomDistribution* dist_expon      = nullptr;
+    RNG::RandomDistribution* dist_gauss      = nullptr;
+    RNG::RandomDistribution* dist_poisson    = nullptr;
+    RNG::RandomDistribution* dist_uniform    = nullptr;
+    Statistic<uint32_t>*     stat_eventcount = nullptr;
+    Statistic<uint32_t>*     stat_rng        = nullptr;
+    Statistic<double>*       stat_dist       = nullptr;
+    Statistic<uint32_t>*     stat_null       = nullptr;
+
+
+    Shared::SharedArray<int>    shared_array;
+    Shared::SharedArray<int>    shared_array_uninit;
+    Shared::SharedSet<int>      shared_set;
+    Shared::SharedSet<int>      shared_set_uninit;
+    Shared::SharedMap<int, int> shared_map;
+    Shared::SharedMap<int, int> shared_map_uninit;
+};
+
+} //PTe SST::ExtTest
+
+#endif // SST_EXT_TESTS_TEST_CHECKPOINT_H

--- a/components/include/SST.h
+++ b/components/include/SST.h
@@ -49,6 +49,9 @@
 #include <sst/core/rng/mersenne.h>
 #include <sst/core/serialization/serialize.h>
 #include <sst/core/serialization/serializer.h>
+#include "sst/core/shared/sharedArray.h"
+#include "sst/core/shared/sharedMap.h"
+#include "sst/core/shared/sharedSet.h"
 #include <sst/core/subcomponent.h>
 #if 1 // Used for interactive console
 #include <sst/core/baseComponent.h>

--- a/tests/debug-console/dbgmin.py
+++ b/tests/debug-console/dbgmin.py
@@ -1,0 +1,15 @@
+#
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# dbgmin.py
+#
+
+import sst
+
+cp0 = sst.Component("cp0", "dbgsst15.DbgMin")
+
+# EOF

--- a/tests/debug-console/sanity-local-test.sh
+++ b/tests/debug-console/sanity-local-test.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "Minimal smoke test using local test_cpt component"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Settings
+CLEANUP=1
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="test_cpt.py"
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+cat << EOF > $CMDFILE
+# The checking convention is: CHECK <id> <regexp>
+# regexp and have multiple \n characters but not a trailing \n
+# There must be an empty line before '# CHECK'
+
+# CHECK 0 ls\nc0\/
+ls
+
+# CHECK 1 cd c0\n
+cd c0
+
+# CHECK 2 ls\nclock_handler\/
+ls
+
+confirm false
+quit
+EOF
+
+# Update this whenever adding checks in the command comments above
+NUMCHECKS=3
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
+echo $LAUNCH
+revVal=0
+$LAUNCH << EOF  | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# Simulation Complete
+PSTR="^Simulation is complete, simulated time: 4.007 ms$"
+egrep "$PSTR" $LOGFILE > /dev/null
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $RC
+fi
+echo "Found pass string \"$PSTR\""
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console/sanity-min.sh
+++ b/tests/debug-console/sanity-min.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "Minimal smoke test using dbgmin component"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Settings
+CLEANUP=1
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="dbgmin.py"
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+cat << EOF > $CMDFILE
+# The checking convention is: CHECK <id> <regexp>
+# regexp and have multiple \n characters but not a trailing \n
+# There must be an empty line before '# CHECK'
+
+# CHECK 0 ls\ncp0\/
+ls
+
+# CHECK 1 cd cp0\n
+cd cp0
+
+# CHECK 2 ls\nclocks
+ls
+
+set clocks 1000
+confirm false
+quit
+EOF
+
+# Update this whenever adding checks in the command comments above
+NUMCHECKS=3
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
+echo $LAUNCH
+revVal=0
+$LAUNCH << EOF  | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# Simulation Complete
+PSTR="^Simulation is complete, simulated time: 1 us$"
+egrep "$PSTR" $LOGFILE > /dev/null
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $RC
+fi
+echo "Found pass string \"$PSTR\""
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console/sanity-sstcore-test.sh
+++ b/tests/debug-console/sanity-sstcore-test.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+#EXT_TEST TEST_FILE_MINVER NEW
+#EXT_TEST TEST_FILE_DESC "Minimal smoke test using local test_cpt component"
+#EXT_TEST TIMEOUT 30
+
+# ensure non-zero exit code in pipe propagates and no unbound variables.
+set -uo pipefail
+
+# --add-lib-path required for Jenkins runs (does not run 'make install')
+# Set default ensure failure if not set and component not installed
+SST_COMPONENT_BASE="${SST_COMPONENT_BASE:=.}"
+
+# Settings
+CLEANUP=1
+SCRIPT_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME=$(basename "$0")
+TNAME="${SCRIPT_NAME%.*}"
+echo "TESTNAME=$TNAME"
+CONFIG="test_Checkpoint_4ms.py"
+
+LOGFILE=$TNAME.log
+OUTFILE=$TNAME.console.out
+CMDFILE=$TNAME.cmd
+CHKFILE=$TNAME.chk
+SPOTCHECKS=$(realpath "${SCRIPT_PATH}/../../scripts/spotchecks.awk")
+if [ ! -e "${SPOTCHECKS}" ]; then
+  echo "Checker script not found. [${SPOTCHECKS}]"
+  exit 1
+fi
+
+cat << EOF > $CMDFILE
+# The checking convention is: CHECK <id> <regexp>
+# regexp and have multiple \n characters but not a trailing \n
+# There must be an empty line before '# CHECK'
+
+# CHECK 0 ls\nc0\/
+ls
+
+# CHECK 1 cd c0\n
+cd c0
+
+# CHECK 2 ls\nclock_handler\/
+ls
+
+confirm false
+quit
+EOF
+
+# Update this whenever adding checks in the command comments above
+NUMCHECKS=3
+
+# Launch the program to start interactive mode at time 0
+LAUNCH="sst --interactive-start=0s --add-lib-path=$SST_COMPONENT_BASE/core-debug $CONFIG -- --verbose=0"
+echo $LAUNCH
+revVal=0
+$LAUNCH << EOF  | tee $LOGFILE
+replay $CMDFILE
+confirm false
+exit
+EOF
+
+retVal=$?
+
+echo $TNAME Complete
+
+# Check result
+if [ $retVal -ne 0 ]; then
+  echo "ERROR $TNAME returned $retVal"
+  exit $retVal
+fi
+
+# spot checks
+# First argument is the number of expected checks
+${SPOTCHECKS} $NUMCHECKS $LOGFILE
+
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR: Test Failed with RC=$RC"
+  exit $RC
+fi
+
+# Simulation Complete
+PSTR="^Simulation is complete, simulated time: 4.007 ms$"
+egrep "$PSTR" $LOGFILE > /dev/null
+RC=$?
+if [ $RC -ne 0 ]; then
+  echo "ERROR could not find pass string in $LOGFILE \"$PSTR\""
+  exit $RC
+fi
+echo "Found pass string \"$PSTR\""
+
+# Cleanup output file on pass
+if [ $CLEANUP -eq 1 ]; then
+  rm -f $LOGFILE $OUTFILE $CMDFILE $CHKFILE
+fi
+
+wait
+echo "PASS"
+exit 0

--- a/tests/debug-console/test_cpt.py
+++ b/tests/debug-console/test_cpt.py
@@ -1,0 +1,70 @@
+# Modified from https://github.com/sstsimulator/sst-core/tests/tests_Checkpoint.py
+# March 11, 2025
+# skuntz@tactcomplabs.com
+#
+
+# 6/4/26 KG - created this copy of test_Checkpoint_4ms.py which uses the internal copy
+# of the sst component
+
+import sst
+
+# Define the simulation components
+comp_count = 8   # Number of components
+start = 0        # This component should start the exchange
+comps = []
+
+for x in range(0,comp_count):
+    comp = sst.Component("c" + str(x), "dbgsst15.coreTestCheckpoint")
+    comp.addParams({
+      "clock_frequency" : "100 kHz",
+      "clock_duty_cycle" : 15,
+      "test_string" : "hello",
+      "output_prefix" : "c" + str(x) + " talking",
+      "output_verbose" : 2,
+      })
+
+    if x == start:
+        comp.addParam("starter", True)
+        comp.addParam("counter", 4000)
+        #comp.addParam("counter", 1000000000)
+        #comp.addParam("counter", 2000000) #1000)
+        comp.addParam("clock_duty_cycle", 20)
+        comp.addParam("dist_discrete_probs", [0.1, 0.3, 0.1, 0.2, 0.3])
+    else:
+        comp.addParam("starter", False)
+    comps.append(comp)
+
+for x in range(0,comp_count):
+    next_x = (x+1) % comp_count
+    link = sst.Link("link" + str(x))
+    link.connect( ( comps[x], "port_right", "1us"), (comps[next_x], "port_left", "1us") )
+
+# Stats config
+sst.setStatisticLoadLevel(0)
+sst.setStatisticOutput("sst.statOutputConsole")
+#sst.setStatisticOutput("sst.statOutputHDF5")
+#sst.setStatisticOutput("sst.statOutputJSON", {"outputsimtime" : "1"})
+#sst.setStatisticOutput("sst.statOutputTxt")
+#sst.setStatisticOutput("sst.statOutputCSV", {
+#    "filepath" : "test_Checkpoint_stats.csv",
+#    "separator" : "; " })
+sst.enableStatisticForComponentName("c0", "rngvals",
+    {"type":"sst.HistogramStatistic",
+     "minvalue" : 0,
+     "binwidth" : 400000000,
+     "numbins" : 10,
+     "IncludeOutOfBounds" : "T"
+})
+#sst.enableAllStatisticsForAllComponents()
+sst.enableAllStatisticsForAllComponents({ "rate" : "100us" })
+
+# Ensure that this will work for all parallelism.  The only case we
+# need to worry about is if comp_count <= num_threads and we have more
+# than one rank.
+num_threads = sst.getThreadCount()
+num_ranks = sst.getMPIRankCount()
+if num_threads >= comp_count and num_ranks > 1:
+    sst.setProgramOption("partitioner","self")
+    for x,comp in enumerate(comps):
+        comp.setRank(x % num_ranks, x // num_ranks)
+


### PR DESCRIPTION
I'm adding 2 new components and 3 new tests to support debugging the interactive console.

Components:
- dbgsst15.DbgMin:   A simple component serializing a simple type and an SST::Object
- dbgsst15.coreTestCheckpoint:  A localized copy of the SST library's coreTestElement.coreTestCheckpoint with minor changes to fix warnings.

Tests:
- debug-console/sanity-min.sh:  minimal test using dbgsst15.DbgMin
- debug-console/sanity-local-test.sh: minimal test using dbgsst15.coreTestCheckpoint
- debug-console/sanity-sstcore-test.sh: same as above but using coreTestElement.coreTestCheckpoint

@donofrio The file `components/core-debug/dbgmin.cc` has an #ifdef to optionally compile `SST_SER(output)` which will cause address sanitizer run to fail.  `sanity-local-test.sh` should fail the same way.  However, `sanity-sstcore-test.sh`, the same component but in a different library, will pass Asan.

